### PR TITLE
Step 16: Refactoring grammar rules into atomic/literals and atomic/operators for clarity and scalability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,19 +50,29 @@ set(JESUS_CPP_FILES
     src/jesus/parser/parser.cpp
     src/jesus/parser/grammar/group_rule.cpp
     src/jesus/parser/grammar/unary_rule.cpp
-    src/jesus/parser/grammar/primitives/number_rule.cpp
-    src/jesus/parser/grammar/primitives/string_rule.cpp
-    src/jesus/parser/grammar/primitives/versus_rule.cpp
-    src/jesus/parser/grammar/primitives/yes_no_rule.cpp
-    src/jesus/parser/grammar/primitives/addition_rule.cpp
-    src/jesus/parser/grammar/primitives/equality_rule.cpp
-    src/jesus/parser/grammar/primitives/variable_rule.cpp
+
+    # ------------------
+    # Expression parsers
+    # ------------------
     src/jesus/parser/grammar/expr/conditional_expr_rule.cpp
+
+    src/jesus/parser/grammar/expr/atomic/literals/number_rule.cpp
+    src/jesus/parser/grammar/expr/atomic/literals/string_rule.cpp
+    src/jesus/parser/grammar/expr/atomic/literals/yes_no_rule.cpp
+    src/jesus/parser/grammar/expr/atomic/literals/variable_rule.cpp
+
+    src/jesus/parser/grammar/expr/atomic/operators/versus_rule.cpp
+    src/jesus/parser/grammar/expr/atomic/operators/addition_rule.cpp
+    src/jesus/parser/grammar/expr/atomic/operators/equality_rule.cpp
+    src/jesus/parser/grammar/expr/atomic/operators/comparison_rule.cpp
+    src/jesus/parser/grammar/expr/atomic/operators/logical_or_rule.cpp
+    src/jesus/parser/grammar/expr/atomic/operators/logical_and_rule.cpp
+    src/jesus/parser/grammar/expr/atomic/operators/multiplication_rule.cpp
+
+    # -----------------
+    # Statement parsers
+    # -----------------
     src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
-    src/jesus/parser/grammar/primitives/comparison_rule.cpp
-    src/jesus/parser/grammar/primitives/logical_or_rule.cpp
-    src/jesus/parser/grammar/primitives/logical_and_rule.cpp
-    src/jesus/parser/grammar/primitives/multiplication_rule.cpp
 
     # -----------
     # Interpreter

--- a/src/jesus/interpreter/stmt_visitor.hpp
+++ b/src/jesus/interpreter/stmt_visitor.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "../ast/stmt/create_var_stmt.hpp"
+#include "../ast/stmt/update_var_stmt.hpp"
+#include "../ast/stmt/output_statement.hpp"
+#include "../ast/stmt/repeat_while_stmt.hpp"
+#include "../ast/stmt/repeat_times_stmt.hpp"
+#include "../ast/stmt/for_each_stmt.hpp"
+#include "../ast/stmt/break_stmt.hpp"
+#include "../ast/stmt/continue_stmt.hpp"
+
+/**
+ * @brief Interface for visiting and executing statement nodes in the AST.
+ *
+ * The StmtVisitor defines a set of methods that must be implemented
+ * by any class that wants to interpret statement types.
+ *
+ * This allows the interpreter (or a debugger, tracer, etc.) to simplify
+ * its execute method by calling stmt->accept(visitor) instead of
+ * manually checking the statement type with conditionals or dynamic casts.
+ *
+ * Usage example:
+ *
+ *     class Interpreter : public StmtVisitor {
+ *         void visitCreateVar(const CreateVarStmt& stmt) override;
+ *         void visitOutput(const OutputStmt& stmt) override;
+ *         // ...
+ *     };
+ *
+ *     std::unique_ptr<Stmt> statement = std::make_unique<OutputStmt>(...);
+ *     Interpreter interpreter;
+ *     interpreter.execute(statement);
+ *
+ * Currently being called in the `execute` method of Interpreter:
+ *     void Interpreter::execute(const std::unique_ptr<Stmt> &stmt) {
+ *         stmt->accept(*this);
+ *     }
+ *
+ * ---
+ * "Do not forget to show hospitality to strangers, for by so doing
+ * some people have shown hospitality to angels without knowing it."
+ * — Hebrews 13:2
+ */
+class StmtVisitor
+{
+public:
+    virtual void visitCreateVar(const CreateVarStmt &stmt) = 0;
+    virtual void visitUpdateVar(const UpdateVarStmt &stmt) = 0;
+    virtual void visitOutput(const OutputStmt &stmt) = 0;
+    virtual void visitRepeatWhile(const RepeatWhileStmt &stmt) = 0;
+    virtual void visitRepeatTimes(const RepeatTimesStmt &stmt) = 0;
+    virtual void visitForEach(const ForEachStmt &stmt) = 0;
+    virtual void visitBreak(const BreakStmt &stmt) = 0;
+    virtual void visitContinue(const ContinueStmt &stmt) = 0;
+
+    virtual ~StmtVisitor() = default;
+};

--- a/src/jesus/parser/grammar/expr/atomic/literals/number_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/number_rule.cpp
@@ -1,5 +1,5 @@
 #include "number_rule.hpp"
-#include "../../../ast/expr/literal_expr.hpp"
+#include "../../../../../ast/expr/literal_expr.hpp"
 
 std::unique_ptr<Expr> NumberRule::parse(ParserContext &ctx)
 {

--- a/src/jesus/parser/grammar/expr/atomic/literals/number_rule.hpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/number_rule.hpp
@@ -1,17 +1,16 @@
-
 #pragma once
-#include "../grammar_rule.hpp"
+#include "../../../grammar_rule.hpp"
 
 /**
- * @brief Matches a string literal.
+ * @brief Matches a number literal.
  */
-class StringRule : public IGrammarRule
+class NumberRule : public IGrammarRule
 {
 public:
     std::unique_ptr<Expr> parse(ParserContext &ctx) override;
 
     std::string toStr(GrammarRuleHashTable &visitedTable) const override
     {
-        return "String";
+        return "Number";
     }
 };

--- a/src/jesus/parser/grammar/expr/atomic/literals/string_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/string_rule.cpp
@@ -1,5 +1,5 @@
 #include "string_rule.hpp"
-#include "../../../ast/expr/literal_expr.hpp"
+#include "../../../../../ast/expr/literal_expr.hpp"
 
 std::unique_ptr<Expr> StringRule::parse(ParserContext &ctx)
 {

--- a/src/jesus/parser/grammar/expr/atomic/literals/string_rule.hpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/string_rule.hpp
@@ -1,16 +1,17 @@
+
 #pragma once
-#include "../grammar_rule.hpp"
+#include "../../../grammar_rule.hpp"
 
 /**
- * @brief Matches a number literal.
+ * @brief Matches a string literal.
  */
-class NumberRule : public IGrammarRule
+class StringRule : public IGrammarRule
 {
 public:
     std::unique_ptr<Expr> parse(ParserContext &ctx) override;
 
     std::string toStr(GrammarRuleHashTable &visitedTable) const override
     {
-        return "Number";
+        return "String";
     }
 };

--- a/src/jesus/parser/grammar/expr/atomic/literals/variable_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/variable_rule.cpp
@@ -1,5 +1,5 @@
 #include "variable_rule.hpp"
-#include "../../../ast/expr/variable_expr.hpp"
+#include "../../../../../ast/expr/variable_expr.hpp"
 
 std::unique_ptr<Expr> VariableRule::parse(ParserContext &ctx)
 {

--- a/src/jesus/parser/grammar/expr/atomic/literals/variable_rule.hpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/variable_rule.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "../grammar_rule.hpp"
+#include "../../../grammar_rule.hpp"
 
 /**
  * @brief Grammar rule that matches variable references.

--- a/src/jesus/parser/grammar/expr/atomic/literals/yes_no_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/yes_no_rule.cpp
@@ -1,5 +1,5 @@
 #include "yes_no_rule.hpp"
-#include "../../../ast/expr/literal_expr.hpp"
+#include "../../../../../ast/expr/literal_expr.hpp"
 
 std::unique_ptr<Expr> YesNoRule::parse(ParserContext &ctx)
 {

--- a/src/jesus/parser/grammar/expr/atomic/literals/yes_no_rule.hpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/yes_no_rule.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "../grammar_rule.hpp"
+#include "../../../grammar_rule.hpp"
 
 /**
  * @brief Parses boolean literals: `yes` or `no`.

--- a/src/jesus/parser/grammar/expr/atomic/operators/addition_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/operators/addition_rule.cpp
@@ -1,5 +1,5 @@
 #include "addition_rule.hpp"
-#include "../../../ast/expr/binary_expr.hpp"
+#include "../../../../../ast/expr/binary_expr.hpp"
 
 std::unique_ptr<Expr> AdditionRule::parse(ParserContext &ctx)
 {

--- a/src/jesus/parser/grammar/expr/atomic/operators/addition_rule.hpp
+++ b/src/jesus/parser/grammar/expr/atomic/operators/addition_rule.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include "../grammar_rule.hpp"
-#include "../../parser_context.hpp"
+#include "../../../grammar_rule.hpp"
+#include "../../../../parser_context.hpp"
 #include <memory>
 
 /**

--- a/src/jesus/parser/grammar/expr/atomic/operators/comparison_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/operators/comparison_rule.cpp
@@ -1,5 +1,5 @@
 #include "comparison_rule.hpp"
-#include "../../../ast/expr/binary_expr.hpp"
+#include "../../../../../ast/expr/binary_expr.hpp"
 
 std::unique_ptr<Expr> ComparisonRule::parse(ParserContext &ctx)
 {

--- a/src/jesus/parser/grammar/expr/atomic/operators/comparison_rule.hpp
+++ b/src/jesus/parser/grammar/expr/atomic/operators/comparison_rule.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../grammar_rule.hpp"
+#include "../../../grammar_rule.hpp"
 #include <memory>
 
 /**

--- a/src/jesus/parser/grammar/expr/atomic/operators/equality_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/operators/equality_rule.cpp
@@ -1,5 +1,5 @@
 #include "equality_rule.hpp"
-#include "../../../ast/expr/binary_expr.hpp"
+#include "../../../../../ast/expr/binary_expr.hpp"
 
 std::unique_ptr<Expr> EqualityRule::parse(ParserContext &ctx)
 {

--- a/src/jesus/parser/grammar/expr/atomic/operators/equality_rule.hpp
+++ b/src/jesus/parser/grammar/expr/atomic/operators/equality_rule.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../grammar_rule.hpp"
+#include "../../../grammar_rule.hpp"
 
 /**
  * @brief Grammar rule to parse equality comparisons (==, !=).

--- a/src/jesus/parser/grammar/expr/atomic/operators/logical_and_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/operators/logical_and_rule.cpp
@@ -1,5 +1,5 @@
 #include "logical_and_rule.hpp"
-#include "../../../ast/expr/binary_expr.hpp"
+#include "../../../../../ast/expr/binary_expr.hpp"
 
 std::unique_ptr<Expr> LogicalAndRule::parse(ParserContext &ctx)
 {

--- a/src/jesus/parser/grammar/expr/atomic/operators/logical_and_rule.hpp
+++ b/src/jesus/parser/grammar/expr/atomic/operators/logical_and_rule.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../grammar_rule.hpp"
+#include "../../../grammar_rule.hpp"
 
 /**
  * @brief Parses logical AND expressions (e.g. a AND b AND c).

--- a/src/jesus/parser/grammar/expr/atomic/operators/logical_or_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/operators/logical_or_rule.cpp
@@ -1,5 +1,5 @@
 #include "logical_or_rule.hpp"
-#include "../../../ast/expr/binary_expr.hpp"
+#include "../../../../../ast/expr/binary_expr.hpp"
 
 std::unique_ptr<Expr> LogicalOrRule::parse(ParserContext &ctx)
 {

--- a/src/jesus/parser/grammar/expr/atomic/operators/logical_or_rule.hpp
+++ b/src/jesus/parser/grammar/expr/atomic/operators/logical_or_rule.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "../grammar_rule.hpp"
+#include "../../../grammar_rule.hpp"
 
 /**
  * @brief Parses expressions combined by logical OR (e.g., a or b or c).

--- a/src/jesus/parser/grammar/expr/atomic/operators/multiplication_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/operators/multiplication_rule.cpp
@@ -1,5 +1,5 @@
 #include "multiplication_rule.hpp"
-#include "../../../ast/expr/binary_expr.hpp"
+#include "../../../../../ast/expr/binary_expr.hpp"
 
 std::unique_ptr<Expr> MultiplicationRule::parse(ParserContext &ctx)
 {

--- a/src/jesus/parser/grammar/expr/atomic/operators/multiplication_rule.hpp
+++ b/src/jesus/parser/grammar/expr/atomic/operators/multiplication_rule.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../grammar_rule.hpp"
+#include "../../../grammar_rule.hpp"
 
 class MultiplicationRule : public IGrammarRule
 {

--- a/src/jesus/parser/grammar/expr/atomic/operators/versus_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/operators/versus_rule.cpp
@@ -1,5 +1,5 @@
 #include "versus_rule.hpp"
-#include "../../../ast/expr/binary_expr.hpp"
+#include "../../../../../ast/expr/binary_expr.hpp"
 
 VersusRule::VersusRule(std::shared_ptr<IGrammarRule> lhs, std::shared_ptr<IGrammarRule> rhs)
     : lhsRule(std::move(lhs)), rhsRule(std::move(rhs))

--- a/src/jesus/parser/grammar/expr/atomic/operators/versus_rule.hpp
+++ b/src/jesus/parser/grammar/expr/atomic/operators/versus_rule.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../grammar_rule.hpp"
+#include "../../../grammar_rule.hpp"
 #include <memory>
 
 /**

--- a/src/jesus/parser/grammar/grammar_aliases.hpp
+++ b/src/jesus/parser/grammar/grammar_aliases.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <memory>
-#include "primitives/number_rule.hpp"
-#include "primitives/string_rule.hpp"
+#include "expr/atomic/literals/number_rule.hpp"
+#include "expr/atomic/literals/string_rule.hpp"
 #include "group_rule.hpp"
 
 /**

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -3,15 +3,18 @@
 #include "combinators/forward_rule.hpp"
 #include "grammar_aliases.hpp" // for Number, String, etc.
 #include "operators.hpp"
-#include "primitives/addition_rule.hpp"
-#include "primitives/comparison_rule.hpp"
-#include "primitives/equality_rule.hpp"
-#include "primitives/logical_and_rule.hpp"
-#include "primitives/logical_or_rule.hpp"
-#include "primitives/multiplication_rule.hpp"
-#include "primitives/variable_rule.hpp"
-#include "primitives/versus_rule.hpp"
-#include "primitives/yes_no_rule.hpp"
+
+#include "expr/atomic/operators/addition_rule.hpp"
+#include "expr/atomic/operators/comparison_rule.hpp"
+#include "expr/atomic/operators/equality_rule.hpp"
+#include "expr/atomic/operators/logical_and_rule.hpp"
+#include "expr/atomic/operators/logical_or_rule.hpp"
+#include "expr/atomic/operators/multiplication_rule.hpp"
+#include "expr/atomic/operators/versus_rule.hpp"
+
+#include "expr/atomic/literals/variable_rule.hpp"
+#include "expr/atomic/literals/yes_no_rule.hpp"
+
 #include "expr/conditional_expr_rule.hpp"
 #include "stmt/create_var_stmt_rule.hpp"
 #include "unary_rule.hpp"


### PR DESCRIPTION
# Description

This PR reorganizes the grammar-related files under `parser/grammar/expr/` into a cleaner structure, separating rules into:

- **`expr/atomic/literals`** — for simple, indivisible expression types like numbers, strings, booleans, etc.
-  **`expr/atomic/operators`** — for operators like `addition`, `multiplication`, etc.

By doing this, we reduce visual confusion in the grammar folder, improve maintainability, and make it easier for future contributors to understand and extend the language grammar.

This structure anticipates the growth of the language while staying easy on the mind.

#### Changes  
- Moved the following from ` parser/grammar/primitives/` to `parser/grammar/expr/atomic/`:
```
parser/grammar/expr/atomic/
├── literals
│   ├── number_rule.cpp
│   ├── number_rule.hpp
│   ├── string_rule.cpp
│   ├── string_rule.hpp
│   ├── variable_rule.cpp
│   ├── variable_rule.hpp
│   ├── yes_no_rule.cpp
│   └── yes_no_rule.hpp
└── operators
    ├── addition_rule.cpp
    ├── addition_rule.hpp
    ├── comparison_rule.cpp
    ├── comparison_rule.hpp
    ├── equality_rule.cpp
    ├── equality_rule.hpp
    ├── logical_and_rule.cpp
    ├── logical_and_rule.hpp
    ├── logical_or_rule.cpp
    ├── logical_or_rule.hpp
    ├── multiplication_rule.cpp
    ├── multiplication_rule.hpp
    ├── versus_rule.cpp
    └── versus_rule.hpp
```



# ✝️ Wisdom

> "For God is not a God of confusion but of peace—as in all the churches of the saints.”  — **1 Corinthians 14:33**
