### PR TITLE
Step 17: Added support for born (biological sex) and weekday literals reflecting the days of Creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ set(JESUS_CPP_FILES
     src/jesus/parser/grammar/expr/atomic/literals/string_rule.cpp
     src/jesus/parser/grammar/expr/atomic/literals/yes_no_rule.cpp
     src/jesus/parser/grammar/expr/atomic/literals/variable_rule.cpp
+    src/jesus/parser/grammar/expr/atomic/literals/born_rule.cpp
 
     src/jesus/parser/grammar/expr/atomic/operators/versus_rule.cpp
     src/jesus/parser/grammar/expr/atomic/operators/addition_rule.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ set(JESUS_CPP_FILES
     src/jesus/parser/grammar/expr/atomic/literals/yes_no_rule.cpp
     src/jesus/parser/grammar/expr/atomic/literals/variable_rule.cpp
     src/jesus/parser/grammar/expr/atomic/literals/born_rule.cpp
+    src/jesus/parser/grammar/expr/atomic/literals/weekday_rule.cpp
 
     src/jesus/parser/grammar/expr/atomic/operators/versus_rule.cpp
     src/jesus/parser/grammar/expr/atomic/operators/addition_rule.cpp

--- a/src/jesus/lexer/lexer.cpp
+++ b/src/jesus/lexer/lexer.cpp
@@ -131,6 +131,12 @@ TokenType recognize_token_type(const std::string &word)
     if (word == "yes")
         return TokenType::YES;
 
+    if (word == "male")
+        return TokenType::MALE;
+
+    if (word == "female")
+        return TokenType::FEMALE;
+
     if (word == "(")
         return TokenType::LEFT_PAREN;
 

--- a/src/jesus/lexer/lexer.cpp
+++ b/src/jesus/lexer/lexer.cpp
@@ -137,6 +137,27 @@ TokenType recognize_token_type(const std::string &word)
     if (word == "female")
         return TokenType::FEMALE;
 
+    if (word == "lightday")
+        return TokenType::LIGHDAY;
+
+    if (word == "skyday")
+        return TokenType::SKYDAY;
+
+    if (word == "treeday")
+        return TokenType::TREEDAY;
+
+    if (word == "lampday")
+        return TokenType::LAMPDAY;
+
+    if (word == "fishday")
+        return TokenType::FISHDAY;
+
+    if (word == "walkday")
+        return TokenType::WALKDAY;
+
+    if (word == "shabbat")
+        return TokenType::SHABBAT;
+
     if (word == "(")
         return TokenType::LEFT_PAREN;
 

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -50,6 +50,15 @@ enum class TokenType
     MALE,           // male
     FEMALE,         // female
 
+    // Week days
+    LIGHDAY,        // lighday = Sunday = 1
+    SKYDAY,         // skyday = Monday = 2
+    TREEDAY,        // treeday = Tuesday = 3
+    LAMPDAY,        // lampday = Wednesday = 4
+    FISHDAY,        // fishday = Thursday = 5
+    WALKDAY,        // walkday = man and animal = Friday = 6
+    SHABBAT,        // shabbat = saturday = 7
+
     REPEAT,         // `repeat` 3 times
     TIMES,          // repeat 3 `times`
 

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -47,6 +47,9 @@ enum class TokenType
     WARN,           // "warn" prints to stderr
     UPDATE,
 
+    MALE,           // male
+    FEMALE,         // female
+
     REPEAT,         // `repeat` 3 times
     TIMES,          // repeat 3 `times`
 

--- a/src/jesus/parser/grammar/expr/atomic/literals/born_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/born_rule.cpp
@@ -1,0 +1,13 @@
+#include "born_rule.hpp"
+#include "../../../../../ast/expr/literal_expr.hpp"
+
+std::unique_ptr<Expr> BornRule::parse(ParserContext &ctx)
+{
+    if (ctx.match(TokenType::MALE))
+        return std::make_unique<LiteralExpr>(Value(true));
+
+    if (ctx.match(TokenType::FEMALE))
+        return std::make_unique<LiteralExpr>(Value(false));
+
+    return nullptr;
+}

--- a/src/jesus/parser/grammar/expr/atomic/literals/born_rule.hpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/born_rule.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "../../../grammar_rule.hpp"
+
+/**
+ * @brief Parses biological/DNA sex literals: `male` or `female`.
+ *
+ * "So God created mankind in his own image, in the image of God he created them; male and female he created them."
+ * — Genesis 1:27
+ */
+class BornRule : public IGrammarRule
+{
+public:
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override;
+
+    std::string toStr(GrammarRuleHashTable &) const override
+    {
+        return "Born";
+    }
+};

--- a/src/jesus/parser/grammar/expr/atomic/literals/weekday_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/weekday_rule.cpp
@@ -1,0 +1,28 @@
+#include "weekday_rule.hpp"
+#include "../../../../../ast/expr/literal_expr.hpp"
+
+std::unique_ptr<Expr> WeekdayRule::parse(ParserContext &ctx)
+{
+    if (ctx.match(TokenType::LIGHDAY))
+        return std::make_unique<LiteralExpr>(Value(1));
+
+    if (ctx.match(TokenType::SKYDAY))
+        return std::make_unique<LiteralExpr>(Value(2));
+
+    if (ctx.match(TokenType::TREEDAY))
+        return std::make_unique<LiteralExpr>(Value(3));
+
+    if (ctx.match(TokenType::LAMPDAY))
+        return std::make_unique<LiteralExpr>(Value(4));
+
+    if (ctx.match(TokenType::FISHDAY))
+        return std::make_unique<LiteralExpr>(Value(5));
+
+    if (ctx.match(TokenType::WALKDAY))
+        return std::make_unique<LiteralExpr>(Value(6));
+
+    if (ctx.match(TokenType::SHABBAT))
+        return std::make_unique<LiteralExpr>(Value(7));
+
+    return nullptr;
+}

--- a/src/jesus/parser/grammar/expr/atomic/literals/weekday_rule.hpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/weekday_rule.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "../../../grammar_rule.hpp"
+
+/**
+ * @brief Parses weekdays literals: `lighday`, `skyday`, `treeday`, `lampday`, `fishday`, `walkday`, `shabbat`.
+ *
+ * "And God blessed the seventh day and made it holy, because on it he rested from all the work of creating that he had done."
+ * — Genesis 2:3
+ */
+class WeekdayRule : public IGrammarRule
+{
+public:
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override;
+
+    std::string toStr(GrammarRuleHashTable &) const override
+    {
+        return "Weekday";
+    }
+};

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -14,6 +14,7 @@
 
 #include "expr/atomic/literals/variable_rule.hpp"
 #include "expr/atomic/literals/yes_no_rule.hpp"
+#include "expr/atomic/literals/born_rule.hpp"
 
 #include "expr/conditional_expr_rule.hpp"
 #include "stmt/create_var_stmt_rule.hpp"
@@ -52,13 +53,14 @@ namespace grammar
     inline auto Conditional = std::make_shared<ConditionalExprRule>(LogicalOr);
     inline auto Expression = Conditional;
 
-    inline auto YesNo = std::make_shared<YesNoRule>();
+    inline auto YesNo = std::make_shared<YesNoRule>(); // yes|no
+    inline auto Sex = std::make_shared<BornRule>(); // male|female
     inline auto Variable = std::make_shared<VariableRule>();
 
     /**
      * @brief Primary is anything that can be evaluated directly: number, string, or a grouped expression.
      */
-    inline auto Primary = Number | String | YesNo | Variable | Group(Expression);
+    inline auto Primary = Number | String | YesNo | Sex | Variable | Group(Expression);
 
     // ----------
     // Statements

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -15,6 +15,7 @@
 #include "expr/atomic/literals/variable_rule.hpp"
 #include "expr/atomic/literals/yes_no_rule.hpp"
 #include "expr/atomic/literals/born_rule.hpp"
+#include "expr/atomic/literals/weekday_rule.hpp"
 
 #include "expr/conditional_expr_rule.hpp"
 #include "stmt/create_var_stmt_rule.hpp"
@@ -55,12 +56,13 @@ namespace grammar
 
     inline auto YesNo = std::make_shared<YesNoRule>(); // yes|no
     inline auto Sex = std::make_shared<BornRule>(); // male|female
+    inline auto Weekday = std::make_shared<WeekdayRule>(); // lighday|skyday|treeday|lampday|fishday|walkday|shabbat
     inline auto Variable = std::make_shared<VariableRule>();
 
     /**
      * @brief Primary is anything that can be evaluated directly: number, string, or a grouped expression.
      */
-    inline auto Primary = Number | String | YesNo | Sex | Variable | Group(Expression);
+    inline auto Primary = Number | String | YesNo | Sex | Weekday | Variable | Group(Expression);
 
     // ----------
     // Statements


### PR DESCRIPTION
# Description

This PR introduces `BornRule` and `WeekdayRule` into the grammar system to parse and recognize the biological sex and the seven days of the week as described in Genesis 1.

✅ **New literals now supported**:

born
* `male` – (bool: 1)
* `female` – (bool: 0)

weekday
* `lightday` – Sunday - day 1 (int: 1)
* `skyday` – Monday - day 2  (int: 2)
* `treeday` – Tuesday - day 3 (int: 3)
* `lampday` – Wednesday - day 4 (int: 4)
* `fishday` – Thursday - day 5 (fish and birds) (int: 5)
* `walkday` – Friday - day 6 (animals and man) (int: 6)
* `shabbat` – saturday - day 7 (Sabbath, day of rest) (int: 7)

These `born` and `weekday` values are now valid atomic expressions and can be used to assign values to variables, compare values, or even build control structures in future developments.

💡 The names are chosen for clarity and memorability, aiming to honor the structure of God’s creation in a way that feels natural to both technical minds and spiritual hearts.


# ✝️ Wisdom

> "And God said, Let there be light: and there was light." — **Genesis 1:3**
> "... And the evening and the morning were the first day." — **Genesis 1:5**
