### PR TITLE
Step 31: Added support for defining class attributes in Jesus language

### DIFF
--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -129,6 +129,15 @@ void Interpreter::visitCreateClass(const CreateClassStmt &stmt)
         stmt.module_name,
         constraints);
 
+    // handle attributes
+    for (auto &member : stmt.body)
+    {
+        if (auto attr = static_cast<CreateVarStmt*>(member.get()))
+        {
+            userClass->addAttribute(attr->name, std::move(attr->value),  &heart);
+        }
+    }
+
     KnownTypes::registerType(std::move(userClass));
 }
 

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -76,9 +76,9 @@ namespace grammar
     // ----------
     // Statements
     // ----------
-    inline auto CreateClass = std::make_shared<CreateClassStmtRule>();
     inline auto CreateVarType = std::make_shared<CreateVarTypeStmtRule>();
     inline auto CreateVar = std::make_shared<CreateVarStmtRule>(Expression, Ask);
+    inline auto CreateClass = std::make_shared<CreateClassStmtRule>(CreateVar);
     inline auto UpdateVar = std::make_shared<UpdateVarStmtRule>(Expression, Ask);
 
     /**

--- a/src/jesus/parser/grammar/stmt/create_class_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_class_stmt_rule.cpp
@@ -43,13 +43,25 @@ std::unique_ptr<Stmt> CreateClassStmtRule::parse(ParserContext &ctx)
     if (!ctx.match(TokenType::COLON))
         throw std::runtime_error("Expected ':' after class name in '" + stmt + "' statement.");
 
+    while (!ctx.check(TokenType::AMEN) && !ctx.isAtEnd())
+    {
+        if (auto attr = createVar->parse(ctx))
+        {
+            body.push_back(std::move(attr));
+        }
+        else
+        {
+            throw std::runtime_error("Unexpected statement inside class body.");
+        }
+    }
+
     if (ctx.isAtEnd())
     {
         return std::make_unique<IncompleteBlockStmt>();
     }
 
     if (!ctx.match(TokenType::AMEN))
-        throw std::runtime_error("Expected 'amen' after ':' in '" + stmt + "' statement.");
+        throw std::runtime_error("Expected 'amen' after ':' in '" + stmt + "' to close class body.");
 
     ctx.registerClassName(className);
     return std::make_unique<CreateClassStmt>(className, module_name, body);

--- a/src/jesus/parser/grammar/stmt/create_class_stmt_rule.hpp
+++ b/src/jesus/parser/grammar/stmt/create_class_stmt_rule.hpp
@@ -2,12 +2,15 @@
 
 #include "../../parser_context.hpp"
 #include "../../../ast/stmt/stmt.hpp"
+#include "create_var_stmt_rule.hpp"
 
 class CreateClassStmtRule
 {
+    std::shared_ptr<CreateVarStmtRule> createVar;
 
 public:
-    explicit CreateClassStmtRule() {}
+    explicit CreateClassStmtRule(std::shared_ptr<CreateVarStmtRule> createVar)
+        : createVar(std::move(createVar)){}
 
     std::unique_ptr<Stmt> parse(ParserContext &ctx);
 };

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -211,3 +211,9 @@ say dia
 haja Canção
 criar Canção louvor = "Me ama, Ele me ama..."
 say louvor
+let there be Person:
+    create text name = "Adam"
+    create text wife = "Eve"
+    create number age = 930
+amen
+say wife

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -160,4 +160,5 @@ What is your age again? (Jesus) (double) 2025.000000
 (Jesus) (logic) 1
 (Jesus) (Jesus) (Jesus) (int) 1
 (Jesus) (Jesus) (Jesus) Me ama, Ele me ama...
+(Jesus) (Jesus) ❌ Error: Undefined variable: wife
 (Jesus) 

--- a/src/jesus/types/creation_type.hpp
+++ b/src/jesus/types/creation_type.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include "../spirit/value.hpp"
+#include "../ast/expr/expr.hpp"
 #include "constraints/constraint.hpp"
 
 enum class PrimitiveType
@@ -32,6 +33,8 @@ public:
     const std::string module_name;
 
     const PrimitiveType primitive_type;
+
+    Heart class_attributes;
 
     CreationType(PrimitiveType primitive_type, std::string name, std::string module = "core",
                  std::vector<std::shared_ptr<IConstraint>> constraints = {})
@@ -86,6 +89,21 @@ public:
             c->validate(value); // may throw
 
         return true;
+    }
+
+    void addAttribute(const std::string &name, std::unique_ptr<Expr> initializer, Heart *heart)
+    {
+        if (primitive_type != PrimitiveType::Class)
+            throw std::runtime_error("Only class types can have attributes.");
+
+        Value initVal;
+        if (initializer)
+        {
+            // Evaluate the expression to a Value (optional; could be done lazily)
+            initVal = initializer->evaluate(heart);
+        }
+
+        class_attributes.createVar(name, initVal);
     }
 
 private:


### PR DESCRIPTION
# Description  

This PR introduces the ability to **define attributes inside class declarations** in the Jesus language.  

- Classes can now contain attributes declared with `create`.  
- Attributes support types like `text` and `number`, just like normal variables.  
- This PR **does not yet include**:  
  - Instance creation (`new`-like semantics).  
  - Attribute retrieval or mutation on instances.  

This lays the foundation for future PRs where instance creation and attribute access will be added.  

---

### ✅ Example Code (now supported)  
```jesus
let there be Human:
    create text name = "Adam"
    create text wife = "Eve"
    create number age = 930
amen
```  

In the above example:  
- `Person` is declared as a class.  
- Attributes `name`, `wife`, and `age` are registered under the class.  
- These attributes are currently stored at the class-level, not per instance.  

# ✝️ Wisdom

> "For since the creation of the world God's invisible **qualities**
>  — his eternal power and divine nature — have been clearly seen,
> being understood from what has been made, so that people are without excuse." — **Romans 1:20**
