### PR TITLE
Step 25: Added "ask" support for variable updates with built-in validation: age = ask "What is your age again? "

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ set(JESUS_CPP_FILES
     src/jesus/ast/stmt/create_var_type_stmt.cpp
     src/jesus/ast/stmt/create_var_stmt.cpp
     src/jesus/ast/stmt/create_var_with_ask_stmt.cpp
+    src/jesus/ast/stmt/update_var_with_ask_stmt.cpp
     src/jesus/ast/stmt/for_each_stmt.cpp
     src/jesus/ast/stmt/output_stmt.cpp
     src/jesus/ast/stmt/repeat_times_stmt.cpp

--- a/src/jesus/ast/stmt/update_var_with_ask_stmt.cpp
+++ b/src/jesus/ast/stmt/update_var_with_ask_stmt.cpp
@@ -1,0 +1,7 @@
+#include "update_var_with_ask_stmt.hpp"
+#include "../../interpreter/stmt_visitor.hpp"
+
+void UpdateVarWithAskStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visitUpdateVarWithAsk(*this);
+}

--- a/src/jesus/ast/stmt/update_var_with_ask_stmt.hpp
+++ b/src/jesus/ast/stmt/update_var_with_ask_stmt.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "../expr/expr.hpp"
+#include "../../types/creation_type.hpp"
+#include "stmt.hpp"
+#include <string>
+#include <memory>
+
+/**
+ * @brief Represents the update of an existing variable using 'ask'.
+ *
+ * "Be transformed by the renewing of your mind..." — Romans 12:2
+ */
+class UpdateVarWithAskStmt : public Stmt
+{
+public:
+    const CreationType var_type;
+    const std::string var_name;
+    std::shared_ptr<Expr> ask_expr; // Type is AskExpr
+
+    UpdateVarWithAskStmt(const CreationType type, std::string name, std::unique_ptr<Expr> ask_expr)
+        : var_type(type), var_name(name), ask_expr(std::move(ask_expr)) {}
+
+    void accept(StmtVisitor &visitor) const override;
+
+    /**
+     * @brief Returns a string representation of the statement.
+     *
+     * "For nothing is hidden that will not be made manifest, nor is anything
+     * secret that will not be known and come to light." — Luke 8:17
+     */
+    std::string toString() const override
+    {
+
+        std::string str = "UpdateVarWithAskStmt(" + var_name + " = " + ask_expr->toString() + ")";
+
+        return str;
+    }
+};

--- a/src/jesus/interpreter/interpreter.hpp
+++ b/src/jesus/interpreter/interpreter.hpp
@@ -172,22 +172,36 @@ private:
     void visitCreateVar(const CreateVarStmt &stmt) override;
 
     /**
-     * @brief Handles the creation of a variable initialized via an 'ask' expression.
+     * @brief Asks for a value and validate it.
      *
-     * This method drives the interactive flow of variable creation when
-     * the initialization expression is an 'ask' prompt. It:
+     * This method drives the interactive flow of variable creation/update when
+     * the expression is an 'ask' prompt. It:
      * - Evaluates the prompt to obtain the question.
      * - Repeatedly asks the user for input until the provided value
      *   passes the CreationType's validation constraints.
-     * - Creates the variable in the runtime environment with the validated value.
+     * - Return the validated value
      *
-     * This enables type-safe variable initialization with built-in validation.
+     * This enables type-safe variable assignment with built-in validation.
+     */
+    Value askAndValidate(const std::shared_ptr<Expr> ask_expr, const CreationType &var_type);
+
+    /**
+     * @brief Handles the creation of a variable initialized via an 'ask' expression.
+     *
+     * * E.g.: create text name = ask "What is your name? "
      */
     void visitCreateVarWithAsk(const CreateVarWithAskStmt &stmt) override;
 
     void visitCreateVarType(const CreateVarTypeStmt &stmt) override;
 
     void visitUpdateVar(const UpdateVarStmt &stmt) override;
+
+    /**
+     * @brief Handles the update of a variable using 'ask' expression.
+     *
+     * E.g.: age = ask "What is your age again?"
+     */
+    void visitUpdateVarWithAsk(const UpdateVarWithAskStmt &stmt) override;
 
     void visitOutput(const OutputStmt &stmt) override;
 

--- a/src/jesus/interpreter/stmt_visitor.hpp
+++ b/src/jesus/interpreter/stmt_visitor.hpp
@@ -2,8 +2,9 @@
 
 #include "../ast/stmt/create_var_type_stmt.hpp"
 #include "../ast/stmt/create_var_stmt.hpp"
-#include "../ast/stmt/create_var_with_ask_stmt.hpp"
 #include "../ast/stmt/update_var_stmt.hpp"
+#include "../ast/stmt/create_var_with_ask_stmt.hpp"
+#include "../ast/stmt/update_var_with_ask_stmt.hpp"
 #include "../ast/stmt/output_statement.hpp"
 #include "../ast/stmt/repeat_while_stmt.hpp"
 #include "../ast/stmt/repeat_times_stmt.hpp"
@@ -50,6 +51,7 @@ public:
     virtual void visitCreateVar(const CreateVarStmt &stmt) = 0;
     virtual void visitCreateVarWithAsk(const CreateVarWithAskStmt &stmt) = 0;
     virtual void visitUpdateVar(const UpdateVarStmt &stmt) = 0;
+    virtual void visitUpdateVarWithAsk(const UpdateVarWithAskStmt &stmt) = 0;
     virtual void visitOutput(const OutputStmt &stmt) = 0;
     virtual void visitRepeatWhile(const RepeatWhileStmt &stmt) = 0;
     virtual void visitRepeatTimes(const RepeatTimesStmt &stmt) = 0;

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -77,7 +77,7 @@ namespace grammar
     // ----------
     inline auto CreateVarType = std::make_shared<CreateVarTypeStmtRule>();
     inline auto CreateVar = std::make_shared<CreateVarStmtRule>(Expression, Ask);
-    inline auto UpdateVar = std::make_shared<UpdateVarStmtRule>(Expression);
+    inline auto UpdateVar = std::make_shared<UpdateVarStmtRule>(Expression, Ask);
 
     /**
      * @brief Set the Expression rule to something (for now just Primary)

--- a/src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
@@ -39,6 +39,8 @@ std::unique_ptr<Stmt> CreateVarStmtRule::parse(ParserContext &ctx)
             if (!ask_expr)
                 throw std::runtime_error("Expected a text literal or a text-typed variable after 'ask' (e.g., ask \"What is your name?\" or ask question).");
 
+            ctx.registerVarType(varName, creationType->name);
+
             return std::make_unique<CreateVarWithAskStmt>(*creationType, varName, std::move(ask_expr));
         }
         value = expression->parse(ctx);

--- a/src/jesus/parser/grammar/stmt/update_var_stmt_rule.hpp
+++ b/src/jesus/parser/grammar/stmt/update_var_stmt_rule.hpp
@@ -2,14 +2,16 @@
 
 #include "../grammar_rule.hpp"
 #include "../../../ast/stmt/stmt.hpp"
+#include "../expr/ask_expr_rule.hpp"
 
 class UpdateVarStmtRule
 {
     std::shared_ptr<IGrammarRule> expression;
+    std::shared_ptr<AskExprRule> ask;
 
 public:
-    explicit UpdateVarStmtRule(std::shared_ptr<IGrammarRule> expression)
-        : expression(std::move(expression)) {}
+    explicit UpdateVarStmtRule(std::shared_ptr<IGrammarRule> expression, std::shared_ptr<AskExprRule> ask_expr)
+        : expression(std::move(expression)), ask(std::move(ask_expr)) {}
 
     std::unique_ptr<Stmt> parse(ParserContext &ctx);
 };

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -181,3 +181,11 @@ fourteen
 say idade
 create number year = ask PI
 create number year2 = ask temperature
+age = ask "What is your age again? "
+fourty
+eternal
+2025
+say age
+question = ask question
+What is the new question?
+say question

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -148,4 +148,8 @@ Qual sua idade? Validation failed: Invalid number: 'fourteen'
 Qual sua idade? (Jesus) (double) 33.000000
 (Jesus) ❌ Error: Variable 'PI' not found. Are you really sure it was declared?
 (Jesus) ❌ Error: Variable 'temperature' not found. Are you really sure it was declared?
+(Jesus) What is your age again? Validation failed: Invalid number: 'fourty'
+What is your age again? Validation failed: Invalid number: 'eternal'
+What is your age again? (Jesus) (double) 2025.000000
+(Jesus) What is your age? (Jesus) What is the new question?
 (Jesus) 


### PR DESCRIPTION
# Description

This PR extends the `ask` expression functionality to variable updates, allowing users to update an existing variable based on interactive input with built-in validation.

### Changes included:

1. **AST**
   * Added `UpdateVarWithAskStmt` to represent variable updates using `ask`.

2. **Parser**

   * Updated `UpdateVarStmtRule` to parse `ask` expressions in `update` statements.
     Example:

     ```
     create int age = 7
     age = ask "What is your age again? "
     say age
     ```

3. **Interpreter**

   * Introduced `askAndValidate` helper method to centralize:

     * Prompt display
     * Input capture
     * Whitespace trimming
     * Parsing and type validation
     
   * Implemented `visitUpdateVarWithAsk` to handle `ask`-based updates using the shared validation logic.

# ✝️ Wisdom

> "For everyone who asks receives; the one who seeks finds; and to the one who knocks, the door will be opened." — **Matthew 7:8**


