### PR TITLE
Step 12: Added CMake and Makefile to improve the build process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.10)
+
+# --------------------
+# Set the project name
+# --------------------
+project(Jesus)
+
+include_directories(src/jesus)
+
+# --------------------
+# Set the C++ standard
+# --------------------
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+# -------------------
+# Define source files
+# -------------------
+set(JESUS_CPP_FILES
+
+    src/jesus/lexer/lexer.cpp
+    src/jesus/spirit/value.cpp
+    src/jesus/spirit/heart.cpp
+    src/jesus/parser/parser.cpp
+    src/jesus/interpreter/interpreter.cpp
+    src/jesus/parser/grammar/group_rule.cpp
+    src/jesus/parser/grammar/unary_rule.cpp
+    src/jesus/parser/grammar/primitives/number_rule.cpp
+    src/jesus/parser/grammar/primitives/string_rule.cpp
+    src/jesus/parser/grammar/primitives/versus_rule.cpp
+    src/jesus/parser/grammar/primitives/yes_no_rule.cpp
+    src/jesus/parser/grammar/primitives/addition_rule.cpp
+    src/jesus/parser/grammar/primitives/equality_rule.cpp
+    src/jesus/parser/grammar/primitives/variable_rule.cpp
+    src/jesus/parser/grammar/primitives/comparison_rule.cpp
+    src/jesus/parser/grammar/primitives/logical_or_rule.cpp
+    src/jesus/parser/grammar/primitives/logical_and_rule.cpp
+    src/jesus/parser/grammar/primitives/multiplication_rule.cpp
+)
+
+# --------------------------
+# Add the `jesus` executable
+# --------------------------
+add_executable(jesus src/jesus/main.cpp ${JESUS_CPP_FILES})

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+# ----------------
+# Define variables
+# ----------------
+CURRENT_DIR := $(shell pwd)
+BUILD_DIR = build
+SRC_DIR = src
+TARGET = Jesus
+CMAKE = cmake
+MAKE = make
+
+# -----------------------------------------------------------------------
+# Default target: It first builds the C++ executable using cmake and make
+# -----------------------------------------------------------------------
+all: $(BUILD_DIR)
+	cd $(BUILD_DIR) && $(CMAKE) .. && $(MAKE)
+
+# ----------------------------------------------
+# Create the build directory if it doesn't exist
+# ----------------------------------------------
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+# --------------------------
+# Run the 'jesus' executable
+# --------------------------
+run: $(BUILD_DIR)/jesus
+	./$(BUILD_DIR)/jesus
+
+# ------------------------
+# Clean up build directory
+# ------------------------
+clean:
+	rm -rf $(BUILD_DIR)
+
+# Add phony targets
+.PHONY: all run clean

--- a/README.md
+++ b/README.md
@@ -8,29 +8,36 @@ This repository currently contains the basic lexer (lexical analyzer) and REPL l
 
 ## 🛠 Compilation
 
-To build and run the project, make sure you have a C++ compiler (like `g++`) installed.
+This project uses **CMake** and **Make** to simplify building.
 
-Compile using the following command:
+##### Requirements
+
+Make sure you have:
+
+* A C++ compiler that supports C++17 (e.g., `g++`)
+* `cmake` installed (version 3.10 or higher)
+* `make`
+
+##### Build & Run
+
+In the root folder of the project, run:
 
 ```bash
-cd src/jesus
-
-g++ main.cpp lexer/lexer.cpp parser/parser.cpp spirit/heart.cpp spirit/value.cpp interpreter/interpreter.cpp parser/grammar/primitives/number_rule.cpp parser/grammar/primitives/string_rule.cpp parser/grammar/group_rule.cpp parser/grammar/unary_rule.cpp parser/grammar/primitives/addition_rule.cpp parser/grammar/primitives/comparison_rule.cpp parser/grammar/primitives/equality_rule.cpp parser/grammar/primitives/logical_and_rule.cpp parser/grammar/primitives/logical_or_rule.cpp parser/grammar/primitives/multiplication_rule.cpp parser/grammar/primitives/yes_no_rule.cpp parser/grammar/primitives/variable_rule.cpp parser/grammar/primitives/versus_rule.cpp -I . -o jesus
+make clean     # Optional: cleans previous build artifacts
+make           # Compiles the project using CMake and Make
+make run       # Runs the Jesus interpreter
 ```
 
-Then run:
+##### Output
 
-```bash
-./jesus
-```
-
-You will see the REPL prompt:
+After running, you’ll see the REPL prompt:
 
 ```
 (Jesus)
 ```
 
-Type a line and see the tokens printed as output.
+Type any valid expression or command and press enter.
+
 
 ## 🧪 Running the Test Suite
 
@@ -45,6 +52,8 @@ Each test is composed of:
 
 Make sure both the `jesus` binary and the `test_runner` are built. Build the `test_runner` using this command:
 ```
+cd src/jesus/
+
 g++ -std=c++17 -o test_runner test_runner.cpp
 ```
 
@@ -56,7 +65,7 @@ Then simply run:
 
 ✅ What It Does
 
-- Automatically runs all .jesus test files in the tests/ directory.
+- Automatically runs all `.jesus` test files in the [tests](src/jesus/tests) directory.
 
 - Captures both stdout and stderr of the Jesus interpreter.
 
@@ -78,7 +87,7 @@ Line 3 differs 🔴️:
 
 💡 Tip for Contributors
 
-To add a new test, create a file like `tests/my_test.jesus` and its expected output in `tests/my_test.jesus.expected`.
+To add a new test, create a file like `src/jesus/tests/my_test.jesus` and its expected output in `src/jesus/tests/my_test.jesus.expected`.
 
 You can generate the .expected file like this:
 

--- a/src/jesus/test_runner.cpp
+++ b/src/jesus/test_runner.cpp
@@ -2,7 +2,6 @@
 #include <filesystem>
 #include <iostream>
 #include <fstream>
-#include "parser/grammar/jesus_grammar.hpp"
 
 std::string runJesusInterpreter(const std::string &inputFile)
 {
@@ -56,8 +55,6 @@ void showDiff(const std::string &expected, const std::string &actual)
 
 int main()
 {
-    grammar::initializeGrammar(); // Sets the Expression rule target to Primary
-
     std::string testDir = "tests";
     bool allPassed = true;
 


### PR DESCRIPTION
# Description

This PR introduces a structured and scalable build system for the Jesus programming language:

- ✅ Adds a `CMakeLists.txt` file to define source files, include paths, and compiler settings.
- ✅ Adds a root-level `Makefile` with user-friendly targets:
  - `make` to configure and build the project.
  - `make run` to launch the `build/jesus` interpreter.
  - `make clean` to remove the `build` directory.

Previously, compiling the project required a long `g++` command with all `.cpp` files listed manually. This made it error-prone and hard to maintain as the codebase grew.

With this update, the build becomes more:
- 📦 Maintainable
- 🛠 Developer-friendly
- 🧩 Ready for CI/CD, cross-platform expansion, and testing integration.

---

## ✝️ Wisdom

> _“Commit to the Lord whatever you do, and He will establish your plans.”_ — Proverbs 16:3
