### PR TITLE
Step 28: Added IncompleteBlockStmt to support multi-line class creation in REPL with 'amen'

### DIFF
--- a/src/jesus/ast/stmt/incomplete_block_stmt.hpp
+++ b/src/jesus/ast/stmt/incomplete_block_stmt.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include "stmt.hpp"
+
+/**
+ * @brief Represents an incomplete block stmt
+ *
+ * When someone is creating a class in the REPL, where the class body
+ * can't be written in a single line, this statement tells the scanner to
+ * keep consuming more tokens.
+ */
+class IncompleteBlockStmt : public Stmt
+{
+public:
+    void accept(StmtVisitor &visitor) const override {};
+    bool inProgress() const override { return true; }
+};

--- a/src/jesus/ast/stmt/stmt.hpp
+++ b/src/jesus/ast/stmt/stmt.hpp
@@ -13,4 +13,13 @@ public:
     virtual ~Stmt() = default;
 
     virtual void accept(StmtVisitor &visitor) const = 0;
+
+    /**
+     * @brief Tells if more tokens are expected.
+     *
+     * Useful when someone is creating a class in the REPL, where the class body
+     * can't be written in a single line. This tells the scanner to keep
+     * scanning tokens before executing the AST.
+     */
+    virtual bool inProgress() const { return false; }
 };

--- a/src/jesus/main.cpp
+++ b/src/jesus/main.cpp
@@ -13,6 +13,7 @@ int main()
 
     Heart heart;
     Interpreter jesus(&heart);
+    std::string buffer;
     std::string line;
 
     KnownTypes::registerBuiltInTypes();
@@ -20,15 +21,23 @@ int main()
     std::cout << "(Jesus) ";
     while (std::getline(std::cin, line))
     {
+        if (!line.empty())
+            line += "\n";
+
+        buffer += line;
+
         try
         {
 
-            auto tokens = lex(line);
+            auto tokens = lex(buffer);
             ParserContext context(tokens, &jesus);
-            auto you = parse(tokens, context);  // AST - Abstract Syntax Tree
+            auto you = parse(tokens, context); // AST - Abstract Syntax Tree
 
             if (you)
             {
+                if (you->inProgress())
+                    continue;
+
                 jesus.loves(you);
             }
         }
@@ -45,6 +54,7 @@ int main()
         //     std::cout << "[" << token.type << ": " << token.value << "]\n";
         // }
 
+        buffer.clear();
         std::cout << "(Jesus) ";
     }
 

--- a/src/jesus/parser/grammar/stmt/create_class_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_class_stmt_rule.cpp
@@ -1,5 +1,6 @@
 #include "create_class_stmt_rule.hpp"
 #include "../../../ast/stmt/create_class_stmt.hpp"
+#include "../../../ast/stmt/incomplete_block_stmt.hpp"
 #include <stdexcept>
 
 std::unique_ptr<Stmt> CreateClassStmtRule::parse(ParserContext &ctx)
@@ -17,6 +18,11 @@ std::unique_ptr<Stmt> CreateClassStmtRule::parse(ParserContext &ctx)
 
     // (MVP: no parsing body for the moment; only spirit for now)
     std::vector<std::shared_ptr<Stmt>> body;
+
+    if (ctx.isAtEnd())
+    {
+        return std::make_unique<IncompleteBlockStmt>();
+    }
 
     if (!ctx.match(TokenType::AMEN))
         throw std::runtime_error("Expected 'amen' after ':' in creation statement.");

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -192,3 +192,9 @@ say question
 creation User: amen
 create User adam = 1
 say adam
+creation MultiLineClass:
+
+
+amen
+create MultiLineClass multiline = 12
+say multiline

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -153,4 +153,5 @@ What is your age again? Validation failed: Invalid number: 'eternal'
 What is your age again? (Jesus) (double) 2025.000000
 (Jesus) What is your age? (Jesus) What is the new question?
 (Jesus) (Jesus) (Jesus) (int) 1
+(Jesus) (Jesus) (Jesus) (int) 12
 (Jesus) 


### PR DESCRIPTION
# Description

This PR enables multi-line class creation in the REPL. Users can now type:

```
creation User:

amen
```

Previously, it only supported single-line statements like this:
```
creation User: amen 
```

### Summary

- The parser recognizes the colon (`:`) and waits until `amen` is entered.  
- Introduces `IncompleteBlockStmt` to mark statements that are still “in progress”.  
- Prepares the foundation for adding class attributes and methods in future PRs.  

### Key changes
- `Stmt` now has `inProgress()` virtual method.  
- `IncompleteBlockStmt` indicates blocks that are not yet complete.  
- `CreateClassStmtRule` returns `IncompleteBlockStmt` if the REPL reaches the end of current input before `amen`.  

**Notes:**  
- This PR focuses only on multi-line parsing. Attribute/method support will be implemented in a separate PR to keep each change focused and reviewable.  

✝️ Wisdom

> “Who marked off its dimensions? Surely you know!
>    Who stretched a measuring line across it?.” — **Job 38:5**
