### PR TITLE
Step 18: Added type declaration support in 'create type varname' syntax

### DIFF
--- a/src/jesus/ast/stmt/create_var_stmt.hpp
+++ b/src/jesus/ast/stmt/create_var_stmt.hpp
@@ -13,11 +13,12 @@
 class CreateVarStmt : public Stmt
 {
 public:
+    std::string type;
     std::string name;
     std::unique_ptr<Expr> value;
 
-    CreateVarStmt(std::string name, std::unique_ptr<Expr> value)
-        : name(name), value(std::move(value)) {}
+    CreateVarStmt(std::string type, std::string name, std::unique_ptr<Expr> value)
+        : type(type), name(name), value(std::move(value)) {}
 
     /**
      * @brief Returns a string representation of the statement.

--- a/src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
@@ -8,7 +8,12 @@ std::unique_ptr<Stmt> CreateVarStmtRule::parse(ParserContext &ctx)
         return nullptr;
 
     if (!ctx.match(TokenType::IDENTIFIER))
-        throw std::runtime_error("Expected variable name after 'create'");
+        throw std::runtime_error("Expected variable type after 'create'");
+
+    std::string varType = ctx.previous().lexeme;
+
+    if (!ctx.match(TokenType::IDENTIFIER))
+        throw std::runtime_error("Expected variable name after 'create type'");
 
     std::string varName = ctx.previous().lexeme;
 
@@ -21,5 +26,5 @@ std::unique_ptr<Stmt> CreateVarStmtRule::parse(ParserContext &ctx)
             throw std::runtime_error("Expected expression after '=' in create statement.");
     }
 
-    return std::make_unique<CreateVarStmt>(varName, std::move(value));
+    return std::make_unique<CreateVarStmt>(varType, varName, std::move(value));
 }

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -1,8 +1,8 @@
-create light = "Day"
-create messiah = "Jesus"
-create age = 33
-create priest = "me"
-create average = 2.3
+create text light = "Day"
+create text messiah = "Jesus"
+create number age = 33
+create text priest = "me"
+create real average = 2.3
 say age
 say messiah
 say priest
@@ -32,7 +32,7 @@ not not 23
 (0 versus age)
 (1 versus age )
 ( 1 versus 0 )
-create name = "Jesus"
+create text name = "Jesus"
 ( age versus name )
 ( 1 vs 9 )
 say name if ( 1 vs 1 ) otherwise "final"
@@ -47,7 +47,7 @@ say "adult" if ((age>=18)) otherwise "minor"
 ( age <= 1 )
 ( ( age <= 1 ) )
 
-create age = 33
+create number age = 33
 say "adult" if ( ( age >= 18 ) ) otherwise "minor"
 ( 1 + 1 )
 ( 2 + 7 )
@@ -90,9 +90,55 @@ not not 23
 ( 1 versus 7 )
 ( 1.0 versus 7 )
 ( 1.0 versus 7.98 )
-create name = "Jesus"
+create text name = "Jesus"
 ( age versus name )
 ( 1 vs 9 )
 say name if ( 1 vs 1 ) otherwise "final"
 (age*4)
 say "adult" if ((age>=18)) otherwise "minor"
+create with_no_type = 33
+create number count = "wrong value"
+create number one = 1
+say count
+say one
+create number zero = 0
+say zero
+create number PI = 3.14
+say PI
+create number temperature = -6
+say temperature
+create positive elders = 24
+say elders
+create positive sinful = 0
+say sinful
+create negative debt = -1
+say debt
+create negative credit = 13
+say credit
+create negative void = 0
+say void
+create natural spirits = 7
+say spirits
+create natural darkness = -13
+say darkness
+create percentage fallen_angels = 0.333
+say fallen_angels
+create percentage fallen_wise = -0.333
+say fallen_wise
+create percentage ships = 100
+create percentage ships = 101
+say ships
+create word empty = ""
+say empty
+create word savior = "Jesus"
+say savior
+create word invalid = "Sinful wise"
+warn invalid
+create phrase confusion = 6
+warn confusion
+create phrase lie = "God does not see"
+warn lie
+create text valid = ""
+say valid
+create text rebellion = 13
+warn rebellion

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -90,4 +90,28 @@
 (Jesus) (text) final
 (Jesus) (int) 132
 (Jesus) (text) adult
+(Jesus) ❌ Error: Expected variable name after 'create type'
+(Jesus) (Jesus) (Jesus) (text) wrong value
+(Jesus) (int) 1
+(Jesus) (Jesus) (int) 0
+(Jesus) (Jesus) (double) 3.140000
+(Jesus) (Jesus) (double) -6.000000
+(Jesus) (Jesus) (int) 24
+(Jesus) (Jesus) (int) 0
+(Jesus) (Jesus) (double) -1.000000
+(Jesus) (Jesus) (int) 13
+(Jesus) (Jesus) (int) 0
+(Jesus) (Jesus) (int) 7
+(Jesus) (Jesus) (double) -13.000000
+(Jesus) (Jesus) (double) 0.333000
+(Jesus) (Jesus) (double) -0.333000
+(Jesus) (Jesus) ❌ Error: The variable 'ships' already exists.
+(Jesus) (int) 100
+(Jesus) (Jesus) (text) 
+(Jesus) (Jesus) (text) Jesus
+(Jesus) (Jesus) (text) Sinful wise
+(Jesus) (Jesus) (int) 6
+(Jesus) (Jesus) (text) God does not see
+(Jesus) (Jesus) (text) 
+(Jesus) (Jesus) (int) 13
 (Jesus) 


### PR DESCRIPTION
# Description

This PR updates the parser to support explicit type declarations during variable creation. It enforces that all variables must declare their type, laying the foundation for future type validation.

Examples:
```
  create number age = 33
  create word savior = "Jesus"
```

Note: This PR does not yet perform type validation. That will follow in a future update.

# ✝️ Wisdom
> "God made the wild animals according to their kinds, the livestock according to their kinds,
>  and all the creatures that move along the ground according to their kinds. And God saw that it was good."
— Genesis 1:25
