### PR TITLE
Simplify parser by introducing grammar-based rules for conditional and variable creation statements (if otherwise; create varname)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ set(JESUS_CPP_FILES
     src/jesus/parser/grammar/primitives/addition_rule.cpp
     src/jesus/parser/grammar/primitives/equality_rule.cpp
     src/jesus/parser/grammar/primitives/variable_rule.cpp
+    src/jesus/parser/grammar/expr/conditional_expr_rule.cpp
+    src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
     src/jesus/parser/grammar/primitives/comparison_rule.cpp
     src/jesus/parser/grammar/primitives/logical_or_rule.cpp
     src/jesus/parser/grammar/primitives/logical_and_rule.cpp

--- a/src/jesus/lexer/lexer.cpp
+++ b/src/jesus/lexer/lexer.cpp
@@ -104,6 +104,9 @@ TokenType recognize_token_type(const std::string &word)
     if (word == "vs" || word == "versus")
         return TokenType::VERSUS;
 
+    if (word == "=")
+        return TokenType::EQUAL;
+
     if (word == "==")
         return TokenType::EQUAL_EQUAL;
 
@@ -160,6 +163,9 @@ TokenType recognize_token_type(const std::string &word)
 
     if (word[0] == '"')
         return TokenType::STRING;
+
+    if (word == "create")
+        return TokenType::CREATE;
 
     if (word == "if")
         return TokenType::IF;

--- a/src/jesus/lexer/lexer.cpp
+++ b/src/jesus/lexer/lexer.cpp
@@ -159,7 +159,13 @@ TokenType recognize_token_type(const std::string &word)
         return TokenType::DOUBLE;
 
     if (word[0] == '"')
-        return TokenType::Word;
+        return TokenType::STRING;
+
+    if (word == "if")
+        return TokenType::IF;
+
+    if (word == "otherwise")
+        return TokenType::OTHERWISE;
 
     return TokenType::IDENTIFIER;
 }
@@ -239,7 +245,7 @@ std::vector<Token> lex(const std::string &input)
                 throw std::runtime_error("Unterminated string literal");
 
             std::string str = input.substr(start, end - start);
-            tokens.emplace_back(TokenType::Word, "\"" + str + "\"", Value(str));
+            tokens.emplace_back(TokenType::STRING, "\"" + str + "\"", Value(str));
             i = end + 1;
             continue;
         }

--- a/src/jesus/lexer/token.hpp
+++ b/src/jesus/lexer/token.hpp
@@ -121,6 +121,13 @@ public:
             return "UPDATE";
         case TokenType::Word:
             return "WORD(" + lexeme + ")";
+
+        case TokenType::IF:
+            return "IF";
+
+        case TokenType::OTHERWISE:
+            return "OTHERWISE";
+
         case TokenType::END_OF_FILE:
             return "EOF";
 

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -48,5 +48,8 @@ enum class TokenType
     REPEAT,         // `repeat` 3 times
     TIMES,          // repeat 3 `times`
 
+    IF,
+    OTHERWISE,
+
     END_OF_FILE
 };

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -21,6 +21,7 @@ enum class TokenType
     AND,            // and
     OR,             // or
     VERSUS,         // versus or vs (it's called XOR, represented as "^" in other languages)
+    EQUAL,          // =
     EQUAL_EQUAL,    // ==
     NOT_EQUAL,      // !=
     GREATER,        // >
@@ -41,6 +42,7 @@ enum class TokenType
     STAR,           // *
     SLASH,          // /
 
+    CREATE,         // create days = 7
     SAY,            // "say" prints to stdout
     WARN,           // "warn" prints to stderr
     UPDATE,

--- a/src/jesus/parser/grammar/expr/conditional_expr_rule.cpp
+++ b/src/jesus/parser/grammar/expr/conditional_expr_rule.cpp
@@ -1,0 +1,63 @@
+#include "conditional_expr_rule.hpp"
+#include "../../../ast/expr/conditional_expr.hpp"
+#include <iostream>
+
+std::unique_ptr<Expr> ConditionalExprRule::parse(ParserContext &ctx)
+{
+    ParserContext backup = ctx.snapshot();
+
+    // Parse the "then" expression
+    auto ifExpr = expression->parse(ctx);
+    if (!ifExpr)
+    {
+        ctx = backup;
+        return nullptr;
+    }
+
+    // Match "if"
+    if (!ctx.match(TokenType::IF))
+    {
+        return ifExpr;
+    }
+
+    // Parse the condition expression
+    auto condition = expression->parse(ctx);
+    if (!condition)
+    {
+        std::cerr << "Expected condition after 'if'.\n";
+        ctx = backup;
+        return nullptr;
+    }
+
+    // Match "otherwise"
+    if (!ctx.match(TokenType::OTHERWISE))
+    {
+        std::cerr << "Expected 'otherwise' after condition.\n";
+        ctx = backup;
+        return nullptr;
+    }
+
+    // Parse the else/otherwise expression
+    auto otherwiseExpr = expression->parse(ctx);
+    if (!otherwiseExpr)
+    {
+        std::cerr << "[ConditionalExprRule] Expected expression after 'otherwise'.\n";
+        ctx = backup;
+        return nullptr;
+    }
+
+    return std::make_unique<ConditionalExpr>(
+        std::move(condition),
+        std::move(ifExpr),
+        std::move(otherwiseExpr));
+}
+
+std::string ConditionalExprRule::toStr(GrammarRuleHashTable &visited) const
+{
+    if (visited.count(this))
+        return "ConditionalExpr(...)";
+
+    visited.insert(this);
+
+    return "ConditionalExpr(" + expression->toStr(visited) + ")";
+}

--- a/src/jesus/parser/grammar/expr/conditional_expr_rule.hpp
+++ b/src/jesus/parser/grammar/expr/conditional_expr_rule.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "../grammar_rule.hpp"
+
+class ConditionalExprRule : public IGrammarRule
+{
+
+private:
+    std::shared_ptr<IGrammarRule> expression;
+
+public:
+    explicit ConditionalExprRule(std::shared_ptr<IGrammarRule> expression)
+        : expression(std::move(expression)) {}
+
+    /**
+     * @brief Parses a conditional expression of the form:
+     *        <then_expr> if <condition_expr> otherwise <else_expr>
+     *
+     * Example:
+     *     "light" if yes otherwise "dark"
+     *
+     * @param ctx The parsing context containing tokens.
+     * @return A ConditionalExpr node if matched, otherwise nullptr.
+     */
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override;
+
+    std::string toStr(GrammarRuleHashTable &visited) const override;
+};

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -12,6 +12,7 @@
 #include "primitives/variable_rule.hpp"
 #include "primitives/versus_rule.hpp"
 #include "primitives/yes_no_rule.hpp"
+#include "expr/conditional_expr_rule.hpp"
 #include "unary_rule.hpp"
 
 /**
@@ -44,7 +45,8 @@ namespace grammar
     inline auto LogicalAnd = std::make_shared<LogicalAndRule>(Equality);
     inline auto Versus = std::make_shared<VersusRule>(LogicalAnd, LogicalAnd);
     inline auto LogicalOr = std::make_shared<LogicalOrRule>(Versus);
-    inline auto Expression = LogicalOr;
+    inline auto Conditional = std::make_shared<ConditionalExprRule>(LogicalOr);
+    inline auto Expression = Conditional;
 
     inline auto YesNo = std::make_shared<YesNoRule>();
     inline auto Variable = std::make_shared<VariableRule>();

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -13,6 +13,7 @@
 #include "primitives/versus_rule.hpp"
 #include "primitives/yes_no_rule.hpp"
 #include "expr/conditional_expr_rule.hpp"
+#include "stmt/create_var_stmt_rule.hpp"
 #include "unary_rule.hpp"
 
 /**
@@ -55,6 +56,11 @@ namespace grammar
      * @brief Primary is anything that can be evaluated directly: number, string, or a grouped expression.
      */
     inline auto Primary = Number | String | YesNo | Variable | Group(Expression);
+
+    // ----------
+    // Statements
+    // ----------
+    inline auto CreateVar = std::make_shared<CreateVarStmtRule>(Expression);
 
     /**
      * @brief Set the Expression rule to something (for now just Primary)

--- a/src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
@@ -1,0 +1,25 @@
+#include "create_var_stmt_rule.hpp"
+#include "../../../ast/stmt/create_var_stmt.hpp"
+#include <stdexcept>
+
+std::unique_ptr<Stmt> CreateVarStmtRule::parse(ParserContext &ctx)
+{
+    if (!ctx.match(TokenType::CREATE))
+        return nullptr;
+
+    if (!ctx.match(TokenType::IDENTIFIER))
+        throw std::runtime_error("Expected variable name after 'create'");
+
+    std::string varName = ctx.previous().lexeme;
+
+    std::unique_ptr<Expr> value = nullptr;
+
+    if (ctx.match(TokenType::EQUAL))
+    {
+        value = expression->parse(ctx);
+        if (!value)
+            throw std::runtime_error("Expected expression after '=' in create statement.");
+    }
+
+    return std::make_unique<CreateVarStmt>(varName, std::move(value));
+}

--- a/src/jesus/parser/grammar/stmt/create_var_stmt_rule.hpp
+++ b/src/jesus/parser/grammar/stmt/create_var_stmt_rule.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "../grammar_rule.hpp"
+#include "../../../ast/stmt/stmt.hpp"
+
+class CreateVarStmtRule
+{
+    std::shared_ptr<IGrammarRule> expression;
+
+public:
+    explicit CreateVarStmtRule(std::shared_ptr<IGrammarRule> expr)
+        : expression(std::move(expr)) {}
+
+    std::unique_ptr<Stmt> parse(ParserContext &ctx);
+};

--- a/src/jesus/parser/parser.cpp
+++ b/src/jesus/parser/parser.cpp
@@ -1,12 +1,10 @@
 #include "parser.hpp"
 #include "grammar/jesus_grammar.hpp"
 #include "parser_context.hpp"
-#include "../ast/expr/literal_expr.hpp"
 #include "../ast/expr/variable_expr.hpp"
 #include "../ast/expr/conditional_expr.hpp"
 #include "../ast/stmt/repeat_times_stmt.hpp"
 #include "../ast/stmt/output_statement.hpp"
-#include "../ast/stmt/create_var_stmt.hpp"
 #include <bits/stdc++.h> // for std::find_if and std::distance
 #include <string>
 #include <memory>
@@ -54,26 +52,10 @@ std::unique_ptr<Stmt> parse(const std::vector<Token> &tokens)
                 std::move(expr));
     }
 
-    if (tokens_count >= 3 &&
-        tokens[0].lexeme == "let" &&
-        tokens[1].lexeme == "there" &&
-        tokens[2].lexeme == "be")
-    {
-        std::string identifier;
-        std::unique_ptr<Expr> value;
-
-        if (tokens_count >= 4)
-        {
-            identifier = tokens[3].lexeme;
-        }
-
-        if (tokens_count >= 7 && tokens[4].lexeme == "set" && tokens[5].lexeme == "to")
-        {
-            value = std::make_unique<LiteralExpr>(tokens[6].literal);
-        }
-
-        return std::make_unique<CreateVarStmt>(identifier, std::move(value));
-    }
+    ParserContext ctx(tokens);
+    auto createVarStmt = grammar::CreateVar->parse(ctx);
+    if (createVarStmt)
+        return createVarStmt;
 
     // If no match, fall back to expression parsing
     ParserContext context(tokens);

--- a/src/jesus/parser/parser.cpp
+++ b/src/jesus/parser/parser.cpp
@@ -1,10 +1,8 @@
 #include "parser.hpp"
 #include "grammar/jesus_grammar.hpp"
 #include "parser_context.hpp"
-#include "../ast/identifier_node.hpp"
 #include "../ast/expr/literal_expr.hpp"
 #include "../ast/expr/variable_expr.hpp"
-#include "../ast/binary_operation_node.hpp"
 #include "../ast/expr/conditional_expr.hpp"
 #include "../ast/stmt/repeat_times_stmt.hpp"
 #include "../ast/stmt/output_statement.hpp"
@@ -22,10 +20,10 @@ std::unique_ptr<Stmt> parse(const std::vector<Token> &tokens)
     if (tokens_count == 1 && tokens[0].type == TokenType::IDENTIFIER)
     {
         // WARN because the person didn't use 'say'
-        return std::make_unique<OutputStmt>(OutputType::WARN,  std::make_unique<VariableExpr>(tokens[1].lexeme));
-
+        return std::make_unique<OutputStmt>(OutputType::WARN, std::make_unique<VariableExpr>(tokens[1].lexeme));
     }
 
+    // repeat n times
     if (tokens_count >= 4 &&
         tokens[0].type == TokenType::REPEAT &&
         tokens[1].type == TokenType::INT &&
@@ -45,81 +43,15 @@ std::unique_ptr<Stmt> parse(const std::vector<Token> &tokens)
         return std::make_unique<RepeatTimesStmt>(repeatCount, std::move(innerStmt));
     }
 
-    // parse use "value" if condition otherwise "value"
-    if ((tokens[0].type == TokenType::SAY || tokens[0].type == TokenType::WARN)  && tokens_count >= 2)
+    if ((tokens[0].type == TokenType::SAY || tokens[0].type == TokenType::WARN) && tokens_count >= 2)
     {
-        // Check if "if" exists in tokens
-        auto ifIt = std::find_if(tokens.begin(), tokens.end(),
-                               [](const Token &t)
-                               { return t.lexeme == "if"; });
-
-        if (ifIt != tokens.end())
-        {
-
-            int otherwiseIndex = -1;
-            int ifIndex = std::distance(tokens.begin(), ifIt);
-            std::unique_ptr<Expr> condition;
-            std::unique_ptr<Expr> ifValue = std::make_unique<LiteralExpr>(Value(tokens[1].lexeme));
-            std::unique_ptr<Expr> elseValue;
-
-            if (tokens[ifIndex + 1].lexeme == "(")
-            {
-                int parenDepth = 1;
-                size_t conditionStart = ifIndex + 1;
-                size_t conditionEnd = conditionStart;
-
-                // Find matching ')'
-                while (conditionEnd < tokens.size() && parenDepth > 0)
-                {
-                    if (tokens[conditionEnd].lexeme == "(")
-                        ++parenDepth;
-
-                    else if (tokens[conditionEnd].lexeme == ")")
-                        --parenDepth;
-
-                    ++conditionEnd;
-                }
-
-                if (parenDepth != 1)
-                {
-                    throw std::runtime_error("Unmatched parentheses in if condition. parenDepth = " + std::to_string(parenDepth));
-                }
-
-                std::vector<Token> conditionTokens(tokens.begin() + conditionStart, tokens.begin() + conditionEnd);
-
-                ParserContext context(conditionTokens);
-                condition = grammar::Expression->parse(context);
-                if (!condition)
-                {
-                    throw std::runtime_error("Failed to parse condition expression inside 'if'.");
-                }
-            }
-            else
-                condition = std::make_unique<BinaryOperationNode>(
-                    tokens[ifIndex + 2].lexeme,                     // operator (e.g.: == )
-                    std::make_unique<IdentifierNode>(tokens[ifIndex + 1].lexeme), // left operand
-                    std::make_unique<LiteralExpr>(tokens[ifIndex + 3].literal)  // right operand
-                );
-
-            // Parse "otherwise/else"
-            for (size_t i = ifIndex + 1; i < tokens_count; ++i)
-            {
-                if (tokens[i].lexeme == "otherwise")
-                {
-                    otherwiseIndex = i;
-                    elseValue = std::make_unique<LiteralExpr>(Value(tokens[otherwiseIndex + 1].lexeme));
-                    break;
-                }
-            }
-
-            return std::make_unique<OutputStmt>(OutputType::WARN,  std::make_unique<ConditionalExpr>(std::move(condition), std::move(ifValue), std::move(elseValue)));
-        }
-
-        // Using WARN because the person didn't call 'say'
-        if (tokens[1].type == TokenType::IDENTIFIER)
-            return std::make_unique<OutputStmt>(OutputType::WARN,  std::make_unique<VariableExpr>(tokens[1].lexeme));
-
-        return std::make_unique<OutputStmt>(OutputType::WARN, std::make_unique<LiteralExpr>(tokens[1].literal));
+        std::vector<Token> expressionTokens(tokens.begin() + 1, tokens.end());
+        ParserContext context(expressionTokens);
+        auto expr = grammar::Expression->parse(context);
+        if (expr)
+            return std::make_unique<OutputStmt>(
+                tokens[0].type == TokenType::SAY ? OutputType::SAY : OutputType::WARN,
+                std::move(expr));
     }
 
     if (tokens_count >= 3 &&
@@ -148,7 +80,7 @@ std::unique_ptr<Stmt> parse(const std::vector<Token> &tokens)
     auto expr = grammar::Expression->parse(context);
     if (!expr)
     {
-        throw std::runtime_error("Unknown expression type");
+        throw std::runtime_error("Unknown expression type (parser.cpp)");
     }
 
     // Using WARN because the person didn't call 'say'

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -1,8 +1,8 @@
-let there be light set to Day
-let there be messiah set to Jesus
-let there be age set to 33
-let there be priest set to me
-let there be average set to 2.3
+create light = "Day"
+create messiah = "Jesus"
+create age = 33
+create priest = "me"
+create average = 2.3
 say age
 say messiah
 say priest
@@ -32,7 +32,7 @@ not not 23
 (0 versus age)
 (1 versus age )
 ( 1 versus 0 )
-let there be name set to "Jesus"
+create name = "Jesus"
 ( age versus name )
 ( 1 vs 9 )
 say name if ( 1 vs 1 ) otherwise "final"
@@ -47,7 +47,7 @@ say "adult" if ((age>=18)) otherwise "minor"
 ( age <= 1 )
 ( ( age <= 1 ) )
 
-let there be age set to 33
+create age = 33
 say "adult" if ( ( age >= 18 ) ) otherwise "minor"
 ( 1 + 1 )
 ( 2 + 7 )
@@ -90,7 +90,7 @@ not not 23
 ( 1 versus 7 )
 ( 1.0 versus 7 )
 ( 1.0 versus 7.98 )
-let there be name set to "Jesus"
+create name = "Jesus"
 ( age versus name )
 ( 1 vs 9 )
 say name if ( 1 vs 1 ) otherwise "final"

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -2,7 +2,7 @@
 (Jesus) (text) Jesus
 (Jesus) (text) me
 (Jesus) (int) 33
-(Jesus) (text) "adult"
+(Jesus) (text) adult
 (Jesus) (int) 2
 (Jesus) (int) 9
 (Jesus) (int) 34
@@ -29,9 +29,9 @@
 (Jesus) (int) 1
 (Jesus) (Jesus) null
 (Jesus) (int) 8
-(Jesus) (text) "final"
+(Jesus) (text) final
 (Jesus) (int) 132
-(Jesus) (text) "adult"
+(Jesus) (text) adult
 (Jesus) (logic) 0
 (Jesus) (logic) 1
 (Jesus) (logic) 0
@@ -40,9 +40,9 @@
 (Jesus) (logic) 1
 (Jesus) (logic) 0
 (Jesus) (logic) 0
-(Jesus) ❌ Error: Unknown expression type
+(Jesus) ❌ Error: Unknown expression type (parser.cpp)
 (Jesus) ❌ Error: The variable 'age' already exists.
-(Jesus) (text) "adult"
+(Jesus) (text) adult
 (Jesus) (int) 2
 (Jesus) (int) 9
 (Jesus) (int) 34
@@ -87,7 +87,7 @@
 (Jesus) ❌ Error: The variable 'name' already exists.
 (Jesus) null
 (Jesus) (int) 8
-(Jesus) (text) "final"
+(Jesus) (text) final
 (Jesus) (int) 132
-(Jesus) (text) "adult"
-(Jesus)
+(Jesus) (text) adult
+(Jesus) 


### PR DESCRIPTION
# Description


This PR significantly simplifies and modularizes the core parser logic by introducing and integrating two grammar-based rules:
- `ConditionalExprRule`: Parses expressions like `"value" if condition otherwise "other_value"` using structured grammar instead of relying on complex manual token handling.
- `CreateVarStmtRule`: Handles variable declaration syntax (e.g. `create days = 7`) cleanly, replacing the older `"let there be"` parsing block.

#### Why this matters  
The manual parsing in `parser.cpp` was becoming error-prone, hard to extend, and lacked reusability. By modeling these constructs as proper grammar rules:
- Logic becomes easier to follow
- Future changes (e.g. new statement forms) are simpler to plug in
- Testing and debugging become more focused and decoupled

#### Impact  
- Removed hardcoded parsing logic for conditional expressions and variable creation
- Parser is now more declarative and EBNF-aligned
- All grammar logic resides in their respective rule classes for better modularity

# ✝️ Wisdom
> "Let all things be done decently and in order." — 1 Corinthians 14:40 (KJV)