### PR TITLE
Step 30: Added banner with current build date in JST (UTC+9) and verse (JST -> Jesusalem Scriptural Time)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 ignore-this-folder
 build
+version.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,59 @@ include_directories(src/jesus)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+# ------------------------------------------------------------------------------
+# Version Information (auto-generated)
+#
+# We don't hardcode version numbers inside the source code.
+# Instead, we generate a header file from a template (version.hpp.in).
+#
+# - version.hpp.in lives in src/jesus/utils/
+# - CMake replaces tokens (@JESUS_BUILD_DATE@, @GIT_COMMIT_HASH@)
+# - The final header is written to src/jesus/utils/version.hpp
+#
+# This ensures the binary always carries correct metadata (date + commit hash)
+# without requiring manual updates in source files.
+# ---
+#
+# JESUS_BUILD_DATE is generated in UTC+9, which we call "Jerusalem Scriptural Time (JST)".
+# Why UTC+9?
+# - In the Bible, a new day begins at sundown in Jerusalem (around 18:00 local time).
+# - This moment aligns with 00:00 in Japan Standard Time (UTC+9).
+# - Using UTC+9 therefore provides a consistent, unambiguous "scriptural day boundary".
+#
+# Why "Jerusalem Scriptural Time"?
+# - To avoid confusion with "Jerusalem Standard Time", which refers to UTC+2/UTC+3.
+# - To highlight the Biblical reasoning instead of civil timezone definitions.
+# - To provide a clear, memorable alias (JST) that reflects the spiritual meaning.
+#
+# Thus, the build date is always stamped in UTC+9 to reflect the Biblical day cycle.
+# ------------------------------------------------------------------------------
+execute_process(
+    COMMAND /bin/sh -c "TZ=Asia/Tokyo date '+%Y.%m.%d JST'" # JST = UTC+9
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE JESUS_BUILD_DATE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+execute_process(
+    COMMAND /bin/sh -c "TZ=Asia/Tokyo date '+%H:%M:%S'" # JST = UTC+9
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE JESUS_BUILD_TIME
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+execute_process(
+    COMMAND git rev-parse --short HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_COMMIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+configure_file(
+    ${CMAKE_SOURCE_DIR}/src/jesus/utils/version.hpp.in
+    ${CMAKE_SOURCE_DIR}/src/jesus/utils/version.hpp
+    @ONLY
+)
+message(STATUS "Build date (Jerusalem Scriptural Time / UTC+9): ${JESUS_BUILD_DATE} ${JESUS_BUILD_TIME}")
+
+
 # -------------------
 # Define source files
 # -------------------

--- a/src/jesus/main.cpp
+++ b/src/jesus/main.cpp
@@ -6,9 +6,23 @@
 #include "interpreter/interpreter.hpp"
 #include "parser/grammar/jesus_grammar.hpp"
 #include "types/known_types.hpp"
+#include "utils/banner.hpp"
+#include "utils/version.hpp"
 
-int main()
+int main(int argc, char **argv)
 {
+    bool quiet = false;
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string arg = argv[i];
+        if (arg == "--quiet")
+            quiet = true;
+    }
+
+    const std::string version = JESUS_VERSION;
+    const std::string commit = JESUS_COMMIT;
+    Banner::show(version, commit, quiet);
+
     grammar::initializeGrammar(); // Sets the Expression rule target to Primary
 
     Heart heart;

--- a/src/jesus/test_runner.cpp
+++ b/src/jesus/test_runner.cpp
@@ -5,7 +5,7 @@
 
 std::string runJesusInterpreter(const std::string &inputFile)
 {
-    std::string command = "./jesus < " + inputFile + " 2>&1";
+    std::string command = "./jesus --quiet < " + inputFile + " 2>&1";
     std::string result;
 
     FILE *pipe = popen(command.c_str(), "r");

--- a/src/jesus/utils/banner.hpp
+++ b/src/jesus/utils/banner.hpp
@@ -1,0 +1,17 @@
+#include <iostream>
+
+namespace Banner
+{
+    inline void show(const std::string &version, const std::string &commit, bool quiet)
+    {
+        if (quiet)
+            return;
+
+        std::cout << "Jesus Programming Language " << version << " (י ש ו ע ה, " << commit << ")\n\n";
+        std::cout << "\"If you confess with your mouth that 'Jesus is Lord', \n";
+        std::cout << "and believe in your heart that God raised him from the dead,\n";
+        std::cout << "you will be saved.\" — Romans 10:9\n";
+        // std::cout << "\"May the peace of the Lord Jesus Christ, the Prince of Peace, rest upon you.\"\n";
+        std::cout << std::endl;
+    }
+}

--- a/src/jesus/utils/version.hpp
+++ b/src/jesus/utils/version.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+/**
+ * @file version.hpp.in
+ * @brief Template header for build versioning of the Jesus Programming Language.
+ *
+ * ⚠️ This is NOT a real header. It is a template processed by CMake at configure time.
+ *
+ * CMake will replace placeholders like:
+ *   2025.08.18 JST   → Current date in JST (UTC+9) at configuration time
+ *   ea1044f    → Short Git commit hash at configuration time
+ *
+ * The processed file will be generated as:
+ *   src/jesus/utils/version.hpp
+ *
+ * and must be included in code as:
+ *   #include "utils/version.hpp"
+ *
+ * This allows the program to always display correct version/date/commit
+ * without manually editing constants in the source.
+ *
+ * Example final generated string:
+ *   Jesus Programming Language v2025-08-17 JST (י ש ו ע ה, commit a1b2c3d)
+ *
+ * JESUS_BUILD_DATE is generated in UTC+9, which we call "Jerusalem Scriptural Time (JST)".
+ *  Why UTC+9?
+ * - In the Bible, a new day begins at sundown in Jerusalem (around 18:00 local time).
+ * - This moment aligns with 00:00 in Japan Standard Time (UTC+9).
+ * - Using UTC+9 therefore provides a consistent, unambiguous "scriptural day boundary".
+ *
+ * Why "Jerusalem Scriptural Time"?
+ * - To avoid confusion with "Jerusalem Standard Time", which refers to UTC+2/UTC+3.
+ * - To highlight the Biblical reasoning instead of civil timezone definitions.
+ * - To provide a clear, memorable alias (JST) that reflects the spiritual meaning.
+ *
+ * Thus, the build date is always stamped in UTC+9 to reflect the Biblical day cycle.
+ */
+
+#define JESUS_VERSION "v2025.08.18 JST" // Replaced by CMake
+#define JESUS_COMMIT "ea1044f"    // Replaced by CMake

--- a/src/jesus/utils/version.hpp.in
+++ b/src/jesus/utils/version.hpp.in
@@ -1,0 +1,40 @@
+#pragma once
+
+/**
+ * @file version.hpp.in
+ * @brief Template header for build versioning of the Jesus Programming Language.
+ *
+ * ⚠️ This is NOT a real header. It is a template processed by CMake at configure time.
+ *
+ * CMake will replace placeholders like:
+ *   @JESUS_BUILD_DATE@   → Current date in JST (UTC+9) at configuration time
+ *   @GIT_COMMIT_HASH@    → Short Git commit hash at configuration time
+ *
+ * The processed file will be generated as:
+ *   src/jesus/utils/version.hpp
+ *
+ * and must be included in code as:
+ *   #include "utils/version.hpp"
+ *
+ * This allows the program to always display correct version/date/commit
+ * without manually editing constants in the source.
+ *
+ * Example final generated string:
+ *   Jesus Programming Language v2025-08-17 JST (י ש ו ע ה, commit a1b2c3d)
+ *
+ * JESUS_BUILD_DATE is generated in UTC+9, which we call "Jerusalem Scriptural Time (JST)".
+ *  Why UTC+9?
+ * - In the Bible, a new day begins at sundown in Jerusalem (around 18:00 local time).
+ * - This moment aligns with 00:00 in Japan Standard Time (UTC+9).
+ * - Using UTC+9 therefore provides a consistent, unambiguous "scriptural day boundary".
+ *
+ * Why "Jerusalem Scriptural Time"?
+ * - To avoid confusion with "Jerusalem Standard Time", which refers to UTC+2/UTC+3.
+ * - To highlight the Biblical reasoning instead of civil timezone definitions.
+ * - To provide a clear, memorable alias (JST) that reflects the spiritual meaning.
+ *
+ * Thus, the build date is always stamped in UTC+9 to reflect the Biblical day cycle.
+ */
+
+#define JESUS_VERSION "v@JESUS_BUILD_DATE@" // Replaced by CMake
+#define JESUS_COMMIT "@GIT_COMMIT_HASH@"    // Replaced by CMake


### PR DESCRIPTION
# Description

This PR adds a friendly and God-centered startup banner to the Jesus Programming Language interpreter. 

When the interpreter launches, it now prints:

- The language version, derived from the Git commit hash.
- The build date in **Jerusalem Scriptural Time (UTC+9)**, reflecting the biblical day cycle (sunset in Jerusalem corresponds to midnight JST).
- A comforting verse for users based on **Romans 10:9**

Example banner:

    Jesus Programming Language v2025.08.18 JST (י ש ו ע ה, ea1044f)

    "If you confess with your mouth that 'Jesus is Lord', 
    and believe in your heart that God raised him from the dead,
    you will be saved." — Romans 10:9

### Motivation

- Helps users immediately feel encouraged and peaceful when starting the interpreter.
- Ensures the build date reflects the biblical day start, consistent with the spiritual theme of the language.
- Provides a God-centered, memorable first impression for new users.

### Implementation Notes

- The banner is printed at interpreter startup.
- The build date is generated in CMake using `date` with UTC+9 (JST).
- The Git commit hash is retrieved using `git rev-parse --short HEAD`.
- The banner and date formatting are configurable in `src/jesus/utils/version.hpp.in`.

# ✝️ Wisdom

> God called the light “day,” and the darkness he called “night.” And **there was evening, and there was morning**—the first day. — **Genesis 1:5**