### PR TITLE
Step 6: Supporting expressions without spaces, enabling grouping expressions like (age*2+3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Compile using the following command:
 ```bash
 cd src/jesus
 
-g++ main.cpp lexer/lexer.cpp parser/parser.cpp spirit/heart.cpp -I . -o jesus
+g++ main.cpp lexer/lexer.cpp parser/parser.cpp spirit/heart.cpp parser/expression_parser.cpp -I . -o jesus
 ```
 
 Then run:

--- a/src/jesus/spirit/value.hpp
+++ b/src/jesus/spirit/value.hpp
@@ -77,23 +77,6 @@ public:
         return (int)toNumber();
     }
 
-    bool toBoolean() const
-    {
-        if (IS_FORMLESS)
-            return false;
-
-        if (IS_BOOLEAN)
-            return std::get<bool>(value);
-
-        if (IS_NUMBER)
-            return std::get<double>(value) != 0;
-
-        if (IS_STRING)
-            return std::get<std::string>(value) != "";
-
-        return false;
-    }
-
     std::string toString() const
     {
         return std::visit(make_string_functor(), value);


### PR DESCRIPTION
## Description

This Pull Request brings clarity and order to the way the language handles expressions, allowing developers to write grouped expressions **without requiring spaces**.

Previously, expressions like `(age*2+3)` would fail unless written with spaces, like `( age * 2 + 3 )`. With this update, the lexer now processes input **character-by-character**, ensuring proper tokenization regardless of spacing.

### 🌱 What’s New

- Expressions such as `(age*2+3)` and `(1+(2*3))` are now **fully supported**.

### 🧪 Example

```jesus
let there be age set to 33

reveal "adult" if ((age>=18)) otherwise "minor"

(1+2*3)
(age*2+3)
(1+(2*3))
((age+4)*(3+1))
```

---

### ✝️ Inspiration

> "Let all things be done decently and in order."  
> — 1 Corinthians 14:40

This update honors the principle of **order and clarity**, allowing expressions to be written more naturally, while keeping the language disciplined and expressive.