### PR TITLE
Step 10: Introduced EBNF-style Grammar-Based Parsing Layer for Expressions

### DIFF
--- a/src/jesus/lexer/lexer.cpp
+++ b/src/jesus/lexer/lexer.cpp
@@ -110,23 +110,23 @@ TokenType recognize_token_type(const std::string &word)
     if (word == "!=")
         return TokenType::NOT_EQUAL;
 
-    if (word == ">")
+    if (word == ">") // greater than
         return TokenType::GREATER;
 
-    if (word == ">=")
+    if (word == ">=") // greater or equals to
         return TokenType::GREATER_EQUAL;
 
-    if (word == "<")
+    if (word == "<") // less than
         return TokenType::LESS;
 
-    if (word == "<=")
+    if (word == "<=") // less or equal to
         return TokenType::LESS_EQUAL;
 
-    if (word == "false")
-        return TokenType::FALSE;
+    if (word == "no")
+        return TokenType::NO;
 
-    if (word == "true")
-        return TokenType::TRUE;
+    if (word == "yes")
+        return TokenType::YES;
 
     if (word == "(")
         return TokenType::LEFT_PAREN;

--- a/src/jesus/lexer/token.hpp
+++ b/src/jesus/lexer/token.hpp
@@ -86,10 +86,10 @@ public:
             return "LESS";
         case TokenType::LESS_EQUAL:
             return "LESS_EQUAL";
-        case TokenType::FALSE:
-            return "FALSE";
-        case TokenType::TRUE:
-            return "TRUE";
+        case TokenType::YES:
+            return "YES";
+        case TokenType::NO:
+            return "NO";
         case TokenType::LEFT_PAREN:
             return "LEFT_PAREN";
         case TokenType::RIGHT_PAREN:

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -27,8 +27,8 @@ enum class TokenType
     GREATER_EQUAL,  // >=
     LESS,           // <
     LESS_EQUAL,     // <=
-    FALSE,          // 17
-    TRUE,           // 18
+    YES,            // 17
+    NO,             // 18
     INT,            // 19
     DOUBLE,         // 20
     STRING,         // 21

--- a/src/jesus/main.cpp
+++ b/src/jesus/main.cpp
@@ -4,9 +4,12 @@
 #include "parser/parser.hpp"
 #include "spirit/heart.hpp"
 #include "interpreter/interpreter.hpp"
+#include "parser/grammar/jesus_grammar.hpp"
 
 int main()
 {
+    grammar::initializeGrammar(); // Sets the Expression rule target to Primary
+
     Heart heart;
     Interpreter interpreter(&heart);
     std::string line;

--- a/src/jesus/parser/expression_parser.cpp
+++ b/src/jesus/parser/expression_parser.cpp
@@ -4,6 +4,7 @@
 #include "../ast/expr/literal_expr.hpp"
 #include "../ast/expr/variable_expr.hpp"
 #include "../ast/expr/grouping_expr.hpp"
+#include "grammar/jesus_grammar.hpp"
 #include <stdexcept>
 
 ExpressionParser::ExpressionParser(const std::vector<Token> &tokens)
@@ -130,8 +131,11 @@ std::unique_ptr<Expr> ExpressionParser::parseLiteralOrGroupOrVar()
         return std::make_unique<LiteralExpr>(Value(true));
     }
 
-    if (match(TokenType::INT, TokenType::DOUBLE, TokenType::STRING))
-    {
+    // Try primitive EBNF-based parsing
+    ParserContext ctx(tokens, current);
+    auto isNumberOrString = grammar::Primary->parse(ctx); // this includes Number | String for now
+    if (isNumberOrString) {
+        advance();
         return std::make_unique<LiteralExpr>(previous().literal);
     }
 

--- a/src/jesus/parser/grammar/combinators/forward_rule.hpp
+++ b/src/jesus/parser/grammar/combinators/forward_rule.hpp
@@ -49,7 +49,7 @@ public:
         target = std::move(rule);
     }
 
-    bool parse(ParserContext &ctx) override
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override
     {
         if (!target)
             throw std::runtime_error("ForwardRule target not set");

--- a/src/jesus/parser/grammar/combinators/forward_rule.hpp
+++ b/src/jesus/parser/grammar/combinators/forward_rule.hpp
@@ -1,0 +1,69 @@
+#pragma once
+#include "../grammar_rule.hpp"
+#include <memory>
+
+/**
+ * @brief A forward-declared grammar rule placeholder that can be resolved later.
+ *
+ * It allows the definition of recursive grammar structures by acting as a proxy
+ * to a real rule that may not have been defined yet at the time of declaration.
+ *
+ * For example, in EBNF we often write:
+ *     expression = term | expression "+" term
+ * Such definitions are inherently recursive, and this class enables us to express that in C++.
+ *
+ * Usage:
+ *     auto Expression = std::make_shared<ForwardRule>();
+ *     Expression->setTarget(...); // assign the real rule after defining it
+ *
+ * ✝️ “The heart of man plans his way, but the Lord establishes his steps.”
+ *     — Proverbs 16:9
+ *
+ * Just as this class temporarily plans a path forward, the real structure is
+ * revealed and resolved in its time.
+ */
+class ForwardRule : public IGrammarRule
+{
+private:
+    std::string name;
+    std::shared_ptr<IGrammarRule> target;
+
+public:
+    explicit ForwardRule(std::string name = "Forward") : name(std::move(name)) {}
+
+    /**
+     * @brief Sets the actual rule this forward reference will resolve to.
+     *
+     * This should be called **once** after all grammar rules are defined.
+     * The ForwardRule then delegates parsing and string conversion to the
+     * assigned target rule.
+     *
+     * ✝️ "Write the vision; make it plain on tablets, so he may run who reads it."
+     *     — Habakkuk 2:2
+     * Like a vision that becomes clear in time, this rule points ahead to what will be revealed.
+     *
+     * @param rule A shared pointer to the actual grammar rule this forward should resolve to.
+     */
+    void setTarget(std::shared_ptr<IGrammarRule> rule)
+    {
+        target = std::move(rule);
+    }
+
+    bool parse(ParserContext &ctx) override
+    {
+        if (!target)
+            throw std::runtime_error("ForwardRule target not set");
+
+        return target->parse(ctx);
+    }
+
+    std::string toStr(GrammarRuleHashTable &visitedTable) const override
+    {
+        if (visitedTable.count(this))
+            return name + "(...)";
+
+        visitedTable.insert(this);
+
+        return target ? target->toStr(visitedTable) : "UnresolvedForwardRule";
+    }
+};

--- a/src/jesus/parser/grammar/combinators/or_rule.hpp
+++ b/src/jesus/parser/grammar/combinators/or_rule.hpp
@@ -35,22 +35,24 @@ public:
         return false;
     }
 
-    std::string toString() override
+    std::string toStr(GrammarRuleHashTable &visitedTable) const override
     {
-        std::string str = "OrRule(";
-        bool firstGone = false;
-        for (auto &rule : rules)
+        if (visitedTable.count(this))
+            return "Or(...)";
+
+        visitedTable.insert(this);
+
+        std::string str = "";
+        bool first = true;
+        for (const auto &rule : rules)
         {
-            if (firstGone)
-            {
-                str += "|";
-            }
+            if (!first)
+                str += " | ";
 
-            str += rule->toString();
+            str += rule->toStr(visitedTable);
 
-            firstGone = true;
+            first = false;
         }
-        str += ")";
 
         return str;
     }

--- a/src/jesus/parser/grammar/combinators/or_rule.hpp
+++ b/src/jesus/parser/grammar/combinators/or_rule.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "../grammar_rule.hpp"
+
+// OR: rule1 | rule2
+class OrRule : public IGrammarRule
+{
+    std::vector<std::shared_ptr<IGrammarRule>> rules;
+
+public:
+    OrRule(std::shared_ptr<IGrammarRule> a, std::shared_ptr<IGrammarRule> b)
+    {
+        rules.push_back(a);
+        rules.push_back(b);
+    }
+
+    OrRule &operator|(std::shared_ptr<IGrammarRule> r)
+    {
+        rules.push_back(r);
+        return *this;
+    }
+
+    bool parse(ParserContext &ctx) override
+    {
+        auto count = 1;
+        for (auto &rule : rules)
+        {
+            ParserContext backup = ctx.snapshot();
+            if (rule->parse(ctx))
+                return true;
+
+            ctx = backup;
+            count++;
+        }
+        return false;
+    }
+
+    std::string toString() override
+    {
+        std::string str = "OrRule(";
+        bool firstGone = false;
+        for (auto &rule : rules)
+        {
+            if (firstGone)
+            {
+                str += "|";
+            }
+
+            str += rule->toString();
+
+            firstGone = true;
+        }
+        str += ")";
+
+        return str;
+    }
+};

--- a/src/jesus/parser/grammar/combinators/or_rule.hpp
+++ b/src/jesus/parser/grammar/combinators/or_rule.hpp
@@ -20,19 +20,20 @@ public:
         return *this;
     }
 
-    bool parse(ParserContext &ctx) override
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override
     {
-        auto count = 1;
         for (auto &rule : rules)
         {
-            ParserContext backup = ctx.snapshot();
-            if (rule->parse(ctx))
-                return true;
+            ParserContext backup = ctx.snapshot(); // Save state in case this rule fails
+            auto result = rule->parse(ctx);        // Try this rule
 
-            ctx = backup;
-            count++;
+            if (result) // If it parsed successfully
+                return result;
+
+            ctx = backup; // Restore context and try next
         }
-        return false;
+
+        return nullptr; // None of the rules matched
     }
 
     std::string toStr(GrammarRuleHashTable &visitedTable) const override

--- a/src/jesus/parser/grammar/combinators/sequence_rule.hpp
+++ b/src/jesus/parser/grammar/combinators/sequence_rule.hpp
@@ -1,0 +1,30 @@
+#pragma once
+#include "../grammar_rule.hpp"
+
+// CHAIN (sequence): rule1 >> rule2
+class SequenceRule : public IGrammarRule
+{
+    std::shared_ptr<IGrammarRule> first;
+    std::shared_ptr<IGrammarRule> second;
+
+public:
+    SequenceRule(std::shared_ptr<IGrammarRule> a, std::shared_ptr<IGrammarRule> b)
+        : first(std::move(a)), second(std::move(b)) {}
+
+    bool parse(ParserContext &ctx) override
+    {
+        ParserContext backup = ctx.snapshot();
+        if (first->parse(ctx))
+        {
+            if (second->parse(ctx))
+                return true;
+        }
+        ctx = backup;
+        return false;
+    }
+
+    std::string toString() override
+    {
+        return "Sequence( " + first->toString() + " >> " + second->toString() + ")";
+    }
+};

--- a/src/jesus/parser/grammar/combinators/sequence_rule.hpp
+++ b/src/jesus/parser/grammar/combinators/sequence_rule.hpp
@@ -23,8 +23,13 @@ public:
         return false;
     }
 
-    std::string toString() override
+    std::string toStr(GrammarRuleHashTable &visitedTable) const override
     {
-        return "Sequence( " + first->toString() + " >> " + second->toString() + ")";
+        if (visitedTable.count(this))
+            return "Sequence(...)";
+
+        visitedTable.insert(this);
+
+        return "Sequence( " + first->toStr(visitedTable) + " >> " + second->toStr(visitedTable) + ")";
     }
 };

--- a/src/jesus/parser/grammar/grammar_aliases.hpp
+++ b/src/jesus/parser/grammar/grammar_aliases.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <memory>
 #include "primitives/number_rule.hpp"
 #include "primitives/string_rule.hpp"

--- a/src/jesus/parser/grammar/grammar_aliases.hpp
+++ b/src/jesus/parser/grammar/grammar_aliases.hpp
@@ -1,0 +1,23 @@
+#include <memory>
+#include "primitives/number_rule.hpp"
+#include "primitives/string_rule.hpp"
+#include "group_rule.hpp"
+
+/**
+ * @file grammar_aliases.hpp
+ * @brief Pure-EBNF aliases for internal GrammarRules.
+ * Use this to define grammars in expressive EBNF style.
+ *
+ * “Do your best to present yourself to God as one approved, a worker who does not need to be ashamed and who correctly handles the word of truth.”
+ * - 2 Timothy 2:15
+ */
+
+inline auto Number = std::make_shared<NumberRule>();
+
+inline auto String = std::make_shared<StringRule>();
+
+// Group is a function because it requires an inner expression rule
+inline auto Group = [](auto inner)
+{
+    return std::make_shared<GroupRule>(inner);
+};

--- a/src/jesus/parser/grammar/grammar_rule.hpp
+++ b/src/jesus/parser/grammar/grammar_rule.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include "../parser_context.hpp"
+
+/**
+ * @brief Base interface for all grammar rules in the Jesus Language parser.
+ *
+ * "Do your best to present yourself to God as one approved,
+ * a worker who does not need to be ashamed and who correctly handles the word of truth."
+ * — 2 Timothy 2:15
+ */
+class IGrammarRule
+{
+public:
+    virtual ~IGrammarRule() = default;
+
+    /**
+     * Tries to parse the rule from the given context.
+     *
+     * @param ctx The parser context containing tokens and state.
+     * @return true if the rule matched and consumed tokens.
+     */
+    virtual bool parse(ParserContext &ctx) = 0;
+
+    virtual std::string toString()
+    {
+        return "IGrammarRule";
+    }
+};

--- a/src/jesus/parser/grammar/grammar_rule.hpp
+++ b/src/jesus/parser/grammar/grammar_rule.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../parser_context.hpp"
+#include "../../ast/expr/expr.hpp"
 #include <unordered_set>
 
 class IGrammarRule; // Forward declaration
@@ -23,7 +24,7 @@ public:
      * @param ctx The parser context containing tokens and state.
      * @return true if the rule matched and consumed tokens.
      */
-    virtual bool parse(ParserContext &ctx) = 0;
+    virtual std::unique_ptr<Expr> parse(ParserContext &ctx) = 0;
 
     /**
      * @brief Return a string version of the rule

--- a/src/jesus/parser/grammar/grammar_rule.hpp
+++ b/src/jesus/parser/grammar/grammar_rule.hpp
@@ -1,5 +1,9 @@
 #pragma once
 #include "../parser_context.hpp"
+#include <unordered_set>
+
+class IGrammarRule; // Forward declaration
+using GrammarRuleHashTable = std::unordered_set<const IGrammarRule *>;
 
 /**
  * @brief Base interface for all grammar rules in the Jesus Language parser.
@@ -21,8 +25,38 @@ public:
      */
     virtual bool parse(ParserContext &ctx) = 0;
 
-    virtual std::string toString()
+    /**
+     * @brief Return a string version of the rule
+     *
+     * ⚠️ Please do not override this. Override `toStr` instead.
+     *
+     * @return std::string
+     */
+    virtual std::string toString() const final // final = "can't" be overwritten
     {
-        return "IGrammarRule";
+        GrammarRuleHashTable visitedTable;
+        return toStr(visitedTable);
     }
+
+    /**
+     * @brief Generates a string representation of the grammar rule,
+     *        avoiding infinite recursion by tracking visited rules.
+     *
+     * This method is used internally by `toString()` to safely convert
+     * the grammar rule structure into a human-readable string,
+     * even when rules are recursively defined (e.g., Expression).
+     *
+     * The `visitedTable` is a set of rule pointers that have already
+     * been visited in the current traversal, preventing recursion like:
+     *     Expression → Group(Expression) → Group(Group(Expression)) → ...
+     *
+     * ⚠️ Override this method in derived grammar rule classes to define
+     *    how each specific rule should be printed, avoiding infinite recursion.
+     *
+     * The purposes of a person’s heart are deep waters, but one who has insight draws them out.  — Psalm 25:9
+     *
+     * @param visitedTable A set tracking visited rules during traversal.
+     * @return A human-readable string of the rule structure.
+     */
+    virtual std::string toStr(GrammarRuleHashTable &visitedTable) const = 0;
 };

--- a/src/jesus/parser/grammar/group_rule.cpp
+++ b/src/jesus/parser/grammar/group_rule.cpp
@@ -1,16 +1,17 @@
 #include "group_rule.hpp"
-#include "../../lexer/token_type.hpp"
+#include "../../ast/expr/grouping_expr.hpp"
 
-bool GroupRule::parse(ParserContext &ctx)
+std::unique_ptr<Expr> GroupRule::parse(ParserContext &ctx)
 {
     if (!ctx.match(TokenType::LEFT_PAREN))
-        return false;
+        return nullptr;
 
-    if (!inner->parse(ctx))
-        return false;
+    auto expr = inner->parse(ctx);
+    if (!expr)
+        return nullptr;
 
     if (!ctx.match(TokenType::RIGHT_PAREN))
-        return false;
+        throw std::runtime_error("Expected ')' after expression.");
 
-    return true;
+    return std::make_unique<GroupingExpr>(std::move(expr));
 }

--- a/src/jesus/parser/grammar/group_rule.cpp
+++ b/src/jesus/parser/grammar/group_rule.cpp
@@ -1,0 +1,16 @@
+#include "group_rule.hpp"
+#include "../../lexer/token_type.hpp"
+
+bool GroupRule::parse(ParserContext &ctx)
+{
+    if (!ctx.match(TokenType::LEFT_PAREN))
+        return false;
+
+    if (!inner->parse(ctx))
+        return false;
+
+    if (!ctx.match(TokenType::RIGHT_PAREN))
+        return false;
+
+    return true;
+}

--- a/src/jesus/parser/grammar/group_rule.hpp
+++ b/src/jesus/parser/grammar/group_rule.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include "grammar_rule.hpp"
+#include <memory>
+
+class GroupRule : public IGrammarRule
+{
+    std::shared_ptr<IGrammarRule> inner;
+
+public:
+    explicit GroupRule(std::shared_ptr<IGrammarRule> rule)
+        : inner(std::move(rule)) {}
+
+    bool parse(ParserContext &ctx) override;
+
+    std::string toString() override
+    {
+        return "Group(" + inner->toString() + ")";
+    }
+};

--- a/src/jesus/parser/grammar/group_rule.hpp
+++ b/src/jesus/parser/grammar/group_rule.hpp
@@ -12,8 +12,13 @@ public:
 
     bool parse(ParserContext &ctx) override;
 
-    std::string toString() override
+    std::string toStr(GrammarRuleHashTable &visitedTable) const override
     {
-        return "Group(" + inner->toString() + ")";
+        if (visitedTable.count(this))
+            return "Group(...)";
+
+        visitedTable.insert(this);
+
+        return "Group(" + inner->toStr(visitedTable) + ")";
     }
 };

--- a/src/jesus/parser/grammar/group_rule.hpp
+++ b/src/jesus/parser/grammar/group_rule.hpp
@@ -10,7 +10,7 @@ public:
     explicit GroupRule(std::shared_ptr<IGrammarRule> rule)
         : inner(std::move(rule)) {}
 
-    bool parse(ParserContext &ctx) override;
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override;
 
     std::string toStr(GrammarRuleHashTable &visitedTable) const override
     {

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -5,6 +5,7 @@
 #include "operators.hpp"
 #include "primitives/addition_rule.hpp"
 #include "primitives/comparison_rule.hpp"
+#include "primitives/equality_rule.hpp"
 #include "primitives/multiplication_rule.hpp"
 #include "unary_rule.hpp"
 
@@ -34,7 +35,8 @@ namespace grammar
     inline auto Multiplication = std::make_shared<MultiplicationRule>(Unary);
     inline auto Addition = std::make_shared<AdditionRule>(Multiplication);
     inline auto Comparison = std::make_shared<ComparisonRule>(Addition);
-    inline auto Expression = Comparison;
+    inline auto Equality = std::make_shared<EqualityRule>(Comparison);
+    inline auto Expression = Equality;
 
     /**
      * @brief Primary is anything that can be evaluated directly: number, string, or a grouped expression.

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -9,6 +9,7 @@
 #include "primitives/logical_and_rule.hpp"
 #include "primitives/logical_or_rule.hpp"
 #include "primitives/multiplication_rule.hpp"
+#include "primitives/variable_rule.hpp"
 #include "primitives/versus_rule.hpp"
 #include "primitives/yes_no_rule.hpp"
 #include "unary_rule.hpp"
@@ -46,11 +47,12 @@ namespace grammar
     inline auto Expression = LogicalOr;
 
     inline auto YesNo = std::make_shared<YesNoRule>();
+    inline auto Variable = std::make_shared<VariableRule>();
 
     /**
      * @brief Primary is anything that can be evaluated directly: number, string, or a grouped expression.
      */
-    inline auto Primary = Number | String | YesNo | Group(Expression);
+    inline auto Primary = Number | String | YesNo | Variable | Group(Expression);
 
     /**
      * @brief Set the Expression rule to something (for now just Primary)

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -7,6 +7,7 @@
 #include "primitives/comparison_rule.hpp"
 #include "primitives/equality_rule.hpp"
 #include "primitives/logical_and_rule.hpp"
+#include "primitives/logical_or_rule.hpp"
 #include "primitives/multiplication_rule.hpp"
 #include "primitives/versus_rule.hpp"
 #include "unary_rule.hpp"
@@ -39,8 +40,9 @@ namespace grammar
     inline auto Comparison = std::make_shared<ComparisonRule>(Addition);
     inline auto Equality = std::make_shared<EqualityRule>(Comparison);
     inline auto LogicalAnd = std::make_shared<LogicalAndRule>(Equality);
-    inline auto Expression = LogicalAnd;
-    inline auto Versus = std::make_shared<VersusRule>(Addition, Addition);
+    inline auto Versus = std::make_shared<VersusRule>(LogicalAnd, LogicalAnd);
+    inline auto LogicalOr = std::make_shared<LogicalOrRule>(Versus);
+    inline auto Expression = LogicalOr;
 
     /**
      * @brief Primary is anything that can be evaluated directly: number, string, or a grouped expression.

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -3,6 +3,7 @@
 #include "combinators/forward_rule.hpp"
 #include "grammar_aliases.hpp" // for Number, String, etc.
 #include "operators.hpp"
+#include "primitives/multiplication_rule.hpp"
 #include "unary_rule.hpp"
 
 /**
@@ -29,6 +30,7 @@ namespace grammar
 
     inline auto Unary = std::make_shared<ForwardRule>("Unary");
     inline auto Expression = std::make_shared<ForwardRule>("Expression");
+    inline auto Multiplication = std::make_shared<ForwardRule>("Multiplication");
 
     /**
      * @brief Primary is anything that can be evaluated directly: number, string, or a grouped expression.
@@ -48,5 +50,6 @@ namespace grammar
     {
         Expression->setTarget(Primary);
         Unary->setTarget(std::make_shared<UnaryRule>(Primary));
+        Multiplication->setTarget(std::make_shared<MultiplicationRule>(Unary));
     }
 }

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -7,6 +7,7 @@
 #include "primitives/comparison_rule.hpp"
 #include "primitives/equality_rule.hpp"
 #include "primitives/multiplication_rule.hpp"
+#include "primitives/versus_rule.hpp"
 #include "unary_rule.hpp"
 
 /**
@@ -37,6 +38,7 @@ namespace grammar
     inline auto Comparison = std::make_shared<ComparisonRule>(Addition);
     inline auto Equality = std::make_shared<EqualityRule>(Comparison);
     inline auto Expression = Equality;
+    inline auto Versus = std::make_shared<VersusRule>(Addition, Addition);
 
     /**
      * @brief Primary is anything that can be evaluated directly: number, string, or a grouped expression.

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -3,6 +3,7 @@
 #include "combinators/forward_rule.hpp"
 #include "grammar_aliases.hpp" // for Number, String, etc.
 #include "operators.hpp"
+#include "unary_rule.hpp"
 
 /**
  * @brief Central EBNF-style grammar definition for the Jesus language.
@@ -25,6 +26,8 @@ namespace grammar
      *
      * It acts as a placeholder that we can define later
      */
+
+    inline auto Unary = std::make_shared<ForwardRule>("Unary");
     inline auto Expression = std::make_shared<ForwardRule>("Expression");
 
     /**
@@ -43,6 +46,7 @@ namespace grammar
      */
     inline void initializeGrammar()
     {
-        std::static_pointer_cast<ForwardRule>(Expression)->setTarget(Primary);
+        Expression->setTarget(Primary);
+        Unary->setTarget(std::make_shared<UnaryRule>(Primary));
     }
 }

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -3,6 +3,7 @@
 #include "combinators/forward_rule.hpp"
 #include "grammar_aliases.hpp" // for Number, String, etc.
 #include "operators.hpp"
+#include "primitives/addition_rule.hpp"
 #include "primitives/multiplication_rule.hpp"
 #include "unary_rule.hpp"
 
@@ -31,6 +32,7 @@ namespace grammar
     inline auto Unary = std::make_shared<ForwardRule>("Unary");
     inline auto Expression = std::make_shared<ForwardRule>("Expression");
     inline auto Multiplication = std::make_shared<ForwardRule>("Multiplication");
+    inline auto Addition = std::make_shared<AdditionRule>(Multiplication);
 
     /**
      * @brief Primary is anything that can be evaluated directly: number, string, or a grouped expression.

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -10,6 +10,7 @@
 #include "primitives/logical_or_rule.hpp"
 #include "primitives/multiplication_rule.hpp"
 #include "primitives/versus_rule.hpp"
+#include "primitives/yes_no_rule.hpp"
 #include "unary_rule.hpp"
 
 /**
@@ -44,10 +45,12 @@ namespace grammar
     inline auto LogicalOr = std::make_shared<LogicalOrRule>(Versus);
     inline auto Expression = LogicalOr;
 
+    inline auto YesNo = std::make_shared<YesNoRule>();
+
     /**
      * @brief Primary is anything that can be evaluated directly: number, string, or a grouped expression.
      */
-    inline auto Primary = Number | String | Group(Expression);
+    inline auto Primary = Number | String | YesNo | Group(Expression);
 
     /**
      * @brief Set the Expression rule to something (for now just Primary)

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "combinators/forward_rule.hpp"
 #include "grammar_aliases.hpp" // for Number, String, etc.
 #include "operators.hpp"
 
@@ -16,8 +17,32 @@
 namespace grammar
 {
 
-    inline auto Primary = Number | String;
+    /**
+     * @brief Create a forward declaration for ExpressionRule
+     *
+     * It solves the following problem: Primary refers to ExpressionRule, and ExpressionRule refers to Primary.
+     * That's a cyclic dependency — a common issue in recursive descent parsers.
+     *
+     * It acts as a placeholder that we can define later
+     */
+    inline auto Expression = std::make_shared<ForwardRule>("Expression");
 
-    inline auto ExpressionRule = Primary | Group(Number | String); // simplistic for now
+    /**
+     * @brief Primary is anything that can be evaluated directly: number, string, or a grouped expression.
+     */
+    inline auto Primary = Number | String | Group(Expression);
 
+    /**
+     * @brief Set the Expression rule to something (for now just Primary)
+     *
+     *  Expression, in its full form, will later be:
+     *  Expression → Or → And → Equality → Comparison → Term → Factor → Primary
+     *
+     *  But for now, Expression := Primary
+     *
+     */
+    inline void initializeGrammar()
+    {
+        std::static_pointer_cast<ForwardRule>(Expression)->setTarget(Primary);
+    }
 }

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "grammar_aliases.hpp" // for Number, String, etc.
+#include "operators.hpp"
+
+/**
+ * @brief Central EBNF-style grammar definition for the Jesus language.
+ *
+ * “Do your best to present yourself to God as one approved, a worker who does not need to be ashamed and who correctly handles the word of truth.” - 2 Timothy 2:15
+ *
+ * 🌟 Central place for all EBNF rules (declarative rules)
+ *
+ * This file contains the full composition of the Jesus language's grammar
+ * using modular EBNF-style rules. The goal is clarity, elegance, and maintainability.
+ */
+namespace grammar
+{
+
+    inline auto Primary = Number | String;
+
+    inline auto ExpressionRule = Primary | Group(Number | String); // simplistic for now
+
+}

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -6,6 +6,7 @@
 #include "primitives/addition_rule.hpp"
 #include "primitives/comparison_rule.hpp"
 #include "primitives/equality_rule.hpp"
+#include "primitives/logical_and_rule.hpp"
 #include "primitives/multiplication_rule.hpp"
 #include "primitives/versus_rule.hpp"
 #include "unary_rule.hpp"
@@ -37,7 +38,8 @@ namespace grammar
     inline auto Addition = std::make_shared<AdditionRule>(Multiplication);
     inline auto Comparison = std::make_shared<ComparisonRule>(Addition);
     inline auto Equality = std::make_shared<EqualityRule>(Comparison);
-    inline auto Expression = Equality;
+    inline auto LogicalAnd = std::make_shared<LogicalAndRule>(Equality);
+    inline auto Expression = LogicalAnd;
     inline auto Versus = std::make_shared<VersusRule>(Addition, Addition);
 
     /**

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -4,6 +4,7 @@
 #include "grammar_aliases.hpp" // for Number, String, etc.
 #include "operators.hpp"
 #include "primitives/addition_rule.hpp"
+#include "primitives/comparison_rule.hpp"
 #include "primitives/multiplication_rule.hpp"
 #include "unary_rule.hpp"
 
@@ -30,9 +31,10 @@ namespace grammar
      */
 
     inline auto Unary = std::make_shared<ForwardRule>("Unary");
-    inline auto Expression = std::make_shared<ForwardRule>("Expression");
-    inline auto Multiplication = std::make_shared<ForwardRule>("Multiplication");
+    inline auto Multiplication = std::make_shared<MultiplicationRule>(Unary);
     inline auto Addition = std::make_shared<AdditionRule>(Multiplication);
+    inline auto Comparison = std::make_shared<ComparisonRule>(Addition);
+    inline auto Expression = Comparison;
 
     /**
      * @brief Primary is anything that can be evaluated directly: number, string, or a grouped expression.
@@ -50,8 +52,6 @@ namespace grammar
      */
     inline void initializeGrammar()
     {
-        Expression->setTarget(Primary);
         Unary->setTarget(std::make_shared<UnaryRule>(Primary));
-        Multiplication->setTarget(std::make_shared<MultiplicationRule>(Unary));
     }
 }

--- a/src/jesus/parser/grammar/operators.hpp
+++ b/src/jesus/parser/grammar/operators.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include "grammar_rule.hpp"
+#include "combinators/or_rule.hpp"
+#include "combinators/sequence_rule.hpp"
+
+// operator overloads
+inline std::shared_ptr<IGrammarRule> operator|(
+    std::shared_ptr<IGrammarRule> a,
+    std::shared_ptr<IGrammarRule> b)
+{
+    return std::make_shared<OrRule>(a, b);
+}
+
+inline std::shared_ptr<IGrammarRule> operator>>(
+    std::shared_ptr<IGrammarRule> a,
+    std::shared_ptr<IGrammarRule> b)
+{
+    return std::make_shared<SequenceRule>(a, b);
+}

--- a/src/jesus/parser/grammar/primitives/addition_rule.cpp
+++ b/src/jesus/parser/grammar/primitives/addition_rule.cpp
@@ -1,0 +1,20 @@
+#include "addition_rule.hpp"
+#include "../../../lexer/token_type.hpp"
+#include <iostream>
+
+bool AdditionRule::parse(ParserContext &ctx)
+{
+    if (!inner->parse(ctx))
+        return false;
+
+    while (ctx.matchAny({TokenType::PLUS, TokenType::MINUS}))
+    {
+        if (!inner->parse(ctx))
+        {
+            std::cerr << "Expected expression after '+' or '-' in AdditionRule.\n";
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/src/jesus/parser/grammar/primitives/addition_rule.cpp
+++ b/src/jesus/parser/grammar/primitives/addition_rule.cpp
@@ -1,20 +1,24 @@
 #include "addition_rule.hpp"
-#include "../../../lexer/token_type.hpp"
-#include <iostream>
+#include "../../../ast/expr/binary_expr.hpp"
 
-bool AdditionRule::parse(ParserContext &ctx)
+std::unique_ptr<Expr> AdditionRule::parse(ParserContext &ctx)
 {
-    if (!inner->parse(ctx))
-        return false;
+    auto left = inner->parse(ctx);
+    if (!left)
+        return nullptr;
 
     while (ctx.matchAny({TokenType::PLUS, TokenType::MINUS}))
     {
-        if (!inner->parse(ctx))
+        Token op = ctx.previous();
+        auto right = inner->parse(ctx);
+        if (!right)
         {
             std::cerr << "Expected expression after '+' or '-' in AdditionRule.\n";
-            return false;
+            return nullptr;
         }
+
+        left = std::make_unique<BinaryExpr>(std::move(left), op, std::move(right));
     }
 
-    return true;
+    return left;
 }

--- a/src/jesus/parser/grammar/primitives/addition_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/addition_rule.hpp
@@ -1,0 +1,35 @@
+#pragma once
+#include "../grammar_rule.hpp"
+#include "../../parser_context.hpp"
+#include <memory>
+
+/**
+ * @brief Handles addition and subtraction expressions (e.g., a + b, a - b).
+ *
+ * This rule parses expressions with + or - operators by left-associative chaining of
+ * `MultiplicationRule`s. For example, it parses `a + b - c` as ((a + b) - c).
+ *
+ * “The blessing of the Lord makes rich, and he adds no sorrow with it.”
+ * — Proverbs 10:22
+ */
+class AdditionRule : public IGrammarRule
+{
+private:
+    std::shared_ptr<IGrammarRule> inner;
+
+public:
+    explicit AdditionRule(std::shared_ptr<IGrammarRule> innerRule)
+        : inner(std::move(innerRule)) {}
+
+    bool parse(ParserContext &ctx) override;
+
+    std::string toStr(GrammarRuleHashTable &visited) const override
+    {
+        if (visited.count(this))
+            return "Addition(...)";
+
+        visited.insert(this);
+
+        return "Addition(" + inner->toStr(visited) + ")";
+    }
+};

--- a/src/jesus/parser/grammar/primitives/addition_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/addition_rule.hpp
@@ -21,7 +21,7 @@ public:
     explicit AdditionRule(std::shared_ptr<IGrammarRule> innerRule)
         : inner(std::move(innerRule)) {}
 
-    bool parse(ParserContext &ctx) override;
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override;
 
     std::string toStr(GrammarRuleHashTable &visited) const override
     {

--- a/src/jesus/parser/grammar/primitives/comparison_rule.cpp
+++ b/src/jesus/parser/grammar/primitives/comparison_rule.cpp
@@ -1,0 +1,28 @@
+#include "comparison_rule.hpp"
+
+bool ComparisonRule::parse(ParserContext &ctx)
+{
+    if (!inner->parse(ctx))
+        return false;
+
+    while (ctx.matchAny({TokenType::GREATER,
+                         TokenType::GREATER_EQUAL,
+                         TokenType::LESS,
+                         TokenType::LESS_EQUAL}))
+    {
+        if (!inner->parse(ctx))
+            return false;
+    }
+
+    return true;
+}
+
+std::string ComparisonRule::toStr(GrammarRuleHashTable &visited) const
+{
+    if (visited.count(this))
+        return "Comparison(...)";
+
+    visited.insert(this);
+
+    return "Comparison(" + inner->toStr(visited) + ")";
+}

--- a/src/jesus/parser/grammar/primitives/comparison_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/comparison_rule.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "../grammar_rule.hpp"
+#include <memory>
+
+/**
+ * @brief Handles comparison operations: >, >=, <, <=
+ *
+ * "But let justice roll down like waters, and righteousness like an ever-flowing stream." — Amos 5:24
+ */
+class ComparisonRule : public IGrammarRule
+{
+private:
+    std::shared_ptr<IGrammarRule> inner;
+
+public:
+    explicit ComparisonRule(std::shared_ptr<IGrammarRule> addition)
+        : inner(std::move(addition)) {}
+
+    bool parse(ParserContext &ctx) override;
+
+    std::string toStr(GrammarRuleHashTable &visited) const override;
+};

--- a/src/jesus/parser/grammar/primitives/comparison_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/comparison_rule.hpp
@@ -17,7 +17,7 @@ public:
     explicit ComparisonRule(std::shared_ptr<IGrammarRule> addition)
         : inner(std::move(addition)) {}
 
-    bool parse(ParserContext &ctx) override;
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override;
 
     std::string toStr(GrammarRuleHashTable &visited) const override;
 };

--- a/src/jesus/parser/grammar/primitives/equality_rule.cpp
+++ b/src/jesus/parser/grammar/primitives/equality_rule.cpp
@@ -1,0 +1,26 @@
+#include "equality_rule.hpp"
+#include "../../../lexer/token_type.hpp"
+
+bool EqualityRule::parse(ParserContext &ctx)
+{
+    if (!operand->parse(ctx))
+        return false;
+
+    while (ctx.matchAny({TokenType::EQUAL_EQUAL, TokenType::NOT_EQUAL}))
+    {
+        if (!operand->parse(ctx))
+            return false;
+    }
+
+    return true;
+}
+
+std::string EqualityRule::toStr(GrammarRuleHashTable &visited) const
+{
+    if (visited.count(this))
+        return "Equality(...)";
+
+    visited.insert(this);
+
+    return "Equality(" + operand->toStr(visited) + ")";
+}

--- a/src/jesus/parser/grammar/primitives/equality_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/equality_rule.hpp
@@ -30,7 +30,7 @@ public:
     explicit EqualityRule(std::shared_ptr<IGrammarRule> operandRule)
         : operand(std::move(operandRule)) {}
 
-    bool parse(ParserContext &ctx) override;
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override;
 
     std::string toStr(GrammarRuleHashTable &visited) const override;
 };

--- a/src/jesus/parser/grammar/primitives/equality_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/equality_rule.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "../grammar_rule.hpp"
+
+/**
+ * @brief Grammar rule to parse equality comparisons (==, !=).
+ *
+ * This rule matches expressions involving equality or inequality checks,
+ * such as `a == b` or `x != y`. It relies on a lower-precedence operand rule,
+ * typically a ComparisonRule, and parses left-associative binary expressions.
+ *
+ * Example matches:
+ * - 1 == 2
+ * - value != (3 + 5)
+ *
+ * "The LORD detests differing weights, but he delights in accurate scales."
+ * — Proverbs 11:1
+ */
+class EqualityRule : public IGrammarRule
+{
+private:
+    std::shared_ptr<IGrammarRule> operand;
+
+public:
+    /**
+     * @brief Constructs the rule with its lower-precedence operand (e.g., Comparison).
+     *
+     * @param operandRule A shared pointer to the rule that parses the operand expressions.
+     */
+    explicit EqualityRule(std::shared_ptr<IGrammarRule> operandRule)
+        : operand(std::move(operandRule)) {}
+
+    bool parse(ParserContext &ctx) override;
+
+    std::string toStr(GrammarRuleHashTable &visited) const override;
+};

--- a/src/jesus/parser/grammar/primitives/logical_and_rule.cpp
+++ b/src/jesus/parser/grammar/primitives/logical_and_rule.cpp
@@ -1,16 +1,26 @@
 #include "logical_and_rule.hpp"
+#include "../../../ast/expr/binary_expr.hpp"
 
-bool LogicalAndRule::parse(ParserContext &ctx)
+std::unique_ptr<Expr> LogicalAndRule::parse(ParserContext &ctx)
 {
-    if (!nextRule->parse(ctx))
-        return false;
+    auto left = nextRule->parse(ctx);
+    if (!left)
+        return nullptr;
 
     while (ctx.match(TokenType::AND))
     {
-        if (!nextRule->parse(ctx))
-            return false;
+        Token op = ctx.previous();
+        auto right = nextRule->parse(ctx);
+        if (!right)
+        {
+            std::cerr << "Expected right-hand expression after '" << op.lexeme << "' logical AND operator.\n";
+            return nullptr;
+        }
+
+        left = std::make_unique<BinaryExpr>(std::move(left), op, std::move(right));
     }
-    return true;
+
+    return left;
 }
 
 std::string LogicalAndRule::toStr(GrammarRuleHashTable &visited) const

--- a/src/jesus/parser/grammar/primitives/logical_and_rule.cpp
+++ b/src/jesus/parser/grammar/primitives/logical_and_rule.cpp
@@ -1,0 +1,24 @@
+#include "logical_and_rule.hpp"
+
+bool LogicalAndRule::parse(ParserContext &ctx)
+{
+    if (!nextRule->parse(ctx))
+        return false;
+
+    while (ctx.match(TokenType::AND))
+    {
+        if (!nextRule->parse(ctx))
+            return false;
+    }
+    return true;
+}
+
+std::string LogicalAndRule::toStr(GrammarRuleHashTable &visited) const
+{
+    if (visited.count(this))
+        return "LogicalAnd(...)";
+
+    visited.insert(this);
+
+    return "LogicalAnd(" + nextRule->toStr(visited) + ")";
+}

--- a/src/jesus/parser/grammar/primitives/logical_and_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/logical_and_rule.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "../grammar_rule.hpp"
+
+/**
+ * @brief Parses logical AND expressions (e.g. a AND b AND c).
+ *
+ * "Two are better than one, because they have a good return for their labor."
+ * — Ecclesiastes 4:9
+ */
+class LogicalAndRule : public IGrammarRule
+{
+private:
+    std::shared_ptr<IGrammarRule> nextRule;
+
+public:
+    explicit LogicalAndRule(std::shared_ptr<IGrammarRule> next)
+        : nextRule(std::move(next)) {}
+
+    bool parse(ParserContext &ctx) override;
+
+    std::string toStr(GrammarRuleHashTable &visited) const override;
+};

--- a/src/jesus/parser/grammar/primitives/logical_and_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/logical_and_rule.hpp
@@ -17,7 +17,7 @@ public:
     explicit LogicalAndRule(std::shared_ptr<IGrammarRule> next)
         : nextRule(std::move(next)) {}
 
-    bool parse(ParserContext &ctx) override;
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override;
 
     std::string toStr(GrammarRuleHashTable &visited) const override;
 };

--- a/src/jesus/parser/grammar/primitives/logical_or_rule.cpp
+++ b/src/jesus/parser/grammar/primitives/logical_or_rule.cpp
@@ -1,0 +1,14 @@
+#include "logical_or_rule.hpp"
+
+bool LogicalOrRule::parse(ParserContext &ctx)
+{
+    if (!nextRule->parse(ctx))
+        return false;
+
+    while (ctx.match(TokenType::OR))
+    {
+        if (!nextRule->parse(ctx))
+            return false;
+    }
+    return true;
+}

--- a/src/jesus/parser/grammar/primitives/logical_or_rule.cpp
+++ b/src/jesus/parser/grammar/primitives/logical_or_rule.cpp
@@ -1,14 +1,24 @@
 #include "logical_or_rule.hpp"
+#include "../../../ast/expr/binary_expr.hpp"
 
-bool LogicalOrRule::parse(ParserContext &ctx)
+std::unique_ptr<Expr> LogicalOrRule::parse(ParserContext &ctx)
 {
-    if (!nextRule->parse(ctx))
-        return false;
+    auto left = nextRule->parse(ctx);
+    if (!left)
+        return nullptr;
 
     while (ctx.match(TokenType::OR))
     {
-        if (!nextRule->parse(ctx))
-            return false;
+        Token op = ctx.previous();
+        auto right = nextRule->parse(ctx);
+        if (!right)
+        {
+            std::cerr << "Expected right-hand expression after '" << op.lexeme << "' OR operator.\n";
+            return nullptr;
+        }
+
+        left = std::make_unique<BinaryExpr>(std::move(left), op, std::move(right));
     }
-    return true;
+
+    return left;
 }

--- a/src/jesus/parser/grammar/primitives/logical_or_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/logical_or_rule.hpp
@@ -19,7 +19,7 @@ private:
 public:
     explicit LogicalOrRule(std::shared_ptr<IGrammarRule> next) : nextRule(std::move(next)) {}
 
-    bool parse(ParserContext &ctx) override;
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override;
 
     std::string toStr(GrammarRuleHashTable &visitedTable) const override
     {

--- a/src/jesus/parser/grammar/primitives/logical_or_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/logical_or_rule.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include "../grammar_rule.hpp"
+
+/**
+ * @brief Parses expressions combined by logical OR (e.g., a or b or c).
+ *
+ * Logical OR sits at the top of the logical precedence hierarchy.
+ *
+ * Example:
+ *   1 or 2 or 3
+ *
+ * "For where two or three gather in my name, there am I with them." — Matthew 18:20
+ */
+class LogicalOrRule : public IGrammarRule
+{
+private:
+    std::shared_ptr<IGrammarRule> nextRule;
+
+public:
+    explicit LogicalOrRule(std::shared_ptr<IGrammarRule> next) : nextRule(std::move(next)) {}
+
+    bool parse(ParserContext &ctx) override;
+
+    std::string toStr(GrammarRuleHashTable &visitedTable) const override
+    {
+        if (visitedTable.count(this))
+            return "LogicalOr(...)";
+
+        visitedTable.insert(this);
+
+        return "LogicalOr(" + nextRule->toStr(visitedTable) + ")";
+    }
+};

--- a/src/jesus/parser/grammar/primitives/multiplication_rule.cpp
+++ b/src/jesus/parser/grammar/primitives/multiplication_rule.cpp
@@ -1,0 +1,25 @@
+#include "multiplication_rule.hpp"
+
+bool MultiplicationRule::parse(ParserContext &ctx)
+{
+    if (!unary->parse(ctx))
+        return false;
+
+    while (ctx.matchAny({TokenType::STAR, TokenType::SLASH}))
+    {
+        if (!unary->parse(ctx))
+            return false;
+    }
+
+    return true;
+}
+
+std::string MultiplicationRule::toStr(GrammarRuleHashTable &visited) const
+{
+    if (visited.count(this))
+        return "Multiplication(...)";
+
+    visited.insert(this);
+
+    return "Multiplication(" + unary->toStr(visited) + ")";
+}

--- a/src/jesus/parser/grammar/primitives/multiplication_rule.cpp
+++ b/src/jesus/parser/grammar/primitives/multiplication_rule.cpp
@@ -1,17 +1,23 @@
 #include "multiplication_rule.hpp"
+#include "../../../ast/expr/binary_expr.hpp"
 
-bool MultiplicationRule::parse(ParserContext &ctx)
+std::unique_ptr<Expr> MultiplicationRule::parse(ParserContext &ctx)
 {
-    if (!unary->parse(ctx))
-        return false;
+    auto left = unary->parse(ctx);
+    if (!left)
+        return nullptr;
 
     while (ctx.matchAny({TokenType::STAR, TokenType::SLASH}))
     {
-        if (!unary->parse(ctx))
-            return false;
+        Token op = ctx.previous();
+        auto right = unary->parse(ctx);
+        if (!right)
+            return nullptr;
+
+        left = std::make_unique<BinaryExpr>(std::move(left), op, std::move(right));
     }
 
-    return true;
+    return left;
 }
 
 std::string MultiplicationRule::toStr(GrammarRuleHashTable &visited) const

--- a/src/jesus/parser/grammar/primitives/multiplication_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/multiplication_rule.hpp
@@ -11,7 +11,7 @@ public:
     explicit MultiplicationRule(std::shared_ptr<IGrammarRule> unaryRule)
         : unary(std::move(unaryRule)) {}
 
-    bool parse(ParserContext &ctx) override;
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override;
 
     std::string toStr(GrammarRuleHashTable &visited) const override;
 };

--- a/src/jesus/parser/grammar/primitives/multiplication_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/multiplication_rule.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "../grammar_rule.hpp"
+
+class MultiplicationRule : public IGrammarRule
+{
+private:
+    std::shared_ptr<IGrammarRule> unary;
+
+public:
+    explicit MultiplicationRule(std::shared_ptr<IGrammarRule> unaryRule)
+        : unary(std::move(unaryRule)) {}
+
+    bool parse(ParserContext &ctx) override;
+
+    std::string toStr(GrammarRuleHashTable &visited) const override;
+};

--- a/src/jesus/parser/grammar/primitives/number_rule.cpp
+++ b/src/jesus/parser/grammar/primitives/number_rule.cpp
@@ -1,7 +1,12 @@
 #include "number_rule.hpp"
-#include "../../../lexer/token_type.hpp"
+#include "../../../ast/expr/literal_expr.hpp"
 
-bool NumberRule::parse(ParserContext &ctx)
+std::unique_ptr<Expr> NumberRule::parse(ParserContext &ctx)
 {
-    return ctx.matchAny({TokenType::INT, TokenType::DOUBLE});
+    if (ctx.matchAny({TokenType::INT, TokenType::DOUBLE}))
+    {
+        return std::make_unique<LiteralExpr>(ctx.previous().literal);
+    }
+
+    return nullptr;
 }

--- a/src/jesus/parser/grammar/primitives/number_rule.cpp
+++ b/src/jesus/parser/grammar/primitives/number_rule.cpp
@@ -1,0 +1,7 @@
+#include "number_rule.hpp"
+#include "../../../lexer/token_type.hpp"
+
+bool NumberRule::parse(ParserContext &ctx)
+{
+    return ctx.matchAny({TokenType::INT, TokenType::DOUBLE});
+}

--- a/src/jesus/parser/grammar/primitives/number_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/number_rule.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include "../grammar_rule.hpp"
+
+/**
+ * @brief Matches a number literal.
+ */
+class NumberRule : public IGrammarRule
+{
+public:
+    bool parse(ParserContext &ctx) override;
+
+    std::string toString() override
+    {
+        return "Number";
+    }
+};

--- a/src/jesus/parser/grammar/primitives/number_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/number_rule.hpp
@@ -9,7 +9,7 @@ class NumberRule : public IGrammarRule
 public:
     bool parse(ParserContext &ctx) override;
 
-    std::string toString() override
+    std::string toStr(GrammarRuleHashTable &visitedTable) const override
     {
         return "Number";
     }

--- a/src/jesus/parser/grammar/primitives/number_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/number_rule.hpp
@@ -7,7 +7,7 @@
 class NumberRule : public IGrammarRule
 {
 public:
-    bool parse(ParserContext &ctx) override;
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override;
 
     std::string toStr(GrammarRuleHashTable &visitedTable) const override
     {

--- a/src/jesus/parser/grammar/primitives/string_rule.cpp
+++ b/src/jesus/parser/grammar/primitives/string_rule.cpp
@@ -1,0 +1,11 @@
+#include "string_rule.hpp"
+#include "../../../lexer/token_type.hpp"
+
+bool StringRule::parse(ParserContext &ctx)
+{
+    if (ctx.match(TokenType::STRING))
+    {
+        return true;
+    }
+    return false;
+}

--- a/src/jesus/parser/grammar/primitives/string_rule.cpp
+++ b/src/jesus/parser/grammar/primitives/string_rule.cpp
@@ -1,11 +1,12 @@
 #include "string_rule.hpp"
-#include "../../../lexer/token_type.hpp"
+#include "../../../ast/expr/literal_expr.hpp"
 
-bool StringRule::parse(ParserContext &ctx)
+std::unique_ptr<Expr> StringRule::parse(ParserContext &ctx)
 {
     if (ctx.match(TokenType::STRING))
     {
-        return true;
+        return std::make_unique<LiteralExpr>(ctx.previous().literal);
     }
-    return false;
+
+    return nullptr;
 }

--- a/src/jesus/parser/grammar/primitives/string_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/string_rule.hpp
@@ -8,7 +8,7 @@
 class StringRule : public IGrammarRule
 {
 public:
-    bool parse(ParserContext &ctx) override;
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override;
 
     std::string toStr(GrammarRuleHashTable &visitedTable) const override
     {

--- a/src/jesus/parser/grammar/primitives/string_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/string_rule.hpp
@@ -10,7 +10,7 @@ class StringRule : public IGrammarRule
 public:
     bool parse(ParserContext &ctx) override;
 
-    std::string toString() override
+    std::string toStr(GrammarRuleHashTable &visitedTable) const override
     {
         return "String";
     }

--- a/src/jesus/parser/grammar/primitives/string_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/string_rule.hpp
@@ -1,0 +1,17 @@
+
+#pragma once
+#include "../grammar_rule.hpp"
+
+/**
+ * @brief Matches a string literal.
+ */
+class StringRule : public IGrammarRule
+{
+public:
+    bool parse(ParserContext &ctx) override;
+
+    std::string toString() override
+    {
+        return "String";
+    }
+};

--- a/src/jesus/parser/grammar/primitives/variable_rule.cpp
+++ b/src/jesus/parser/grammar/primitives/variable_rule.cpp
@@ -1,0 +1,6 @@
+#include "variable_rule.hpp"
+
+bool VariableRule::parse(ParserContext &ctx)
+{
+    return ctx.match(TokenType::IDENTIFIER);
+}

--- a/src/jesus/parser/grammar/primitives/variable_rule.cpp
+++ b/src/jesus/parser/grammar/primitives/variable_rule.cpp
@@ -1,6 +1,10 @@
 #include "variable_rule.hpp"
+#include "../../../ast/expr/variable_expr.hpp"
 
-bool VariableRule::parse(ParserContext &ctx)
+std::unique_ptr<Expr> VariableRule::parse(ParserContext &ctx)
 {
-    return ctx.match(TokenType::IDENTIFIER);
+    if (ctx.match(TokenType::IDENTIFIER))
+        return std::make_unique<VariableExpr>(ctx.previous().lexeme);
+
+    return nullptr;
 }

--- a/src/jesus/parser/grammar/primitives/variable_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/variable_rule.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#include "../grammar_rule.hpp"
+
+/**
+ * @brief Grammar rule that matches variable references.
+ *
+ * It corresponds to a VariableExpr node in the AST.
+ *
+ * “The LORD called Moses by name from the tent of meeting and said…”
+ * — Leviticus 1:1
+ */
+class VariableRule : public IGrammarRule
+{
+public:
+    bool parse(ParserContext &ctx) override;
+
+    std::string toStr(GrammarRuleHashTable &visited) const override
+    {
+        return "Variable";
+    }
+};

--- a/src/jesus/parser/grammar/primitives/variable_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/variable_rule.hpp
@@ -12,7 +12,7 @@
 class VariableRule : public IGrammarRule
 {
 public:
-    bool parse(ParserContext &ctx) override;
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override;
 
     std::string toStr(GrammarRuleHashTable &visited) const override
     {

--- a/src/jesus/parser/grammar/primitives/versus_rule.cpp
+++ b/src/jesus/parser/grammar/primitives/versus_rule.cpp
@@ -1,0 +1,30 @@
+#include "versus_rule.hpp"
+
+VersusRule::VersusRule(std::shared_ptr<IGrammarRule> lhs, std::shared_ptr<IGrammarRule> rhs)
+    : lhsRule(std::move(lhs)), rhsRule(std::move(rhs))
+{
+}
+
+bool VersusRule::parse(ParserContext &ctx)
+{
+    // Parse left-hand side expression
+    if (!lhsRule->parse(ctx))
+        return false;
+
+    // Check if next token is VERSUS
+    if (!ctx.match(TokenType::VERSUS))
+        return true; // no operator found, expression is just lhs
+
+    // Parse right-hand side expression
+    return rhsRule->parse(ctx);
+}
+
+std::string VersusRule::toStr(GrammarRuleHashTable &visitedTable) const
+{
+    if (visitedTable.count(this))
+        return "Versus(...)";
+
+    visitedTable.insert(this);
+
+    return "Versus(" + lhsRule->toStr(visitedTable) + " vs " + rhsRule->toStr(visitedTable) + ")";
+}

--- a/src/jesus/parser/grammar/primitives/versus_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/versus_rule.hpp
@@ -21,7 +21,7 @@ private:
 public:
     explicit VersusRule(std::shared_ptr<IGrammarRule> lhs, std::shared_ptr<IGrammarRule> rhs);
 
-    bool parse(ParserContext &ctx) override;
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override;
 
     std::string toStr(GrammarRuleHashTable &visitedTable) const override;
 };

--- a/src/jesus/parser/grammar/primitives/versus_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/versus_rule.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "../grammar_rule.hpp"
+#include <memory>
+
+/**
+ * @brief Rule to parse the 'VERSUS' binary operator expressions, also known as XOR.
+ *
+ * This rule parses expressions with the 'VERSUS' operator, e.g. `expr VERSUS expr`.
+ *
+ * "No one can serve two masters. Either you will hate the one and love the other,
+ * or you will be devoted to the one and despise the other.
+ * You cannot serve both God and money." — Matthew 6:24
+ */
+class VersusRule : public IGrammarRule
+{
+private:
+    std::shared_ptr<IGrammarRule> lhsRule;
+    std::shared_ptr<IGrammarRule> rhsRule;
+
+public:
+    explicit VersusRule(std::shared_ptr<IGrammarRule> lhs, std::shared_ptr<IGrammarRule> rhs);
+
+    bool parse(ParserContext &ctx) override;
+
+    std::string toStr(GrammarRuleHashTable &visitedTable) const override;
+};

--- a/src/jesus/parser/grammar/primitives/yes_no_rule.cpp
+++ b/src/jesus/parser/grammar/primitives/yes_no_rule.cpp
@@ -1,0 +1,13 @@
+#include "yes_no_rule.hpp"
+#include "../../../ast/expr/literal_expr.hpp"
+
+std::unique_ptr<Expr> YesNoRule::parse(ParserContext &ctx)
+{
+    if (ctx.match(TokenType::YES))
+        return std::make_unique<LiteralExpr>(Value(true));
+
+    if (ctx.match(TokenType::NO))
+        return std::make_unique<LiteralExpr>(Value(false));
+
+    return nullptr;
+}

--- a/src/jesus/parser/grammar/primitives/yes_no_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/yes_no_rule.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include "../grammar_rule.hpp"
+
+/**
+ * @brief Parses boolean literals: `yes` or `no`.
+ *
+ * Known as Boolean `true` or `false` in other languages.
+ *
+ * “Let your ‘Yes’ be ‘Yes,’ and your ‘No,’ ‘No’; anything beyond this comes from the evil one.”
+ * — Matthew 5:37
+ */
+class YesNoRule : public IGrammarRule
+{
+public:
+    bool parse(ParserContext &ctx) override
+    {
+        return ctx.match(TokenType::YES) || ctx.match(TokenType::NO);
+    }
+
+    std::string toStr(GrammarRuleHashTable &) const override
+    {
+        return "YesNo";
+    }
+};

--- a/src/jesus/parser/grammar/primitives/yes_no_rule.hpp
+++ b/src/jesus/parser/grammar/primitives/yes_no_rule.hpp
@@ -12,10 +12,7 @@
 class YesNoRule : public IGrammarRule
 {
 public:
-    bool parse(ParserContext &ctx) override
-    {
-        return ctx.match(TokenType::YES) || ctx.match(TokenType::NO);
-    }
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override;
 
     std::string toStr(GrammarRuleHashTable &) const override
     {

--- a/src/jesus/parser/grammar/unary_rule.cpp
+++ b/src/jesus/parser/grammar/unary_rule.cpp
@@ -1,15 +1,17 @@
 #include "unary_rule.hpp"
-#include "../../lexer/token_type.hpp"
+#include "../../ast/expr/unary_expr.hpp"
 
-bool UnaryRule::parse(ParserContext &ctx)
+std::unique_ptr<Expr> UnaryRule::parse(ParserContext &ctx)
 {
     if (ctx.matchAny({TokenType::NOT, TokenType::MINUS, TokenType::PLUS}))
     {
-        // Recursively call self to support cases like -(--42)
-        if (!parse(ctx))
-            return false;
+        Token op = ctx.previous();
 
-        return true;
+        auto right = parse(ctx); // Recursive call to allow repeated like `-(--42)`
+        if (!right)
+            return nullptr;
+
+        return std::make_unique<UnaryExpr>(op, std::move(right));
     }
 
     // Try to parse operand directly without unary operator.

--- a/src/jesus/parser/grammar/unary_rule.cpp
+++ b/src/jesus/parser/grammar/unary_rule.cpp
@@ -1,0 +1,27 @@
+#include "unary_rule.hpp"
+#include "../../lexer/token_type.hpp"
+
+bool UnaryRule::parse(ParserContext &ctx)
+{
+    if (ctx.matchAny({TokenType::NOT, TokenType::MINUS, TokenType::PLUS}))
+    {
+        // Recursively call self to support cases like -(--42)
+        if (!parse(ctx))
+            return false;
+
+        return true;
+    }
+
+    // Try to parse operand directly without unary operator.
+    return operandRule->parse(ctx);
+}
+
+std::string UnaryRule::toStr(GrammarRuleHashTable &visitedTable) const
+{
+    if (visitedTable.count(this))
+        return "Unary(...)";
+
+    visitedTable.insert(this);
+
+    return "Unary(" + operandRule->toStr(visitedTable) + ")";
+}

--- a/src/jesus/parser/grammar/unary_rule.hpp
+++ b/src/jesus/parser/grammar/unary_rule.hpp
@@ -22,7 +22,7 @@ public:
     explicit UnaryRule(std::shared_ptr<IGrammarRule> operandRule)
         : operandRule(std::move(operandRule)) {}
 
-    bool parse(ParserContext &ctx) override;
+     std::unique_ptr<Expr> parse(ParserContext &ctx) override;
 
     std::string toStr(GrammarRuleHashTable &visitedTable) const override;
 };

--- a/src/jesus/parser/grammar/unary_rule.hpp
+++ b/src/jesus/parser/grammar/unary_rule.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "grammar_rule.hpp"
+#include "../parser_context.hpp"
+#include <memory>
+
+/**
+ * @brief Rule for parsing unary expressions, such as "not expr" or "-expr".
+ *
+ * This rule supports unary operators like 'not', '+', and '-'.
+ * It defers to an inner rule (e.g., Primary or Expression) for parsing the operand.
+ *
+ * "Put on the full armor of God, so that you can take your stand against the devil’s schemes."
+ * — Ephesians 6:11
+ */
+class UnaryRule : public IGrammarRule
+{
+private:
+    std::shared_ptr<IGrammarRule> operandRule;
+
+public:
+    explicit UnaryRule(std::shared_ptr<IGrammarRule> operandRule)
+        : operandRule(std::move(operandRule)) {}
+
+    bool parse(ParserContext &ctx) override;
+
+    std::string toStr(GrammarRuleHashTable &visitedTable) const override;
+};

--- a/src/jesus/parser/parser_context.hpp
+++ b/src/jesus/parser/parser_context.hpp
@@ -19,8 +19,8 @@
 class ParserContext
 {
 public:
-    explicit ParserContext(const std::vector<Token> &tokens)
-        : tokens(tokens), current(0) {}
+    explicit ParserContext(const std::vector<Token> &tokens, int current=0)
+        : tokens(tokens), current(current) {}
 
     /**
      * @brief Returns the current token without consuming it
@@ -101,8 +101,6 @@ public:
      */
     bool isAtEnd() const
     {
-        std::cout << "  ParserContext::isAtEnd()\n";
-
         return peek().type == TokenType::END_OF_FILE;
     }
 

--- a/src/jesus/parser/parser_context.hpp
+++ b/src/jesus/parser/parser_context.hpp
@@ -1,0 +1,154 @@
+#pragma once
+
+#include "../lexer/token.hpp"
+#include "../lexer/token_type.hpp"
+
+#include <string>
+#include <vector>
+#include <stdexcept>
+
+/**
+ * @brief The context passed around during parsing, holding tokens and parsing position.
+ *
+ * It acts as a shared parsing state for all grammar rules
+ * — keeping track of the token list, current position, and convenience functions
+ *
+ * “Wisdom is the principal thing; therefore get wisdom:
+ * and with all thy getting get understanding.” — Proverbs 4:7
+ */
+class ParserContext
+{
+public:
+    explicit ParserContext(const std::vector<Token> &tokens)
+        : tokens(tokens), current(0) {}
+
+    /**
+     * @brief Returns the current token without consuming it
+     *
+     * @return const Token&
+     */
+    const Token &peek() const
+    {
+        return tokens[current];
+    }
+
+    /**
+     * @brief Returns the previous token
+     *
+     * @return const Token&
+     */
+    const Token &previous() const
+    {
+        if (current == 0)
+            throw std::runtime_error("No previous token");
+
+        return tokens[current - 1];
+    }
+
+    /**
+     * @brief Advances to the next token if not at end
+     *
+     * @return const Token&
+     */
+    const Token &advance()
+    {
+        if (!isAtEnd())
+            current++;
+
+        return previous();
+    }
+
+    /**
+     * @brief Checks if the next token matches expected type
+     */
+    bool match(TokenType type)
+    {
+        if (check(type))
+        {
+            advance();
+            return true;
+        }
+
+        return false;
+    }
+
+    bool matchAny(const std::initializer_list<TokenType> &types)
+    {
+        for (auto type : types)
+        {
+            if (check(type))
+            {
+                advance();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @brief Checks if current token is of the given type
+     */
+    bool check(TokenType type) const
+    {
+        if (isAtEnd())
+            return false;
+
+        return peek().type == type;
+    }
+
+    /**
+     * @brief Check if all tokens have been consumed
+     */
+    bool isAtEnd() const
+    {
+        std::cout << "  ParserContext::isAtEnd()\n";
+
+        return peek().type == TokenType::END_OF_FILE;
+    }
+
+    /**
+     * @brief For error reporting
+     */
+    Token currentToken() const
+    {
+        return peek();
+    }
+
+    /**
+     * @brief Rollback support (snapshot/rewind)
+     */
+    size_t position() const
+    {
+        return current;
+    }
+
+    void rewind(size_t pos)
+    {
+        current = pos;
+    }
+
+    ParserContext snapshot() const
+    {
+        ParserContext copy(this->tokens);
+        copy.current = this->current;
+        return copy;
+    }
+
+    std::string toString()
+    {
+        std::string str = "ParserContext(current: " + std::to_string(current) + ", tokens: ";
+
+        for (auto token : tokens)
+        {
+            str += token.toString() + ", ";
+        }
+
+        str += ")";
+
+        return str;
+    }
+
+private:
+    std::vector<Token> tokens;
+    size_t current = 0;
+};

--- a/src/jesus/test_runner.cpp
+++ b/src/jesus/test_runner.cpp
@@ -2,6 +2,7 @@
 #include <filesystem>
 #include <iostream>
 #include <fstream>
+#include "parser/grammar/jesus_grammar.hpp"
 
 std::string runJesusInterpreter(const std::string &inputFile)
 {
@@ -55,6 +56,8 @@ void showDiff(const std::string &expected, const std::string &actual)
 
 int main()
 {
+    grammar::initializeGrammar(); // Sets the Expression rule target to Primary
+
     std::string testDir = "tests";
     bool allPassed = true;
 


### PR DESCRIPTION
# Description

This PR introduces a new *Grammar-Based Parsing Layer* built around EBNF-style rule composition. It replaces the hardcoded recursive descent structure previously used in `ExpressionParser`.

## Motivation
While trying to implement the `repeat x times:` statement, it became clear that the former parser structure made it **impossible** to support more flexible expression parsing and grouping. The existing mode (e.g. `parseOr() → parseAnd() → parseEquality()...`) quickly became difficult to extend or reason about.

##  What's New

Instead of hardcoded parser sequences, expressions are now described declaratively using combinable grammar rules like this:

```cpp
inline auto Unary          = std::make_shared<ForwardRule>("Unary");
inline auto Multiplication = std::make_shared<MultiplicationRule>(Unary);
inline auto Addition       = std::make_shared<AdditionRule>(Multiplication);
inline auto Comparison     = std::make_shared<ComparisonRule>(Addition);
inline auto Equality       = std::make_shared<EqualityRule>(Comparison);
inline auto LogicalAnd     = std::make_shared<LogicalAndRule>(Equality);
inline auto Versus         = std::make_shared<VersusRule>(LogicalAnd, LogicalAnd);
inline auto LogicalOr      = std::make_shared<LogicalOrRule>(Versus);
inline auto Expression     = LogicalOr;

inline auto YesNo    = std::make_shared<YesNoRule>();
inline auto Variable = std::make_shared<VariableRule>();

inline auto Primary = Number | String | YesNo | Variable | Group(Expression);

```

This makes the grammar:

- 🌿 **More maintainable** — rules are small, composable units.
- 🧠 **Easier to reason about** — structure reflects natural EBNF composition.
- 🧱 **Extensible** — new operators and language constructs can be added without breaking the parser internals.
- 🧪 **Testable** — each rule can be tested in isolation and plugged together later.

## Architecture

Each rule is represented by a class inheriting from `IGrammarRule`, whose `parser` method returns `std::unique_ptr<Expr>`. This enables our grammar layer to build actual **expression trees**, not just token matchers.

The previously hardcoded logic like this:
```cpp
parse()
  → parseOr()
    → parseAnd()
      → parseEquality()
        ...
```
Is now **cleanly defined** in ~12 lines of grammar setup (see `jesus_grammar.hpp`).

---

## ✝️ Wisdom

> Then the Lord replied: “Write down the revelation and make it plain on tablets so that one who runs can read it” 
> — *Habakkuk 2:2*

Just as God commanded the vision to be made **plain**, this parser refactor aims to make the language’s grammar **clear and readable**, so that both users and future maintainers can "run with it" — understanding and extending it with confidence.

---

Let me know if you’d like this adapted into a changelog or summarized for documentation as well.