### PR TITLE
Step 4: Added "evaluate" and toString methods in AST, and support for binary and conditional expressions

### DIFF
--- a/src/jesus/ast/ast_node.hpp
+++ b/src/jesus/ast/ast_node.hpp
@@ -1,4 +1,8 @@
 #pragma once
+
+#include <optional> // for std::optional
+#include <iostream>
+
 struct Heart; // forward declaration
 
 /**
@@ -25,5 +29,41 @@ struct ASTNode
      *
      * @param heart Pointer to the Heart (Symbol table) for variable storage.
      */
-    virtual void execute(Heart* heart) = 0;
+    virtual void execute(Heart *heart) = 0;
+
+    /**
+     * @brief Evaluates the node and returns an optional value.
+     * Defaults to no value, meant to be overridden in subclasses that produce a result.
+     *
+     * "The Spirit searches all things, even the deep things of God." — 1 Corinthians 2:10
+     *
+     * @param heart Runtime context containing variables and their values.
+     * @return std::optional<std::string> The result of the evaluation, or nullopt if not applicable.
+     */
+    virtual std::optional<std::string> evaluate(Heart *heart)
+    {
+
+        std::cout << "🔴️ ASTNode.evaluate(should be implemented on child classes)\n";
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Returns a string representation of the node.
+     *
+     * "For nothing is hidden that will not be made manifest, nor is anything
+     * secret that will not be known and come to light." — Luke 8:17
+     */
+    virtual std::string toString() const { return "ASTNode"; }
 };
+
+/**
+ * @brief Output stream overload for ASTNode
+ *
+ * Uses the node's `toString()` method to produce a readable description.
+ *
+ * "Therefore, if anyone is in Christ, he is a new creation. The old has passed away; behold, the new has come." — 2 Corinthians 5:17
+ */
+inline std::ostream &operator<<(std::ostream &os, const ASTNode &node)
+{
+    return os << node.toString();
+}

--- a/src/jesus/ast/binary_operation_node.hpp
+++ b/src/jesus/ast/binary_operation_node.hpp
@@ -1,0 +1,75 @@
+#pragma once
+#include "ast_node.hpp"
+#include "value_node.hpp"
+#include "spirit/heart.hpp"
+
+/**
+ * @brief Represents a binary operation between two AST nodes (e.g., age >= 18)
+ *
+ * This node performs a comparison between the evaluated values of two
+ * child nodes (`left` and `right`) using a specified operator such as:
+ * `>=`, `<=`, `==`, `!=`, `>`, or `<`.
+ *
+ * Example usage:
+ *     BinaryOperationNode(">=", leftNode, rightNode);
+ *     => Evaluates to "true" or "false" depending on the values.
+ */
+struct BinaryOperationNode : public ASTNode
+{
+    std::string op;
+    ASTNode *left;
+    ASTNode *right;
+
+    /**
+     * @brief Construct a new BinaryOperationNode object (e.g., age >= 18)
+     *
+     * 📖 "But solid food is for the mature, who by constant use have trained themselves to distinguish good from evil."
+     * — Hebrews 5:14
+     *
+     * @param op The binary operator as a string (e.g., "==", "!=").
+     * @param left Pointer to the left operand node.
+     * @param right Pointer to the right operand node.
+     */
+    BinaryOperationNode(std::string op, ASTNode *left, ASTNode *right)
+        : op(op), left(left), right(right) {}
+
+    /**
+     * @brief Evaluates the binary operation and returns an optional value.
+     *
+     * @param heart The "Symbol table"
+     * @return An optional string result: "true", "false", or std::nullopt if evaluation failed.
+     */
+    std::optional<std::string> evaluate(Heart *heart)
+    {
+        auto l = left->evaluate(heart);
+        auto r = right->evaluate(heart);
+
+        if (!l.has_value() || !r.has_value())
+            return std::nullopt;
+
+        int leftNum = std::stoi(l.value());
+        int rightNum = std::stoi(r.value());
+
+        if (op == ">=")
+            return (leftNum >= rightNum) ? "true" : "false";
+
+        if (op == "<=")
+            return (leftNum <= rightNum) ? "true" : "false";
+
+        if (op == "==")
+            return (leftNum == rightNum) ? "true" : "false";
+
+        if (op == "!=")
+            return (leftNum != rightNum) ? "true" : "false";
+
+        if (op == ">")
+            return (leftNum > rightNum) ? "true" : "false";
+
+        if (op == "<")
+            return (leftNum < rightNum) ? "true" : "false";
+
+        return std::nullopt;
+    }
+
+    void execute(Heart *heart) override {}
+};

--- a/src/jesus/ast/conditional_expression_node.hpp
+++ b/src/jesus/ast/conditional_expression_node.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "ast_node.hpp"
+#include "spirit/heart.hpp"
+#include <iostream>
+
+/**
+ * @brief Represents `reveal "adult" if age >= 18 otherwise "young"`
+ *
+ * 📖 "I have set before you life and death, blessings and curses. Now choose life, so that you and your children may live."
+ * — Deuteronomy 30:19
+ *
+ * This node evaluates a condition and returns the result of either the
+ * `ifTrue` or `ifFalse` branch based on the logic outcome of the condition.
+ *
+ * It enables decision-making logic in the language's syntax, allowing
+ * expressions such as: condition ? ifTrue : ifFalse
+ */
+struct ConditionalExpressionNode : public ASTNode
+{
+    ASTNode *condition;
+    ASTNode *ifTrue;
+    ASTNode *ifFalse;
+
+    /**
+     * @brief Construct a new ConditionalExpressionNode object
+     *
+     * Represents a conditional expression (similar to a ternary operation).
+     *
+     * 📖 "I have set before you life and death, blessings and curses. Now choose life, so that you and your children may live."
+     * — Deuteronomy 30:19
+     *
+     * @param condition The condition to evaluate (should return "true" or "false").
+     * @param ifTrue The expression to evaluate if the condition is true.
+     * @param ifFalse The expression to evaluate if the condition is false.
+     */
+    ConditionalExpressionNode(ASTNode *condition, ASTNode *ifTrue, ASTNode *ifFalse)
+        : condition(condition), ifTrue(ifTrue), ifFalse(ifFalse) {}
+
+    /**
+     * @brief  Evaluates a condition and returns the result of either the
+     * `ifTrue` or `ifFalse` branch based on the logic outcome of the condition.
+     *
+     * - If the condition evaluates to "true", it evaluates and returns the `ifTrue` branch.
+     * - If the condition evaluates to anything else (or fails), it evaluates and returns the `ifFalse` branch if available.
+     *
+     * @param heart The "Symbol table"
+     * @return std::optional<std::string>
+     */
+    std::optional<std::string> evaluate(Heart *heart) override
+    {
+        auto result = condition->evaluate(heart);
+
+        if (result.has_value() && result.value() == "true")
+        {
+            return ifTrue->evaluate(heart);
+        }
+
+        if (!ifFalse)
+            return std::nullopt;
+
+        return ifFalse->evaluate(heart);
+    }
+
+    void execute(Heart *heart)
+    {
+        auto value = evaluate(heart);
+        if (value.has_value())
+        {
+            std::cout << value.value() << std::endl;
+        }
+    }
+};

--- a/src/jesus/ast/identifier_node.hpp
+++ b/src/jesus/ast/identifier_node.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ast_node.hpp"
+#include "spirit/heart.hpp"
 #include <string>
 
 /**
@@ -22,5 +23,18 @@ struct IdentifierNode : ASTNode
 
     IdentifierNode(const std::string &name) : name(name) {}
 
+    std::optional<std::string> evaluate(Heart *heart)
+    {
+
+        if (heart)
+        {
+            return heart->get(name);
+        }
+
+        return std::nullopt;
+    }
+
     void execute(Heart* heart) override {}
+
+    std::string toString() const override { return "IdentifierNode(" + name + ")"; }
 };

--- a/src/jesus/ast/value_node.hpp
+++ b/src/jesus/ast/value_node.hpp
@@ -29,10 +29,18 @@ struct ValueNode : ASTNode
      */
     ValueNode(const std::string &value) : value(value) {}
 
+    std::optional<std::string> evaluate(Heart *heart)
+    {
+        return value;
+    }
+
     /**
      * @brief Executes the node (currently does nothing).
      *
      * @param heart Pointer to the Heart (Symbol table) for variable storage.
      */
     void execute(Heart* heart) override {}
+
+    std::string toString() const override { return "ValueNode(" + value + ")"; }
+
 };

--- a/src/jesus/parser/parser.cpp
+++ b/src/jesus/parser/parser.cpp
@@ -3,6 +3,9 @@
 #include "ast/identifier_node.hpp"
 #include "ast/value_node.hpp"
 #include "ast/reveal_node.hpp"
+#include "ast/binary_operation_node.hpp"
+#include "ast/conditional_expression_node.hpp"
+#include <bits/stdc++.h> // for std::find_if and std::distance
 
 std::unique_ptr<ASTNode> parse(const std::vector<Token> &tokens)
 {
@@ -10,12 +13,42 @@ std::unique_ptr<ASTNode> parse(const std::vector<Token> &tokens)
     if (!tokens_count)
         return nullptr;
 
-    if (tokens[0].value == "reveal")
+    // parse use "value" if condition otherwise "value"
+    if (tokens[0].value == "reveal" && tokens_count >= 2)
     {
-        if (tokens_count >= 2)
+        // Check if "if" exists in tokens
+        auto it = std::find_if(tokens.begin(), tokens.end(),
+                               [](const Token &t)
+                               { return t.value == "if"; });
+
+        if (it != tokens.end())
         {
-            return std::make_unique<RevealNode>(new IdentifierNode(tokens[1].value));
+
+            int otherwiseIndex = -1;
+            int ifIndex = std::distance(tokens.begin(), it);
+            ASTNode *elseValue = NULL;
+
+            ASTNode *ifValue = new ValueNode(tokens[1].value);
+            ASTNode *condition = new BinaryOperationNode(
+                tokens[ifIndex + 2].value,                     // operator (e.g.: == )
+                new IdentifierNode(tokens[ifIndex + 1].value), // left operand
+                new ValueNode(tokens[ifIndex + 3].value));     // right operand
+
+            // Parse "otherwise/else"
+            for (size_t i = ifIndex + 1; i < tokens_count; ++i)
+            {
+                if (tokens[i].value == "otherwise")
+                {
+                    otherwiseIndex = i;
+                    elseValue = new ValueNode(tokens[otherwiseIndex + 1].value);
+                    break;
+                }
+            }
+
+            return std::make_unique<ConditionalExpressionNode>(condition, ifValue, elseValue);
         }
+
+        return std::make_unique<RevealNode>(new IdentifierNode(tokens[1].value));
     }
 
     if (tokens_count >= 3 &&


### PR DESCRIPTION
### Description

This Pull Request continues the shaping of the language’s heart by enabling introspection (`toString`) and discernment (`evaluate`) across AST nodes. It also introduces:

- 🧠 `evaluate` method in `ASTNode`, empowering nodes with the ability to return computed values.
- 📝 `toString` method for consistent and meaningful representation of nodes.
- ⚖️ `BinaryOperationNode`, which allows truth comparisons (e.g., `age >= 18`).
- 🌿 `ConditionalExpressionNode`, enabling decisions like `reveal "death-and-resurrection-v1" if age == 33 otherwise "Alive"
`.

The parser has also been extended to support these new node types.

---
### Usage

How to test the language at this point:

> let there be age set to 33
> reveal age
> reveal "death-and-resurrection-v1" if age == 33 otherwise "Alive"
> reveal "death-and-resurrection-v2" if age == 2025 otherwise "Jesus-is-Alive"

---

### ✝️ Inspiration

> "But solid food is for the mature, who by constant use have trained themselves to distinguish good from evil."  
> — Hebrews 5:14

By giving the language discernment, we echo God's call to test, compare, and act in truth.
