### PR TITLE
Step 19: Adding initial variable types and validating them when creating variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,11 @@ set(JESUS_CPP_FILES
     src/jesus/spirit/value.cpp
     src/jesus/spirit/heart.cpp
 
+    # ----------------------
+    # Initial variable types
+    # ----------------------
+    src/jesus/types/known_types.cpp
+
     # ---------------
     # AST Expressions
     # ---------------

--- a/src/jesus/main.cpp
+++ b/src/jesus/main.cpp
@@ -5,6 +5,7 @@
 #include "spirit/heart.hpp"
 #include "interpreter/interpreter.hpp"
 #include "parser/grammar/jesus_grammar.hpp"
+#include "types/known_types.hpp"
 
 int main()
 {
@@ -13,6 +14,8 @@ int main()
     Heart heart;
     Interpreter interpreter(&heart);
     std::string line;
+
+    KnownTypes::registerBuiltInTypes();
 
     std::cout << "(Jesus) ";
     while (std::getline(std::cin, line))

--- a/src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
@@ -1,5 +1,6 @@
 #include "create_var_stmt_rule.hpp"
 #include "../../../ast/stmt/create_var_stmt.hpp"
+#include "../../../types/known_types.hpp"
 #include <stdexcept>
 
 std::unique_ptr<Stmt> CreateVarStmtRule::parse(ParserContext &ctx)
@@ -16,6 +17,12 @@ std::unique_ptr<Stmt> CreateVarStmtRule::parse(ParserContext &ctx)
         throw std::runtime_error("Expected variable name after 'create type'");
 
     std::string varName = ctx.previous().lexeme;
+
+    const auto *creationType = KnownTypes::resolve(varType, "core");
+    if (!creationType)
+    {
+        throw std::runtime_error("Unknown variable type: '" + varType + "'");
+    }
 
     std::unique_ptr<Expr> value = nullptr;
 

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -142,3 +142,7 @@ create text valid = ""
 say valid
 create text rebellion = 13
 warn rebellion
+create car hilux = 0
+say hilux
+create decimal forgive = 70 * 7
+say forgive

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -114,4 +114,7 @@
 (Jesus) (Jesus) (text) God does not see
 (Jesus) (Jesus) (text) 
 (Jesus) (Jesus) (int) 13
+(Jesus) ❌ Error: Unknown variable type: 'car'
+(Jesus) ❌ Error: Undefined variable: hilux
+(Jesus) (Jesus) (int) 490
 (Jesus) 

--- a/src/jesus/types/atomic/numbers/decimal_type.hpp
+++ b/src/jesus/types/atomic/numbers/decimal_type.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "../../creation_type.hpp"
+
+class DecimalType : public CreationType
+{
+public:
+    DecimalType() : CreationType("decimal", "core") {}
+
+    bool validate(const Value &value) const override
+    {
+        return value.IS_NUMBER;
+    }
+};

--- a/src/jesus/types/atomic/numbers/natural_type.hpp
+++ b/src/jesus/types/atomic/numbers/natural_type.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "../../creation_type.hpp"
+
+class NaturalType : public CreationType
+{
+public:
+    NaturalType() : CreationType("natural", "core") {}
+
+    bool validate(const Value &value) const override
+    {
+        return value >= Value(0);
+    }
+};

--- a/src/jesus/types/atomic/numbers/negative_type.hpp
+++ b/src/jesus/types/atomic/numbers/negative_type.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "../../creation_type.hpp"
+
+class NegativeType : public CreationType
+{
+public:
+    NegativeType() : CreationType("negative", "core") {}
+
+    bool validate(const Value &value) const override
+    {
+        return value < Value(0);
+    }
+};

--- a/src/jesus/types/atomic/numbers/number_type.hpp
+++ b/src/jesus/types/atomic/numbers/number_type.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "../../creation_type.hpp"
+
+class NumberType : public CreationType
+{
+public:
+    NumberType() : CreationType("number", "core") {}
+
+    bool validate(const Value &value) const override
+    {
+        return value.IS_INT;
+    }
+};

--- a/src/jesus/types/atomic/numbers/percentage_type.hpp
+++ b/src/jesus/types/atomic/numbers/percentage_type.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "../../creation_type.hpp"
+
+class PercentageType : public CreationType
+{
+public:
+    PercentageType() : CreationType("percentage", "core") {}
+
+    bool validate(const Value &value) const override
+    {
+        return Value(0) <= value && value <= Value(100);
+    }
+};

--- a/src/jesus/types/atomic/numbers/positive_type.hpp
+++ b/src/jesus/types/atomic/numbers/positive_type.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "../../creation_type.hpp"
+
+class PositiveType : public CreationType
+{
+public:
+    PositiveType() : CreationType("positive", "core") {}
+
+    bool validate(const Value &value) const override
+    {
+        return value > Value(0);
+    }
+};

--- a/src/jesus/types/atomic/numbers/real_type.hpp
+++ b/src/jesus/types/atomic/numbers/real_type.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "../../creation_type.hpp"
+
+class RealType : public CreationType
+{
+public:
+    RealType() : CreationType("real", "core") {}
+
+    bool validate(const Value &value) const override
+    {
+        return value.IS_NUMBER;
+    }
+};

--- a/src/jesus/types/atomic/strings/phrase_type.hpp
+++ b/src/jesus/types/atomic/strings/phrase_type.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "../../creation_type.hpp"
+
+class PhraseType : public CreationType
+{
+public:
+    PhraseType() : CreationType("phrase", "core") {}
+
+    bool validate(const Value &value) const override
+    {
+        return value.IS_STRING;
+    }
+};

--- a/src/jesus/types/atomic/strings/text_type.hpp
+++ b/src/jesus/types/atomic/strings/text_type.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "../../creation_type.hpp"
+
+class TextType : public CreationType
+{
+public:
+    TextType() : CreationType("text", "core") {}
+
+    bool validate(const Value &value) const override
+    {
+        return value.IS_STRING;
+    }
+};

--- a/src/jesus/types/atomic/strings/word_type.hpp
+++ b/src/jesus/types/atomic/strings/word_type.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "../../creation_type.hpp"
+
+class WordType : public CreationType
+{
+public:
+    WordType() : CreationType("word", "core") {}
+
+    bool validate(const Value &value) const override
+    {
+        return value.IS_STRING;
+    }
+};

--- a/src/jesus/types/creation_type.hpp
+++ b/src/jesus/types/creation_type.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#include <string>
+#include "../spirit/value.hpp"
+
+class CreationType
+{
+
+public:
+    virtual ~CreationType() = default;
+
+    /**
+     * @brief Unique internal ID for runtime (index in vector)
+     */
+    const int id;
+
+    /**
+     * @brief The creation type. E.g.: number, User
+     */
+    const std::string name;
+
+    /**
+     * @brief The module name. E.g.: core, my.custom.package
+     */
+    const std::string module_name;
+
+    CreationType(const std::string &name, const std::string &module_name = "core")
+        : name(name), module_name(module_name), id(lastId++) {}
+
+    /**
+     * @brief Returns true if the value belongs to this type.
+     */
+    virtual bool validate(const Value &value) const = 0;
+
+private:
+    inline static int lastId = 0;
+};

--- a/src/jesus/types/known_types.cpp
+++ b/src/jesus/types/known_types.cpp
@@ -1,0 +1,65 @@
+#include "known_types.hpp"
+#include "atomic/numbers/number_type.hpp"
+#include "atomic/numbers/real_type.hpp"
+#include "atomic/numbers/positive_type.hpp"
+#include "atomic/numbers/negative_type.hpp"
+#include "atomic/numbers/natural_type.hpp"
+#include "atomic/numbers/percentage_type.hpp"
+#include "atomic/strings/text_type.hpp"
+#include "atomic/strings/word_type.hpp"
+#include "atomic/strings/phrase_type.hpp"
+#include <memory>
+
+void KnownTypes::registerBuiltInTypes()
+{
+    registerType(std::make_unique<WordType>());
+    registerType(std::make_unique<PhraseType>());
+    registerType(std::make_unique<TextType>());
+
+    registerType(std::make_unique<RealType>());
+    registerType(std::make_unique<NumberType>());
+    registerType(std::make_unique<NaturalType>());
+    registerType(std::make_unique<PositiveType>());
+    registerType(std::make_unique<NegativeType>());
+    registerType(std::make_unique<PercentageType>());
+}
+
+void KnownTypes::registerType(std::unique_ptr<CreationType> type)
+{
+    const std::string fullname = makeKey(type->module_name, type->name);
+    int id = type->id;
+
+    if (typesById.size() <= id)
+        typesById.resize(id + 50);
+
+    typesById[id] = type.get();
+    typesByName[fullname] = std::move(type);
+}
+
+const CreationType *KnownTypes::resolve(const std::string &name, const std::string &module)
+{
+    const std::string key = makeKey(module, name);
+    auto it = typesByName.find(key);
+    if (it != typesByName.end())
+        return it->second.get();
+
+    return nullptr;
+}
+
+const CreationType *KnownTypes::getById(int id)
+{
+    if (id < 0 || id >= typesById.size())
+        return nullptr; // TODO: Remove this checking?
+
+    return typesById[id];
+}
+
+bool KnownTypes::isValid(const CreationType *type, const Value &value)
+{
+    return type && type->validate(value);
+}
+
+std::string KnownTypes::makeKey(const std::string &module_name, const std::string &name)
+{
+    return module_name + "." + name;
+}

--- a/src/jesus/types/known_types.cpp
+++ b/src/jesus/types/known_types.cpp
@@ -5,6 +5,7 @@
 #include "atomic/numbers/negative_type.hpp"
 #include "atomic/numbers/natural_type.hpp"
 #include "atomic/numbers/percentage_type.hpp"
+#include "atomic/numbers/decimal_type.hpp"
 #include "atomic/strings/text_type.hpp"
 #include "atomic/strings/word_type.hpp"
 #include "atomic/strings/phrase_type.hpp"
@@ -22,6 +23,7 @@ void KnownTypes::registerBuiltInTypes()
     registerType(std::make_unique<PositiveType>());
     registerType(std::make_unique<NegativeType>());
     registerType(std::make_unique<PercentageType>());
+    registerType(std::make_unique<DecimalType>());
 }
 
 void KnownTypes::registerType(std::unique_ptr<CreationType> type)

--- a/src/jesus/types/known_types.hpp
+++ b/src/jesus/types/known_types.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include <string>
+#include <unordered_map>
+#include "creation_type.hpp"
+#include "../spirit/value.hpp"
+
+class KnownTypes
+{
+public:
+    static void registerBuiltInTypes();
+
+    static void registerType(std::unique_ptr<CreationType> type);
+
+    static const CreationType *resolve(const std::string &name, const std::string &module = "core");
+    static const CreationType *getById(int id);
+
+    static bool isValid(const CreationType *type, const Value &value);
+
+private:
+    /**
+     * @brief  Joins module and type name (e.g. core.born)
+     */
+    static std::string makeKey(const std::string &module_name, const std::string &name);
+
+    inline static std::unordered_map<std::string, std::unique_ptr<CreationType>> typesByName;
+    inline static std::vector<const CreationType *> typesById;
+};


### PR DESCRIPTION
# Description

This PR introduces the foundation for type safety in the Jesus Language by:

1. **Creating the `CreationType` base class** — a base class for defining and validating types.
2. **Adding atomic built-in types** such as:
   - `number`, `real`, `positive`, `natural`, `percentage`, `negative`, `decimal`
   - `text`, `word`, `phrase`
3. **Implementing `KnownTypes::registerBuiltInTypes()`** to register and manage available types within the core module.
4. **Refactoring `CreateVarStmtRule`** to enforce that all declared types are explicitly known using `KnownTypes::resolve(...)`.

This marks the first milestone toward full type validation in the language. Future PRs will handle **type-checking of values** and custom user-defined types.

# ✝️ Wisdom
> "By the grace God has given me, I laid a foundation as a wise builder, and someone else is building on it. 
> But each one must be careful how he builds." — 1 Corinthians 3:10