### PR TITLE
Step 29: Expanded class creation syntax with multilingual support (English + Portuguese): haja Luz (let there be Light)

### DIFF
--- a/src/jesus/ast/stmt/create_class_stmt.hpp
+++ b/src/jesus/ast/stmt/create_class_stmt.hpp
@@ -7,13 +7,13 @@
 /**
  * @brief Represents the 'creation' of a new class in the Jesus language.
  *
- * In the Jesus language, `creation` is the equivalent of a "class" in other
+ * In the Jesus language, `let there be` is the equivalent of a "class" in other
  * programming languages. It defines a new user-defined type, initially with
  * an empty body, which can later contain attributes and methods.
  *
  * Usage:
  * @code
- *   creation Person: amen
+ *   let there be Person: amen
  * @endcode
  *
  * "God saw all that He had made, and it was very good..." — Genesis 1:31

--- a/src/jesus/lexer/lexer.cpp
+++ b/src/jesus/lexer/lexer.cpp
@@ -194,8 +194,14 @@ TokenType recognize_token_type(const std::string &word)
     if (word == "warn")
         return TokenType::WARN;
 
-    if (word == "creation")
-        return TokenType::CREATION;
+    if (word == "let")
+        return TokenType::LET;
+
+    if (word == "there")
+        return TokenType::THERE;
+
+    if (word == "be")
+        return TokenType::BE;
 
     if (isInteger(word))
         return TokenType::INT;

--- a/src/jesus/lexer/lexer.cpp
+++ b/src/jesus/lexer/lexer.cpp
@@ -92,13 +92,13 @@ TokenType recognize_token_type(const std::string &word)
     if (word == "end")
         return TokenType::EndNote;
 
-    if (word == "not")
+    if (word == "not" || word == "não")
         return TokenType::NOT;
 
-    if (word == "and")
+    if (word == "and" || word == "e")
         return TokenType::AND;
 
-    if (word == "or")
+    if (word == "or" || word == "ou")
         return TokenType::OR;
 
     if (word == "vs" || word == "versus")
@@ -188,7 +188,7 @@ TokenType recognize_token_type(const std::string &word)
     if (word == "say")
         return TokenType::SAY;
 
-    if (word == "amen")
+    if (word == "amen" || word == "amém")
         return TokenType::AMEN;
 
     if (word == "warn")
@@ -203,6 +203,9 @@ TokenType recognize_token_type(const std::string &word)
     if (word == "be")
         return TokenType::BE;
 
+    if (word == "haja")
+        return TokenType::HAJA;
+
     if (isInteger(word))
         return TokenType::INT;
 
@@ -212,13 +215,13 @@ TokenType recognize_token_type(const std::string &word)
     if (word[0] == '"')
         return TokenType::STRING;
 
-    if (word == "create")
+    if (word == "create" || word == "criar")
         return TokenType::CREATE;
 
-    if (word == "if")
+    if (word == "if" || word == "se")
         return TokenType::IF;
 
-    if (word == "otherwise")
+    if (word == "otherwise" || word == "senão")
         return TokenType::OTHERWISE;
 
     return TokenType::IDENTIFIER;

--- a/src/jesus/lexer/token.hpp
+++ b/src/jesus/lexer/token.hpp
@@ -62,6 +62,8 @@ public:
             return "THERE";
         case TokenType::BE:
             return "BE";
+        case TokenType::HAJA:
+            return "HAJA";
         case TokenType::Note:
             return "NOTE";
         case TokenType::Todo:

--- a/src/jesus/lexer/token.hpp
+++ b/src/jesus/lexer/token.hpp
@@ -56,8 +56,12 @@ public:
     {
         switch (type)
         {
-        case TokenType::CREATION:
-            return "CREATION";
+        case TokenType::LET:
+            return "LET";
+        case TokenType::THERE:
+            return "THERE";
+        case TokenType::BE:
+            return "BE";
         case TokenType::Note:
             return "NOTE";
         case TokenType::Todo:

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -46,6 +46,7 @@ enum class TokenType
     LET,            // let there be Person: amen (class in other langs)
     THERE,          // let there be Person: amen (class in other langs)
     BE,             // let there be Person: amen (class in other langs)
+    HAJA,           // haja Luz: amén (portuguese way of creating class)
     CREATE,         // create days = 7
     ASK,            // create int age = ask "What is your age?"
     SAY,            // "say" prints to stdout

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -43,7 +43,9 @@ enum class TokenType
     SLASH,          // /
     COLON,          // ':' (Begining of a block)
 
-    CREATION,       // creation Person: amen (class in other langs)
+    LET,            // let there be Person: amen (class in other langs)
+    THERE,          // let there be Person: amen (class in other langs)
+    BE,             // let there be Person: amen (class in other langs)
     CREATE,         // create days = 7
     ASK,            // create int age = ask "What is your age?"
     SAY,            // "say" prints to stdout

--- a/src/jesus/parser/grammar/stmt/create_class_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_class_stmt_rule.cpp
@@ -5,16 +5,23 @@
 
 std::unique_ptr<Stmt> CreateClassStmtRule::parse(ParserContext &ctx)
 {
-    const std::string stmt = "let there be";
+    std::string stmt = "let there be";
 
-    if (!ctx.match(TokenType::LET))
-        return nullptr;
+    if (ctx.match(TokenType::HAJA))
+    {
+        stmt = "haja"; // haja Luz: amém
+    }
+    else
+    {
+        if (!ctx.match(TokenType::LET))
+            return nullptr;
 
-    if (!ctx.match(TokenType::THERE))
-        return nullptr;
+        if (!ctx.match(TokenType::THERE))
+            return nullptr;
 
-    if (!ctx.match(TokenType::BE))
-        throw std::runtime_error("Expected 'be' after 'let there'");
+        if (!ctx.match(TokenType::BE))
+            throw std::runtime_error("Expected 'be' after 'let there'");
+    }
 
     if (!ctx.match(TokenType::IDENTIFIER))
         throw std::runtime_error("Expected class name after '" + stmt + "'");

--- a/src/jesus/parser/grammar/stmt/create_class_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_class_stmt_rule.cpp
@@ -28,11 +28,20 @@ std::unique_ptr<Stmt> CreateClassStmtRule::parse(ParserContext &ctx)
 
     std::string className = ctx.previous().lexeme;
 
-    if (!ctx.match(TokenType::COLON))
-        throw std::runtime_error("Expected ':' after class name in '" + stmt + "' statement.");
-
     // (MVP: no parsing body for the moment; only spirit for now)
     std::vector<std::shared_ptr<Stmt>> body;
+    std::string module_name = "core"; // FIXME: consider user modules.
+
+    if (ctx.isAtEnd())
+    {
+        // Allowing 'empty-bodied' classes without ': amen'.
+        // Just: let there be Light
+        ctx.registerClassName(className);
+        return std::make_unique<CreateClassStmt>(className, module_name, body);
+    }
+
+    if (!ctx.match(TokenType::COLON))
+        throw std::runtime_error("Expected ':' after class name in '" + stmt + "' statement.");
 
     if (ctx.isAtEnd())
     {
@@ -43,7 +52,5 @@ std::unique_ptr<Stmt> CreateClassStmtRule::parse(ParserContext &ctx)
         throw std::runtime_error("Expected 'amen' after ':' in '" + stmt + "' statement.");
 
     ctx.registerClassName(className);
-
-    std::string module_name = "core"; // FIXME: consider user modules.
     return std::make_unique<CreateClassStmt>(className, module_name, body);
 }

--- a/src/jesus/parser/grammar/stmt/create_class_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_class_stmt_rule.cpp
@@ -5,16 +5,24 @@
 
 std::unique_ptr<Stmt> CreateClassStmtRule::parse(ParserContext &ctx)
 {
-    if (!ctx.match(TokenType::CREATION))
+    const std::string stmt = "let there be";
+
+    if (!ctx.match(TokenType::LET))
         return nullptr;
 
+    if (!ctx.match(TokenType::THERE))
+        return nullptr;
+
+    if (!ctx.match(TokenType::BE))
+        throw std::runtime_error("Expected 'be' after 'let there'");
+
     if (!ctx.match(TokenType::IDENTIFIER))
-        throw std::runtime_error("Expected class name after 'creation'");
+        throw std::runtime_error("Expected class name after '" + stmt + "'");
 
     std::string className = ctx.previous().lexeme;
 
     if (!ctx.match(TokenType::COLON))
-        throw std::runtime_error("Expected ':' after class name in creation statement.");
+        throw std::runtime_error("Expected ':' after class name in '" + stmt + "' statement.");
 
     // (MVP: no parsing body for the moment; only spirit for now)
     std::vector<std::shared_ptr<Stmt>> body;
@@ -25,7 +33,7 @@ std::unique_ptr<Stmt> CreateClassStmtRule::parse(ParserContext &ctx)
     }
 
     if (!ctx.match(TokenType::AMEN))
-        throw std::runtime_error("Expected 'amen' after ':' in creation statement.");
+        throw std::runtime_error("Expected 'amen' after ':' in '" + stmt + "' statement.");
 
     ctx.registerClassName(className);
 

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -189,12 +189,25 @@ say age
 question = ask question
 What is the new question?
 say question
-creation User: amen
+let there be User: amen
 create User adam = 1
 say adam
-creation MultiLineClass:
+let there be MultiLineClass:
 
 
 amen
 create MultiLineClass multiline = 12
 say multiline
+say "igual" se 1 == 1 senão "diferente"
+criar text nome = "Jesus"
+say não nome
+criar number sim = 1
+criar number nao = 0
+say sim ==  1 e nao == 0
+say sim == 1 ou nao == 0
+haja Luz: amém
+criar Luz dia = 1
+say dia
+haja Canção
+criar Canção louvor = "Me ama, Ele me ama..."
+say louvor

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -154,4 +154,10 @@ What is your age again? (Jesus) (double) 2025.000000
 (Jesus) What is your age? (Jesus) What is the new question?
 (Jesus) (Jesus) (Jesus) (int) 1
 (Jesus) (Jesus) (Jesus) (int) 12
+(Jesus) igual
+(Jesus) (Jesus) (logic) 0
+(Jesus) (Jesus) (Jesus) (logic) 1
+(Jesus) (logic) 1
+(Jesus) (Jesus) (Jesus) (int) 1
+(Jesus) (Jesus) (Jesus) Me ama, Ele me ama...
 (Jesus) 

--- a/src/jesus/utils/string_utils.hpp
+++ b/src/jesus/utils/string_utils.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <cctype>
+#include <vector>
 
 namespace utils
 {
@@ -30,4 +31,73 @@ namespace utils
 
         return str.substr(start, end - start + 1);
     }
+
+    /**
+     * @brief Extracts each UTF-8 character (1 or 2 bytes for Portuguese letters)
+     *
+     * @param source UTF-8 encoded string.
+     * @return std::vector<std::string> Vector of UTF-8 characters.
+     */
+    inline std::vector<std::string> to_utf8(const std::string &source)
+    {
+        std::vector<std::string> chars;
+        size_t len;
+
+        for (size_t i = 0; i < source.size();)
+        {
+            unsigned char c = source[i];
+            len = 1;
+
+            // -----------------------------------------------------------------
+            // 'c' is an unsigned char representing one byte from a UTF-8 encoded string.
+            // In UTF-8, a single "logical character" may take 1 to 4 bytes.
+            // ASCII characters (a-z, 0-9, etc.) are 1 byte, with the most significant bit = 0.
+            // Portuguese accented letters like ç, é, ã are 2 bytes in UTF-8.
+            //
+            // 0xF0 in binary: 1111 0000
+            // 'c & 0xF0' masks the top 4 bits of the byte.
+            // UTF-8 2-byte sequences always start with a byte whose top 4 bits are 1100 (binary for 0xC).
+            //
+            // 11000000 = 0xC0
+            // c & 0xF0 → isolate the top 4 bits of the first byte.
+            // Compare with 0xC0 → check if this byte signals a 2-byte UTF-8 sequence.
+            // If true, len = 2 → this “logical character” spans 2 bytes
+            // -----------------------------------------------------------------
+            if ((c & 0xF0) == 0xC0)
+                len = 2; // 2-byte character (Portuguese letters)
+
+            // No need to handle >2 bytes if we don't want emojis
+
+            chars.push_back(source.substr(i, len));
+            i += len;
+        }
+        return chars;
+    }
+
+    inline bool is_alpha_utf8(const std::string &c)
+    {
+        if (c.empty())
+            return false;
+
+        // ASCII letters
+        if ((c[0] >= 'a' && c[0] <= 'z') || (c[0] >= 'A' && c[0] <= 'Z'))
+            return true;
+
+        // Portuguese letters in UTF-8 (2 bytes)
+        static const std::string portuguese_letters[] = {
+            "á", "à", "ã", "â", "é", "ê", "í", "ó", "ô", "õ", "ú", "ç",
+            "Á", "À", "Ã", "Â", "É", "Ê", "Í", "Ó", "Ô", "Õ", "Ú", "Ç"};
+
+        for (const auto &p : portuguese_letters)
+            if (c == p)
+                return true;
+
+        return false;
+    }
+
+    inline bool is_digit_utf8(const std::string &c)
+    {
+        return (c.size() == 1 && c[0] >= '0' && c[0] <= '9');
+    }
+
 }


### PR DESCRIPTION
# Description

This PR introduces several important improvements to the language syntax, with a focus on clarity, expressiveness, and multilingual support:

####  New Features

* **Class creation with `let there be`**

  * Simplifies class declarations by replacing `creation ClassName` (confusing with `create varName`) with a more natural syntax:

    ```jesus
    let there be Light: amen
    ```

* **Support for empty-bodied classes without `: amen`**

  * Classes with no body can now be declared without requiring an explicit block terminator:

    ```jesus
    let there be Light
    ```

    instead of:

    ```jesus
    let there be Light: amen
    ```

* **Portuguese syntax support**

  * Added `haja` and `amém` as a natural equivalent for `let there be`:

    ```jesus
    haja Luz: amen

    haja Graça: amém

    haja Salvação
    ```
  * Introduced Portuguese keywords:

    * `criar` → `create`
    * `não` → `not`
    * `e` → `and`
    * `ou` → `or`
    * `senão` → `otherwise`
    * `amém` → `amen`

* **UTF-8 identifiers**

  * Classes and methods can now include Portuguese letters and accents:

    ```jesus
    haja Canção
    criar Canção graça = "Tua graça me basta..."
    say graça
    ```

# ✝️ Wisdom

> And God said, “Let there be light,” and there was light. — **Genesis 1:3**
