### PR TITLE
Step 24: Added support for "ask" expressions to create variables with built-in validation: create int age = ask "Your age? "

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ set(JESUS_CPP_FILES
     # ---------------
     # AST Expressions
     # ---------------
+    src/jesus/ast/expr/ask_expr.cpp
     src/jesus/ast/expr/unary_expr.cpp
     src/jesus/ast/expr/binary_expr.cpp
     src/jesus/ast/expr/literal_expr.cpp
@@ -44,6 +45,7 @@ set(JESUS_CPP_FILES
     src/jesus/ast/stmt/continue_stmt.cpp
     src/jesus/ast/stmt/create_var_type_stmt.cpp
     src/jesus/ast/stmt/create_var_stmt.cpp
+    src/jesus/ast/stmt/create_var_with_ask_stmt.cpp
     src/jesus/ast/stmt/for_each_stmt.cpp
     src/jesus/ast/stmt/output_stmt.cpp
     src/jesus/ast/stmt/repeat_times_stmt.cpp
@@ -61,6 +63,7 @@ set(JESUS_CPP_FILES
     # ------------------
     # Expression parsers
     # ------------------
+    src/jesus/parser/grammar/expr/ask_expr_rule.cpp
     src/jesus/parser/grammar/expr/conditional_expr_rule.cpp
 
     src/jesus/parser/grammar/expr/atomic/literals/number_rule.cpp

--- a/src/jesus/ast/expr/ask_expr.cpp
+++ b/src/jesus/ast/expr/ask_expr.cpp
@@ -1,0 +1,14 @@
+#include "ask_expr.hpp"
+#include "../../interpreter/expr_visitor.hpp"
+
+Value AskExpr::evaluate(Heart *heart) const
+{
+    auto question = prompt->evaluate(heart);
+    return question;
+}
+
+Value AskExpr::accept(ExprVisitor &visitor) const
+{
+    Value answer = visitor.visitAsk(*this);
+    return answer;
+}

--- a/src/jesus/ast/expr/ask_expr.hpp
+++ b/src/jesus/ast/expr/ask_expr.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "expr.hpp"
+
+/**
+ * @brief Represents an 'ask' expression in the Jesus language.
+ *
+ * This expression holds a prompt, which can be either a string literal
+ * or a variable expression that will be evaluated to produce the question
+ * asked to the user.
+ *
+ * "Ask, and it will be given to you; seek, and you will find; knock, and it will be opened to you." — Matthew 7:7
+ */
+class AskExpr : public Expr
+{
+public:
+    /**
+     * @brief The prompt of the question, which can be an expression producing text (literal or variable)
+     */
+    std::unique_ptr<Expr> prompt;
+
+public:
+    /**
+     * @brief Constructs the AskExpr with a given prompt expression.
+     *
+     * @param prompt An expression representing the question to be asked.
+     */
+    explicit AskExpr(std::unique_ptr<Expr> prompt) : prompt(std::move(prompt)) {}
+
+    /**
+     * @brief Evaluates the 'prompt' expression.
+     *
+     * @return The string representing the question.
+     */
+    Value evaluate(Heart *heart) const override;
+
+    /**
+     * @brief Gets the answer from the user.
+     *
+     * @return The value received as the user's answer.
+     */
+    Value accept(ExprVisitor &visitor) const override;
+
+    std::string toString() const override
+    {
+        // TODO: Add toJesus() that returns: return "ask \"" + prompt + "\"";
+        //  'jesus refine' 7 times: Psalm 12:6
+        return "AskExpr(" + prompt->toString() + ")";
+    }
+};

--- a/src/jesus/ast/stmt/create_var_with_ask_stmt.cpp
+++ b/src/jesus/ast/stmt/create_var_with_ask_stmt.cpp
@@ -1,0 +1,7 @@
+#include "create_var_with_ask_stmt.hpp"
+#include "../../interpreter/stmt_visitor.hpp"
+
+void CreateVarWithAskStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visitCreateVarWithAsk(*this);
+}

--- a/src/jesus/ast/stmt/create_var_with_ask_stmt.hpp
+++ b/src/jesus/ast/stmt/create_var_with_ask_stmt.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "../expr/expr.hpp"
+#include "../../types/creation_type.hpp"
+#include "stmt.hpp"
+#include <string>
+#include <memory>
+
+/**
+ * @brief Represents the creation of a new variable using 'ask'
+ *
+ * E.g.: create int age = ask "What is your age?"
+ *
+ * "Ask and it will be given to you; seek and you will find; knock and the door will be opened to you." — Matthew 7:7
+ */
+class CreateVarWithAskStmt : public Stmt
+{
+public:
+    const CreationType var_type;
+    std::string var_name;
+    std::shared_ptr<Expr> ask_expr; // Type is AskExpr
+
+    CreateVarWithAskStmt(const CreationType type, std::string name, std::unique_ptr<Expr> ask_expr)
+        : var_type(type), var_name(name), ask_expr(std::move(ask_expr)) {}
+
+    void accept(StmtVisitor &visitor) const override;
+
+    /**
+     * @brief Returns a string representation of the statement.
+     *
+     * "For nothing is hidden that will not be made manifest, nor is anything
+     * secret that will not be known and come to light." — Luke 8:17
+     */
+    std::string toString() const override
+    {
+
+        std::string str = "CreateVarWithAsk(" + var_name + " = " + ask_expr->toString() + ")";
+
+        return str;
+    }
+};

--- a/src/jesus/interpreter/expr_visitor.hpp
+++ b/src/jesus/interpreter/expr_visitor.hpp
@@ -7,6 +7,7 @@
 #include "../ast/expr/literal_expr.hpp"
 #include "../ast/expr/variable_expr.hpp"
 #include "../ast/expr/grouping_expr.hpp"
+#include "../ast/expr/ask_expr.hpp"
 
 /**
  * @brief Interface for visiting and evaluating expression nodes in the AST.
@@ -49,6 +50,7 @@ public:
     virtual Value visitUnary(const UnaryExpr &expr) = 0;
     virtual Value visitConditional(const ConditionalExpr &expr) = 0;
     virtual Value visitVariable(const VariableExpr &expr) = 0;
+    virtual Value visitAsk(const AskExpr &expr) = 0;
 
     virtual ~ExprVisitor() = default;
 };

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -53,6 +53,12 @@ Value Interpreter::visitVariable(const VariableExpr &expr)
     return heart.getVar(expr.name);
 }
 
+Value Interpreter::visitAsk(const AskExpr &expr)
+{
+    auto question = expr.evaluate(&heart);
+    return question;
+}
+
 Value Interpreter::visitGrouping(const GroupingExpr &expr)
 {
     return evaluate(expr.expression);
@@ -69,18 +75,47 @@ void Interpreter::visitCreateVar(const CreateVarStmt &stmt)
     createVariable(stmt.name, val);
 }
 
+void Interpreter::visitCreateVarWithAsk(const CreateVarWithAskStmt &stmt)
+{
+    // Step 1: Evaluate the ask expression (e.g., ask "Your age?")
+    Value question = stmt.ask_expr->evaluate(&heart);
+
+    while (true)
+    {
+        // Step 2: Show the question to the user
+        std::cout << question.toString();
+
+        // Step 3: Get the answer from the user
+        std::string answer;
+        std::getline(std::cin, answer);
+
+        try
+        {
+            // Step 4: Validate the value according to the creation type
+            Value value = stmt.var_type.parseFromString(answer);
+            stmt.var_type.validate(value);
+
+            // Step 5: Only if validation passed, create the variable
+            createVariable(stmt.var_name, value);
+            break;
+        }
+        catch (const std::exception &e)
+        {
+            std::cerr << "Validation failed: " << e.what() << std::endl;
+        }
+    }
+}
+
 void Interpreter::visitCreateVarType(const CreateVarTypeStmt &stmt)
 {
     auto custom_type = std::make_shared<CreationType>(
         stmt.base_type.primitive_type,
         stmt.name,
         stmt.module_name,
-        stmt.constraints
-    );
+        stmt.constraints);
 
     KnownTypes::registerType(std::move(custom_type));
 }
-
 
 void Interpreter::visitUpdateVar(const UpdateVarStmt &stmt)
 {

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -2,6 +2,7 @@
 #include <stdexcept>
 #include "../ast/stmt/output_statement.hpp"
 #include "../types/known_types.hpp"
+#include "../utils/string_utils.hpp"
 
 #include <iostream>
 
@@ -91,6 +92,8 @@ void Interpreter::visitCreateVarWithAsk(const CreateVarWithAskStmt &stmt)
 
         try
         {
+            answer = utils::trim(answer);
+
             // Step 4: Validate the value according to the creation type
             Value value = stmt.var_type.parseFromString(answer);
             stmt.var_type.validate(value);

--- a/src/jesus/interpreter/interpreter.hpp
+++ b/src/jesus/interpreter/interpreter.hpp
@@ -128,6 +128,23 @@ private:
     Value visitVariable(const VariableExpr &expr) override;
 
     /**
+     * @brief Evaluates an AskExpr by evaluating its prompt expression.
+     *
+     * It processes the 'ask' expression node in the AST,
+     * evaluating the prompt (which can be a string literal or a variable
+     * that resolves to text) to produce the question string that will be
+     * presented to the user.
+     *
+     * The returned Value represents the prompt message, ready to be
+     * displayed or used for user input collection.
+     *
+     * "Ask, and it will be given to you..." — Matthew 7:7
+     *
+     * @return Value The evaluated prompt as a Value object (typically text).
+     */
+    Value visitAsk(const AskExpr &expr) override;
+
+    /**
      * @brief Evaluates a grouped expression (expressions in parentheses).
      *
      * “When the day of Pentecost came, they were all together in one place.
@@ -153,6 +170,20 @@ private:
     // 🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️
 
     void visitCreateVar(const CreateVarStmt &stmt) override;
+
+    /**
+     * @brief Handles the creation of a variable initialized via an 'ask' expression.
+     *
+     * This method drives the interactive flow of variable creation when
+     * the initialization expression is an 'ask' prompt. It:
+     * - Evaluates the prompt to obtain the question.
+     * - Repeatedly asks the user for input until the provided value
+     *   passes the CreationType's validation constraints.
+     * - Creates the variable in the runtime environment with the validated value.
+     *
+     * This enables type-safe variable initialization with built-in validation.
+     */
+    void visitCreateVarWithAsk(const CreateVarWithAskStmt &stmt) override;
 
     void visitCreateVarType(const CreateVarTypeStmt &stmt) override;
 

--- a/src/jesus/interpreter/stmt_visitor.hpp
+++ b/src/jesus/interpreter/stmt_visitor.hpp
@@ -2,6 +2,7 @@
 
 #include "../ast/stmt/create_var_type_stmt.hpp"
 #include "../ast/stmt/create_var_stmt.hpp"
+#include "../ast/stmt/create_var_with_ask_stmt.hpp"
 #include "../ast/stmt/update_var_stmt.hpp"
 #include "../ast/stmt/output_statement.hpp"
 #include "../ast/stmt/repeat_while_stmt.hpp"
@@ -47,6 +48,7 @@ class StmtVisitor
 public:
     virtual void visitCreateVarType(const CreateVarTypeStmt &stmt) = 0;
     virtual void visitCreateVar(const CreateVarStmt &stmt) = 0;
+    virtual void visitCreateVarWithAsk(const CreateVarWithAskStmt &stmt) = 0;
     virtual void visitUpdateVar(const UpdateVarStmt &stmt) = 0;
     virtual void visitOutput(const OutputStmt &stmt) = 0;
     virtual void visitRepeatWhile(const RepeatWhileStmt &stmt) = 0;

--- a/src/jesus/lexer/lexer.cpp
+++ b/src/jesus/lexer/lexer.cpp
@@ -182,6 +182,9 @@ TokenType recognize_token_type(const std::string &word)
     if (word == "-")
         return TokenType::MINUS;
 
+    if (word == "ask")
+        return TokenType::ASK;
+
     if (word == "say")
         return TokenType::SAY;
 

--- a/src/jesus/lexer/token.hpp
+++ b/src/jesus/lexer/token.hpp
@@ -115,6 +115,8 @@ public:
             return "IDENTIFIER(" + lexeme + ")";
         case TokenType::SAY:
             return "SAY";
+        case TokenType::ASK:
+            return "ASK";
         case TokenType::WARN:
             return "WARN";
         case TokenType::UPDATE:

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -43,6 +43,7 @@ enum class TokenType
     SLASH,          // /
 
     CREATE,         // create days = 7
+    ASK,            // create int age = ask "What is your age?"
     SAY,            // "say" prints to stdout
     WARN,           // "warn" prints to stderr
     UPDATE,

--- a/src/jesus/parser/grammar/expr/ask_expr_rule.cpp
+++ b/src/jesus/parser/grammar/expr/ask_expr_rule.cpp
@@ -1,0 +1,46 @@
+#include "ask_expr_rule.hpp"
+#include "../../../ast/expr/ask_expr.hpp"
+#include "../../../ast/expr/literal_expr.hpp"
+#include "../../../ast/expr/variable_expr.hpp"
+#include <memory>
+
+std::unique_ptr<Expr> AskExprRule::parse(ParserContext &ctx)
+{
+    if (!ctx.match(TokenType::ASK))
+        return nullptr;
+
+    if (ctx.match(TokenType::STRING))
+    {
+        Value prompt = ctx.previous().literal;
+        return std::make_unique<AskExpr>(std::make_unique<LiteralExpr>(prompt));
+    }
+
+    if (!ctx.match(TokenType::IDENTIFIER))
+        throw std::runtime_error("Expected a text literal or a text-typed variable after 'ask' (e.g., ask \"What is your age?\" or ask question).");
+
+    std::string varName = ctx.previous().lexeme;
+
+    const CreationType *varType = ctx.getVarType(varName);
+    if (!varType)
+    {
+        throw std::runtime_error("Variable '" + varName + "' not found. Are you really sure it was declared?");
+    }
+
+    if (varType->primitive_type != PrimitiveType::Text)
+    {
+        throw std::runtime_error("Error: 'ask' expects a variable of primitive type 'text' as its prompt, but received variable '" + varName + "' of primitive type '" + varType->primitiveTypeName() + "'.");
+    }
+
+    return std::make_unique<AskExpr>(std::make_unique<VariableExpr>(varName));
+}
+
+std::string AskExprRule::toStr(GrammarRuleHashTable &visited) const
+{
+    if (visited.count(this))
+        return "AskExpr(...)";
+
+    visited.insert(this);
+
+    // return "AskExpr(" + expression->toStr(visited) +  ")";
+    return "AskExpr(?)";
+}

--- a/src/jesus/parser/grammar/expr/ask_expr_rule.hpp
+++ b/src/jesus/parser/grammar/expr/ask_expr_rule.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include "../grammar_rule.hpp"
+
+/**
+ * @brief Grammar rule for parsing `ask` expressions in the Jesus language.
+ *
+ * It parses expressions that use the `ask` keyword, which prompts the user
+ * for input at runtime and stores the result in a variable.
+ *
+ * In typical usage, the `ask` keyword is followed by a string literal or a
+ * text-typed variable that serves as the prompt message. This rule ensures
+ * the correct syntax is enforced.
+ *
+ * Example Jesus code:
+ * @code
+ *  create int age = ask "What is your age?"
+ * @endcode
+ *
+ * "Ask, and it will be given to you; seek, and you will find; knock, and it will be opened to you." — Matthew 7:7
+ */
+class AskExprRule : public IGrammarRule
+{
+public:
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override;
+
+    std::string toStr(GrammarRuleHashTable &visited) const override;
+};

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -19,6 +19,7 @@
 #include "expr/atomic/literals/born_rule.hpp"
 #include "expr/atomic/literals/weekday_rule.hpp"
 
+#include "expr/ask_expr_rule.hpp"
 #include "expr/conditional_expr_rule.hpp"
 #include "stmt/create_var_type_stmt_rule.hpp"
 #include "stmt/create_var_stmt_rule.hpp"
@@ -64,6 +65,7 @@ namespace grammar
     inline auto Sex = std::make_shared<BornRule>(); // male|female
     inline auto Weekday = std::make_shared<WeekdayRule>(); // lighday|skyday|treeday|lampday|fishday|walkday|shabbat
     inline auto Variable = std::make_shared<VariableRule>();
+    inline auto Ask = std::make_shared<AskExprRule>();
 
     /**
      * @brief Primary is anything that can be evaluated directly: number, string, or a grouped expression.
@@ -74,7 +76,7 @@ namespace grammar
     // Statements
     // ----------
     inline auto CreateVarType = std::make_shared<CreateVarTypeStmtRule>();
-    inline auto CreateVar = std::make_shared<CreateVarStmtRule>(Expression);
+    inline auto CreateVar = std::make_shared<CreateVarStmtRule>(Expression, Ask);
     inline auto UpdateVar = std::make_shared<UpdateVarStmtRule>(Expression);
 
     /**

--- a/src/jesus/parser/grammar/stmt/create_var_stmt_rule.hpp
+++ b/src/jesus/parser/grammar/stmt/create_var_stmt_rule.hpp
@@ -2,14 +2,16 @@
 
 #include "../grammar_rule.hpp"
 #include "../../../ast/stmt/stmt.hpp"
+#include "../expr/ask_expr_rule.hpp"
 
 class CreateVarStmtRule
 {
     std::shared_ptr<IGrammarRule> expression;
+    std::shared_ptr<AskExprRule> ask;
 
 public:
-    explicit CreateVarStmtRule(std::shared_ptr<IGrammarRule> expr)
-        : expression(std::move(expr)) {}
+    explicit CreateVarStmtRule(std::shared_ptr<IGrammarRule> expr, std::shared_ptr<AskExprRule> ask_expr)
+        : expression(std::move(expr)), ask(std::move(ask_expr)) {}
 
     std::unique_ptr<Stmt> parse(ParserContext &ctx);
 };

--- a/src/jesus/spirit/heart.hpp
+++ b/src/jesus/spirit/heart.hpp
@@ -4,6 +4,8 @@
 #include <unordered_map>
 #include "value.hpp"
 
+#define STRINGIFY(x) #x
+
 /**
  * @brief The Heart class stores variables declared during execution.
  *

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -170,3 +170,14 @@ create text Confirm matches "(Y|y)es"
 create Confirm sure = "Yes"
 sure = "no"
 say sure
+create text question = "What is your age? "
+create number edad = ask question
+18
+say edad
+create number idade = ask "Qual sua idade? "
+seven
+fourteen
+33
+say idade
+create number year = ask PI
+create number year2 = ask temperature

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -142,4 +142,10 @@
 (Jesus) (int) 12
 (Jesus) (Jesus) (Jesus) ❌ Error: Value "no" does not match expected pattern.
 (Jesus) Yes
+(Jesus) (Jesus) What is your age? (Jesus) (double) 18.000000
+(Jesus) Qual sua idade? Validation failed: Invalid number: 'seven'
+Qual sua idade? Validation failed: Invalid number: 'fourteen'
+Qual sua idade? (Jesus) (double) 33.000000
+(Jesus) ❌ Error: Variable 'PI' not found. Are you really sure it was declared?
+(Jesus) ❌ Error: Variable 'temperature' not found. Are you really sure it was declared?
 (Jesus) 

--- a/src/jesus/types/creation_type.hpp
+++ b/src/jesus/types/creation_type.hpp
@@ -36,6 +36,44 @@ public:
                  std::vector<std::shared_ptr<IConstraint>> constraints = {})
         : primitive_type(primitive_type), name(name), module_name(module), constraints(std::move(constraints)), id(lastId++) {}
 
+    virtual Value parseFromString(const std::string &raw) const
+    {
+        switch (primitive_type)
+        {
+        case PrimitiveType::Number:
+        {
+            try
+            {
+                double number = std::stod(raw);
+                return Value(number);
+            }
+            catch (...)
+            {
+                throw std::runtime_error("Invalid number: '" + raw + "'");
+            }
+        }
+
+        case PrimitiveType::Text:
+            return Value(raw);
+
+        default:
+            throw std::runtime_error("Unknown primitive type for parsing.");
+        }
+    }
+
+    std::string primitiveTypeName() const
+    {
+        switch (primitive_type)
+        {
+        case PrimitiveType::Number:
+            return "number";
+        case PrimitiveType::Text:
+            return "text";
+        default:
+            return "unknown";
+        }
+    }
+
     /**
      * @brief Returns true if the value belongs to this type.
      */

--- a/src/jesus/utils/string_utils.hpp
+++ b/src/jesus/utils/string_utils.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <string>
+#include <cctype>
+
+namespace utils
+{
+    /**
+     * @brief Removes leading and trailing whitespace from the input string.
+     *
+     * @param str The string to trim.
+     * @return std::string A new string with leading and trailing whitespace removed.
+     */
+    inline std::string trim(const std::string &str)
+    {
+        size_t start = 0;
+        while (start < str.size() && std::isspace(static_cast<unsigned char>(str[start])))
+        {
+            ++start;
+        }
+
+        if (start == str.size())
+            return "";
+
+        size_t end = str.size() - 1;
+        while (end > start && std::isspace(static_cast<unsigned char>(str[end])))
+        {
+            --end;
+        }
+
+        return str.substr(start, end - start + 1);
+    }
+}


### PR DESCRIPTION
# Description

This PR introduces the ability to use the `ask` statement in variable creation, similar to `scanf` in C or `input` in Python, allowing interactive user input during runtime with automatic type validation.

## Main changes:

* Added `AskExpr` AST node and `CreateVarWithAskStmt` to represent `ask` expressions in variable declarations.
* Added `AskExprRule` in the parser grammar to parse `ask` expressions.
* Extended `CreateVarStmtRule::parse` to support syntax like:

  ```jesus
  create int age = ask "What is your age?"
  ```

* Implemented interpreter methods `visitAsk` and `visitCreateVarWithAsk` to evaluate prompts, read user input, parse and validate values according to the declared type, and create variables only on successful validation.

**Examples of valid `ask` usage:**

```jesus
create int age = ask "What is your age? "

create text question = "What is your full name? "
create text name = ask question
create Positive score = ask "Enter your score: "
```

The system loops input until a valid value conforming to the variable’s type and constraints is entered.

# ✝️ Wisdom

> "Ask and it will be given to you; seek and you will find; knock and the door will be opened to you." — **Matthew 7:7**