### PR TITLE
Step 26: Added basic support for class creation, called 'creation' in Jesus language: creation User: amen 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ set(JESUS_CPP_FILES
     # --------------
     src/jesus/ast/stmt/break_stmt.cpp
     src/jesus/ast/stmt/continue_stmt.cpp
+    src/jesus/ast/stmt/create_class_stmt.cpp
     src/jesus/ast/stmt/create_var_type_stmt.cpp
     src/jesus/ast/stmt/create_var_stmt.cpp
     src/jesus/ast/stmt/create_var_with_ask_stmt.cpp
@@ -85,6 +86,7 @@ set(JESUS_CPP_FILES
     # -----------------
     # Statement parsers
     # -----------------
+    src/jesus/parser/grammar/stmt/create_class_stmt_rule.cpp
     src/jesus/parser/grammar/stmt/create_var_type_stmt_rule.cpp
     src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
     src/jesus/parser/grammar/stmt/update_var_stmt_rule.cpp

--- a/src/jesus/ast/stmt/create_class_stmt.cpp
+++ b/src/jesus/ast/stmt/create_class_stmt.cpp
@@ -1,0 +1,7 @@
+#include "create_class_stmt.hpp"
+#include "../../interpreter/stmt_visitor.hpp"
+
+void CreateClassStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visitCreateClass(*this);
+}

--- a/src/jesus/ast/stmt/create_class_stmt.hpp
+++ b/src/jesus/ast/stmt/create_class_stmt.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include "stmt.hpp"
+#include <string>
+#include <vector>
+#include <memory>
+
+/**
+ * @brief Represents the 'creation' of a new class in the Jesus language.
+ *
+ * In the Jesus language, `creation` is the equivalent of a "class" in other
+ * programming languages. It defines a new user-defined type, initially with
+ * an empty body, which can later contain attributes and methods.
+ *
+ * Usage:
+ * @code
+ *   creation Person: amen
+ * @endcode
+ *
+ * "God saw all that He had made, and it was very good..." — Genesis 1:31
+ */
+class CreateClassStmt : public Stmt
+{
+public:
+    std::string name;
+    std::string module_name;
+    std::vector<std::shared_ptr<Stmt>> body;
+
+    CreateClassStmt(const std::string &name, const std::string &module_name,
+                    const std::vector<std::shared_ptr<Stmt>> &body)
+        : name(name), module_name(module_name), body(body) {}
+
+    void accept(StmtVisitor &visitor) const override;
+};

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -119,6 +119,19 @@ void Interpreter::visitUpdateVarWithAsk(const UpdateVarWithAskStmt &stmt)
     updateVariable(stmt.var_name, value);
 }
 
+void Interpreter::visitCreateClass(const CreateClassStmt &stmt)
+{
+    std::vector<std::shared_ptr<IConstraint>> constraints; // no constraints yet
+
+    auto userClass = std::make_shared<CreationType>(
+        PrimitiveType::Class,
+        stmt.name,
+        stmt.module_name,
+        constraints);
+
+    KnownTypes::registerType(std::move(userClass));
+}
+
 void Interpreter::visitCreateVarType(const CreateVarTypeStmt &stmt)
 {
     auto custom_type = std::make_shared<CreationType>(

--- a/src/jesus/interpreter/interpreter.hpp
+++ b/src/jesus/interpreter/interpreter.hpp
@@ -192,6 +192,8 @@ private:
      */
     void visitCreateVarWithAsk(const CreateVarWithAskStmt &stmt) override;
 
+    void visitCreateClass(const CreateClassStmt &stmt) override;
+
     void visitCreateVarType(const CreateVarTypeStmt &stmt) override;
 
     void visitUpdateVar(const UpdateVarStmt &stmt) override;

--- a/src/jesus/interpreter/stmt_visitor.hpp
+++ b/src/jesus/interpreter/stmt_visitor.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../ast/stmt/create_class_stmt.hpp"
 #include "../ast/stmt/create_var_type_stmt.hpp"
 #include "../ast/stmt/create_var_stmt.hpp"
 #include "../ast/stmt/update_var_stmt.hpp"
@@ -47,6 +48,7 @@
 class StmtVisitor
 {
 public:
+    virtual void visitCreateClass(const CreateClassStmt &stmt) = 0;
     virtual void visitCreateVarType(const CreateVarTypeStmt &stmt) = 0;
     virtual void visitCreateVar(const CreateVarStmt &stmt) = 0;
     virtual void visitCreateVarWithAsk(const CreateVarWithAskStmt &stmt) = 0;

--- a/src/jesus/lexer/lexer.cpp
+++ b/src/jesus/lexer/lexer.cpp
@@ -188,8 +188,14 @@ TokenType recognize_token_type(const std::string &word)
     if (word == "say")
         return TokenType::SAY;
 
+    if (word == "amen")
+        return TokenType::AMEN;
+
     if (word == "warn")
         return TokenType::WARN;
+
+    if (word == "creation")
+        return TokenType::CREATION;
 
     if (isInteger(word))
         return TokenType::INT;
@@ -273,6 +279,13 @@ std::vector<Token> lex(const std::string &input)
         if (c == '/')
         {
             tokens.emplace_back(TokenType::SLASH, "/", Value("/"));
+            i++;
+            continue;
+        }
+
+        if (c == ':')
+        {
+            tokens.emplace_back(TokenType::COLON, ":", Value(":"));
             i++;
             continue;
         }

--- a/src/jesus/lexer/token.hpp
+++ b/src/jesus/lexer/token.hpp
@@ -56,6 +56,8 @@ public:
     {
         switch (type)
         {
+        case TokenType::CREATION:
+            return "CREATION";
         case TokenType::Note:
             return "NOTE";
         case TokenType::Todo:
@@ -106,6 +108,8 @@ public:
 
         case TokenType::MINUS:
             return "MINUS";
+        case TokenType::COLON:
+            return "COLON";
 
         case TokenType::INT:
             return "INT(" + lexeme + ")";
@@ -129,6 +133,9 @@ public:
 
         case TokenType::OTHERWISE:
             return "OTHERWISE";
+
+        case TokenType::AMEN:
+            return "AMEN";
 
         case TokenType::END_OF_FILE:
             return "EOF";

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -41,7 +41,9 @@ enum class TokenType
     MINUS,          // -
     STAR,           // *
     SLASH,          // /
+    COLON,          // ':' (Begining of a block)
 
+    CREATION,       // creation Person: amen (class in other langs)
     CREATE,         // create days = 7
     ASK,            // create int age = ask "What is your age?"
     SAY,            // "say" prints to stdout
@@ -68,5 +70,6 @@ enum class TokenType
     IF,
     OTHERWISE,
 
+    AMEN,           // amen (end of blocks in Jesus lang; '}' in other langs)
     END_OF_FILE
 };

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -21,6 +21,7 @@
 
 #include "expr/ask_expr_rule.hpp"
 #include "expr/conditional_expr_rule.hpp"
+#include "stmt/create_class_stmt_rule.hpp"
 #include "stmt/create_var_type_stmt_rule.hpp"
 #include "stmt/create_var_stmt_rule.hpp"
 #include "stmt/update_var_stmt_rule.hpp"
@@ -75,6 +76,7 @@ namespace grammar
     // ----------
     // Statements
     // ----------
+    inline auto CreateClass = std::make_shared<CreateClassStmtRule>();
     inline auto CreateVarType = std::make_shared<CreateVarTypeStmtRule>();
     inline auto CreateVar = std::make_shared<CreateVarStmtRule>(Expression, Ask);
     inline auto UpdateVar = std::make_shared<UpdateVarStmtRule>(Expression, Ask);

--- a/src/jesus/parser/grammar/stmt/create_class_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_class_stmt_rule.cpp
@@ -1,0 +1,28 @@
+#include "create_class_stmt_rule.hpp"
+#include "../../../ast/stmt/create_class_stmt.hpp"
+#include <stdexcept>
+
+std::unique_ptr<Stmt> CreateClassStmtRule::parse(ParserContext &ctx)
+{
+    if (!ctx.match(TokenType::CREATION))
+        return nullptr;
+
+    if (!ctx.match(TokenType::IDENTIFIER))
+        throw std::runtime_error("Expected class name after 'creation'");
+
+    std::string className = ctx.previous().lexeme;
+
+    if (!ctx.match(TokenType::COLON))
+        throw std::runtime_error("Expected ':' after class name in creation statement.");
+
+    // (MVP: no parsing body for the moment; only spirit for now)
+    std::vector<std::shared_ptr<Stmt>> body;
+
+    if (!ctx.match(TokenType::AMEN))
+        throw std::runtime_error("Expected 'amen' after ':' in creation statement.");
+
+    ctx.registerClassName(className);
+
+    std::string module_name = "core"; // FIXME: consider user modules.
+    return std::make_unique<CreateClassStmt>(className, module_name, body);
+}

--- a/src/jesus/parser/grammar/stmt/create_class_stmt_rule.hpp
+++ b/src/jesus/parser/grammar/stmt/create_class_stmt_rule.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "../../parser_context.hpp"
+#include "../../../ast/stmt/stmt.hpp"
+
+class CreateClassStmtRule
+{
+
+public:
+    explicit CreateClassStmtRule() {}
+
+    std::unique_ptr<Stmt> parse(ParserContext &ctx);
+};

--- a/src/jesus/parser/parser.cpp
+++ b/src/jesus/parser/parser.cpp
@@ -52,6 +52,11 @@ std::unique_ptr<Stmt> parse(const std::vector<Token> &tokens, ParserContext &con
     }
 
     int snapshot = context.snapshot();
+    auto createClassStmt = grammar::CreateClass->parse(context);
+    if (createClassStmt)
+        return createClassStmt;
+
+    context.restore(snapshot);
     auto createVarTypeStmt = grammar::CreateVarType->parse(context);
     if (createVarTypeStmt)
         return createVarTypeStmt;

--- a/src/jesus/parser/parser_context.hpp
+++ b/src/jesus/parser/parser_context.hpp
@@ -8,7 +8,6 @@
 #include <vector>
 #include <stdexcept>
 
-
 class Interpreter; // Forward declaration
 
 /**
@@ -147,7 +146,6 @@ public:
         current = pos;
     }
 
-
     /**
      * @brief Return current token position
      */
@@ -156,15 +154,23 @@ public:
         return this->current;
     }
 
-    void restore(int snapshot) {
+    void restore(int snapshot)
+    {
         current = snapshot;
     }
 
-    void registerVarType(const std::string& varName, const std::string& typeName) {
+    void registerVarType(const std::string &varName, const std::string &typeName)
+    {
         SemanticAnalyzer::registerVarType(varName, typeName);
     }
 
-    const CreationType* getVarType(const std::string& varName) {
+    void registerClassName(const std::string &className)
+    {
+        SemanticAnalyzer::registerClassName(className);
+    }
+
+    const CreationType *getVarType(const std::string &varName)
+    {
         return SemanticAnalyzer::getVarType(varName);
     }
 

--- a/src/jesus/semantic/semantic_analyser.hpp
+++ b/src/jesus/semantic/semantic_analyser.hpp
@@ -1,12 +1,18 @@
 #pragma once
 
 #include <unordered_map>
+#include <unordered_set>
 #include "../types/creation_type.hpp"
 #include "../types/known_types.hpp"
 
 class SemanticAnalyzer
 {
 public:
+    static void registerClassName(const std::string &className)
+    {
+        classNames.insert(className);
+    }
+
     static void registerVarType(const std::string &varName, const std::string &typeName)
     {
         variableTypes[varName] = typeName;
@@ -25,6 +31,12 @@ public:
         return varType;
     }
 
+    static bool isClassKnown(const std::string &className)
+    {
+        return classNames.find(className) != classNames.end();
+    }
+
 private:
     inline static std::unordered_map<std::string, std::string> variableTypes; // varName: typeName
+    inline static std::unordered_set<std::string> classNames;
 };

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -189,3 +189,6 @@ say age
 question = ask question
 What is the new question?
 say question
+creation User: amen
+create User adam = 1
+say adam

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -152,4 +152,5 @@ Qual sua idade? (Jesus) (double) 33.000000
 What is your age again? Validation failed: Invalid number: 'eternal'
 What is your age again? (Jesus) (double) 2025.000000
 (Jesus) What is your age? (Jesus) What is the new question?
+(Jesus) (Jesus) (Jesus) (int) 1
 (Jesus) 

--- a/src/jesus/types/creation_type.hpp
+++ b/src/jesus/types/creation_type.hpp
@@ -5,6 +5,7 @@
 
 enum class PrimitiveType
 {
+    Class,
     Number,
     Text
 };
@@ -65,6 +66,8 @@ public:
     {
         switch (primitive_type)
         {
+        case PrimitiveType::Class:
+            return "creation";
         case PrimitiveType::Number:
             return "number";
         case PrimitiveType::Text:


### PR DESCRIPTION
# Description:

This PR introduces foundational support for the `creation` keyword in the Jesus language, enabling the definition of user-defined classes (called "creations" to align with the language's biblical inspiration). It follows a clear, incremental approach across three commits:

1. **AST**  
   Added `CreateClassStmt` AST node to represent class creation statements, capturing the class name and an (initially) empty body.

2. **Parser**  
   Implemented `CreateClassStmtRule` and integrated it into the main parser, enabling syntax parsing of `creation ClassName: amen` blocks.

3. **Interpreter**  
   Added `visitCreateClass` method to the interpreter, registering the new class type in the runtime’s type system (`KnownTypes`), allowing user-defined classes to exist during execution.

### Usage

Since attributes and methods are not yet supported, you can assign 'number' and 'text' when instantiating a class.
Example:

```
creation User: amen 

create User adam = 1
create User eve = "Eve"

say adam
say eve
```

The code above will output '1' and 'Even', the values of of `adam` and ` eve` variables.

---

# ✝️ Wisdom

> *"By the word of the LORD the heavens were made, their starry host by the breath of his mouth."*  
> — **Psalm 33:6**

Just as God’s spoken word brought creation into existence, these changes empower the language to bring user-defined creations (classes) to life through code.
