### PR TITLE
Step 21: Introduced UpdateVarStmtRule to support variable update ( var = newValue)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,4 +14,4 @@ Scribe:
 - Ruben Alves - https://github.com/rubenanapu
 
 Special thanks to all contributors.
-See the Git history for details.
+See the Git history (git shortlog -sne) for details.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ set(JESUS_CPP_FILES
     # Statement parsers
     # -----------------
     src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
+    src/jesus/parser/grammar/stmt/update_var_stmt_rule.cpp
 
     # -----------
     # Interpreter

--- a/src/jesus/ast/stmt/update_var_stmt.hpp
+++ b/src/jesus/ast/stmt/update_var_stmt.hpp
@@ -16,7 +16,7 @@ public:
     std::string name;
     std::unique_ptr<Expr> value;
 
-    UpdateVarStmt(const std::string &name, std::unique_ptr<Expr> value)
+    UpdateVarStmt(const std::string name, std::unique_ptr<Expr> value)
         : name(name), value(std::move(value)) {}
 
     void accept(StmtVisitor &visitor) const override;

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -19,6 +19,7 @@
 
 #include "expr/conditional_expr_rule.hpp"
 #include "stmt/create_var_stmt_rule.hpp"
+#include "stmt/update_var_stmt_rule.hpp"
 #include "unary_rule.hpp"
 
 /**
@@ -68,6 +69,7 @@ namespace grammar
     // Statements
     // ----------
     inline auto CreateVar = std::make_shared<CreateVarStmtRule>(Expression);
+    inline auto UpdateVar = std::make_shared<UpdateVarStmtRule>(Expression);
 
     /**
      * @brief Set the Expression rule to something (for now just Primary)

--- a/src/jesus/parser/grammar/stmt/update_var_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/update_var_stmt_rule.cpp
@@ -1,0 +1,21 @@
+#include "update_var_stmt_rule.hpp"
+#include "../../../ast/stmt/update_var_stmt.hpp"
+#include <stdexcept>
+
+std::unique_ptr<Stmt> UpdateVarStmtRule::parse(ParserContext &ctx)
+{
+    if (!ctx.match(TokenType::IDENTIFIER))
+        return nullptr;
+
+    const std::string varName = ctx.previous().lexeme;
+
+    if (!ctx.match(TokenType::EQUAL))
+        return nullptr;
+
+    std::unique_ptr<Expr> value = expression->parse(ctx);
+
+    if (!value)
+        throw std::runtime_error("Expected expression after '=' in update statement.");
+
+    return std::make_unique<UpdateVarStmt>(varName, std::move(value));
+}

--- a/src/jesus/parser/grammar/stmt/update_var_stmt_rule.hpp
+++ b/src/jesus/parser/grammar/stmt/update_var_stmt_rule.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "../grammar_rule.hpp"
+#include "../../../ast/stmt/stmt.hpp"
+
+class UpdateVarStmtRule
+{
+    std::shared_ptr<IGrammarRule> expression;
+
+public:
+    explicit UpdateVarStmtRule(std::shared_ptr<IGrammarRule> expression)
+        : expression(std::move(expression)) {}
+
+    std::unique_ptr<Stmt> parse(ParserContext &ctx);
+};

--- a/src/jesus/parser/parser.cpp
+++ b/src/jesus/parser/parser.cpp
@@ -57,6 +57,10 @@ std::unique_ptr<Stmt> parse(const std::vector<Token> &tokens)
     if (createVarStmt)
         return createVarStmt;
 
+    auto updateVarStmt = grammar::UpdateVar->parse(ctx);
+    if (updateVarStmt)
+        return updateVarStmt;
+
     // If no match, fall back to expression parsing
     ParserContext context(tokens);
     auto expr = grammar::Expression->parse(context);

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -125,9 +125,9 @@ create percentage fallen_angels = 0.333
 say fallen_angels
 create percentage fallen_wise = -0.333
 say fallen_wise
-create percentage ships = 100
-create percentage ships = 101
-say ships
+create percentage sheep = 100
+create percentage sheep = 101
+say sheep
 create word empty = ""
 say empty
 create word savior = "Jesus"
@@ -146,3 +146,5 @@ create car hilux = 0
 say hilux
 create decimal forgive = 70 * 7
 say forgive
+valid = "Jesus loves YOU"
+say valid

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -105,7 +105,7 @@
 (Jesus) (Jesus) (double) -13.000000
 (Jesus) (Jesus) (double) 0.333000
 (Jesus) (Jesus) (double) -0.333000
-(Jesus) (Jesus) ❌ Error: The variable 'ships' already exists.
+(Jesus) (Jesus) ❌ Error: The variable 'sheep' already exists.
 (Jesus) (int) 100
 (Jesus) (Jesus) (text) 
 (Jesus) (Jesus) (text) Jesus
@@ -117,4 +117,5 @@
 (Jesus) ❌ Error: Unknown variable type: 'car'
 (Jesus) ❌ Error: Undefined variable: hilux
 (Jesus) (Jesus) (int) 490
+(Jesus) (Jesus) (text) Jesus loves YOU
 (Jesus) 


### PR DESCRIPTION
# Description

This Pull Request introduces support for updating existing variables in the language using assignment statements like:

    variable_name = new_value

Changes include:

- Added `UpdateVarStmtRule` in the parser to recognize assignment expressions.
- Updated the parser to understand the intention to update the value.

Example usage:
```
    create number age = 30
    age = 31
    say age
```

This makes the language more practical for real programs.

✝️ Wisdom

> "But the pot he was shaping from the clay was marred in his hands; so the potter formed it into another pot, shaping it as seemed best to him." - **Jeremiah 18:4**