### PR TITLE
Step 7: Added support for `say` and `warn` keywords that prints to stdout and stderr, and dropped support for `reveal` 

### DIFF
--- a/src/jesus/ast/reveal_node.hpp
+++ b/src/jesus/ast/reveal_node.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
 #include "ast_node.hpp"
-#include "identifier_node.hpp"
 #include "../spirit/heart.hpp"
-#include <iostream>
 
 /**
  * @brief The RevealNode class represents the `reveal` command in the language.
@@ -17,23 +15,24 @@
  * @example
  * (Jesus) let there be name set to Jesus
  * name = Jesus
- * (Jesus) reveal name
+ * (Jesus) say name
  * Jesus
- * (Jesus)
+ * (Jesus) warn name
+ * Jesus
  */
 struct RevealNode : public ASTNode
 {
-    IdentifierNode *identifier;
+    ASTNode *node;
 
     /**
      * @brief Construct a new RevealNode object
      *
-     * @param id A pointer to an IdentifierNode representing the variable name.
+     * @param id A pointer to an ASTNode representing a variable or a value.
      */
-    explicit RevealNode(IdentifierNode *id) : identifier(id) {}
+    explicit RevealNode(ASTNode *node) : node(node) {}
 
     /**
-     * @brief Executes the `reveal` command by displaying the value of a stored variable.
+     * @brief Executes the `say` command by displaying the value of `node`.
      *
      * This method queries the Heart (symbol table) for the variable associated with
      * the provided identifier. If found, it prints the value; otherwise, it prints
@@ -46,16 +45,10 @@ struct RevealNode : public ASTNode
      */
     void execute(Heart *heart) override
     {
-        if (!heart)
+        if (!node)
             return;
 
-        auto value = heart->get(identifier->name);
-        if (! value.IS_FORMLESS)
-        {
-            std::cout << value.toString() << std::endl;
-        } else {
-            std::cout << "Unknown: " << identifier->name << std::endl;
-        }
+        node->execute(heart);
     }
 
     /**
@@ -68,8 +61,8 @@ struct RevealNode : public ASTNode
     {
         std::string str = "RevealNode";
 
-        if (identifier)
-            str += "(" + identifier->name + ")";
+        if (node)
+            str += "(" + node->toString() + ")";
 
         return str;
     }

--- a/src/jesus/ast/stmt/output_statement.cpp
+++ b/src/jesus/ast/stmt/output_statement.cpp
@@ -1,0 +1,21 @@
+#pragma once
+#include "stmt.hpp"
+#include "../expr/expr.hpp"
+#include <memory>
+
+enum class OutputType
+{
+    SAY,
+    WARN,
+};
+
+/// Statement for printing output: say, praise, rebuke
+class OutputStmt : public Stmt
+{
+public:
+    OutputType type;
+    std::unique_ptr<Expr> message;
+
+    OutputStmt(OutputType type, std::unique_ptr<Expr> message)
+        : type(type), message(std::move(message)) {}
+};

--- a/src/jesus/ast/stmt/output_statement.hpp
+++ b/src/jesus/ast/stmt/output_statement.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#include "stmt.hpp"
+#include "../expr/expr.hpp"
+#include <memory>
+
+enum class OutputType
+{
+    SAY,
+    WARN,
+};
+
+/// Statement for printing output: say, praise, rebuke
+class OutputStmt : public Stmt
+{
+public:
+    OutputType type;
+    std::unique_ptr<Expr> message;
+
+    OutputStmt(OutputType type, std::unique_ptr<Expr> message)
+        : type(type), message(std::move(message)) {}
+};

--- a/src/jesus/ast/value_node.hpp
+++ b/src/jesus/ast/value_node.hpp
@@ -11,7 +11,7 @@
  * that can be used in expressions, assignments, or function calls.
  *
  * In a full interpreter, this node might return the value or push it
- * onto an evaluation stack. For now, `execute()` is a no-op.
+ * onto an evaluation stack.
  *
  * "Every good and perfect gift is from above..." — James 1:17
  *  A ValueNode reminds us that even simple values can carry meaning and purpose.
@@ -40,7 +40,9 @@ struct ValueNode : ASTNode
      *
      * @param heart Pointer to the Heart (Symbol table) for variable storage.
      */
-    void execute(Heart* heart) override {}
+    void execute(Heart* heart) override {
+        std::cout << value.toString() << std::endl;
+    }
 
     std::string toString() const override { return "ValueNode(" + value.toString() + ")"; }
 

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -1,5 +1,7 @@
 #include "interpreter.hpp"
 #include <stdexcept>
+#include "../ast/stmt/output_statement.hpp"
+#include <iostream>
 
 Value Interpreter::evaluate(std::unique_ptr<Expr> &expr)
 {
@@ -110,7 +112,10 @@ void Interpreter::execute(std::unique_ptr<Stmt> &stmt)
     if (auto set = dynamic_cast<SetStmt *>(stmt.get()))
         return visitSet(set);
 
-    throw std::runtime_error("Unknown statement type.");
+    if (auto out = dynamic_cast<OutputStmt *>(stmt.get()))
+        return visitOutput(out);
+
+    throw std::runtime_error("Unknown statement tyspe.");
 }
 
 void Interpreter::visitSet(SetStmt *stmt)
@@ -132,4 +137,13 @@ Value Interpreter::visitConditional(ConditionalExpr *expr)
     {
         return evaluate(expr->elseBranch);
     }
+}
+
+void Interpreter::visitOutput(OutputStmt *stmt)
+{
+    Value value = evaluate(stmt->message);
+
+    std::ostream &out = (stmt->type == OutputType::WARN) ? std::cerr : std::cout;
+
+    out << value.toString() << std::endl;
 }

--- a/src/jesus/interpreter/interpreter.hpp
+++ b/src/jesus/interpreter/interpreter.hpp
@@ -11,8 +11,8 @@
 #include "../ast/expr/grouping_expr.hpp"
 #include "../ast/stmt/stmt.hpp"
 #include "../ast/stmt/set_stmt.hpp"
+#include "../ast/stmt/output_statement.hpp"
 #include "../spirit/heart.hpp"
-
 
 /**
  * @brief Interprets expressions of the language and evaluates their result.
@@ -36,7 +36,7 @@ public:
 
     void defineVariable(const std::string &name, const Value &value);
     void assignVariable(const std::string &name, const Value &value);
-    void execute(std::unique_ptr<Stmt>& stmt);
+    void execute(std::unique_ptr<Stmt> &stmt);
 
 private:
     /**
@@ -107,7 +107,9 @@ private:
      */
     std::string valueToString(const Value &value);
 
-    void visitSet(SetStmt* stmt);
+    void visitSet(SetStmt *stmt);
 
-    Value visitConditional(ConditionalExpr* expr);
+    Value visitConditional(ConditionalExpr *expr);
+
+    void visitOutput(OutputStmt *stmt);
 };

--- a/src/jesus/lexer/lexer.cpp
+++ b/src/jesus/lexer/lexer.cpp
@@ -146,6 +146,12 @@ TokenType recognize_token_type(const std::string &word)
     if (word == "-")
         return TokenType::MINUS;
 
+    if (word == "say")
+        return TokenType::SAY;
+
+    if (word == "warn")
+        return TokenType::WARN;
+
     if (isInteger(word))
         return TokenType::INT;
 

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -41,8 +41,8 @@ enum class TokenType
     STAR,           // *
     SLASH,          // /
 
-    SAY,
-    WARN,
+    SAY,            // "say" prints to stdout
+    WARN,           // "warn" prints to stderr
     UPDATE,
 
     END_OF_FILE

--- a/src/jesus/parser/parser.cpp
+++ b/src/jesus/parser/parser.cpp
@@ -21,7 +21,7 @@ std::unique_ptr<ASTNode> parse(const std::vector<Token> &tokens)
     }
 
     // parse use "value" if condition otherwise "value"
-    if (tokens[0].lexeme == "reveal" && tokens_count >= 2)
+    if ((tokens[0].type == TokenType::SAY || tokens[0].type == TokenType::WARN)  && tokens_count >= 2)
     {
         // Check if "if" exists in tokens
         auto ifIt = std::find_if(tokens.begin(), tokens.end(),
@@ -91,7 +91,10 @@ std::unique_ptr<ASTNode> parse(const std::vector<Token> &tokens)
             return std::make_unique<ConditionalExpressionNode>(condition, ifValue, elseValue);
         }
 
-        return std::make_unique<RevealNode>(new IdentifierNode(tokens[1].lexeme));
+        if (tokens[1].type == TokenType::IDENTIFIER)
+            return std::make_unique<RevealNode>(new IdentifierNode(tokens[1].lexeme));
+
+        return std::make_unique<RevealNode>(new ValueNode(tokens[1].literal));
     }
 
     if (tokens_count >= 3 &&


### PR DESCRIPTION
### Description

This Pull Request empowers the language to communicate clearly and purposefully by introducing two new expression types:

- 🗣️ `say` — Prints messages to **stdout**, useful for declarations, affirmations, and joyful expressions.
- ⚠️ `warn` — Prints messages to **stderr**, designed for important warnings, errors, or divine rebukes.

These expressions are now parsed and evaluated as part of the AST. With them, developers can provide feedback that respects both tone and intent—mirroring how truth is delivered with grace or with urgency.

### Usage Examples

```jesus
let there be wisdom set to "Love your neighbor as you love yourself "
let there be trumpet set to "The wages of sin is death"

say wisdom
warn trumpet
```

### Internal Notes

- The parser now recognizes and correctly builds `say` and `warn` expressions into the AST.
- Both expressions are currently handled inside `Interpreter::visitOutput`.
- Although both `say` and `warn` are now **interpreted**, they currently both **print to** `stdout`, since `Interpreter` is not yet integrated into the full execution flow.
- Future work will connect `Interpreter` fully and route `warn` to `stderr` as intended.

---

### 📖 Biblical Inspiration

> **"Preach the word; be prepared in season and out of season; correct, rebuke and encourage—with great patience and careful instruction."**  
> — 2 Timothy 4:2

The introduction of `say` and `warn` reflects this divine rhythm—**encourage** with `say`, **rebuke** with `warn`—just as the Word of God speaks to us in both comfort and correction.