### PR TITLE
Step 39: Interpreter can now pass arguments to methods - feat(method-call)

### DIFF
--- a/src/jesus/ast/expr/method_call_expr.hpp
+++ b/src/jesus/ast/expr/method_call_expr.hpp
@@ -9,9 +9,13 @@ class MethodCallExpr : public Expr
 public:
     std::unique_ptr<Expr> object;
     std::shared_ptr<Method> method;
+    std::vector<std::unique_ptr<Expr>> args;
 
-    MethodCallExpr(std::unique_ptr<Expr> object, std::shared_ptr<Method> method)
-        : object(std::move(object)), method(std::move(method))
+    MethodCallExpr(
+        std::unique_ptr<Expr> object,
+        std::shared_ptr<Method> method,
+        std::vector<std::unique_ptr<Expr>> args)
+        : object(std::move(object)), method(std::move(method)), args(std::move(args))
     {
         if (this->method == nullptr)
         {

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -76,9 +76,13 @@ Value Interpreter::visitMethodCallExpr(const MethodCallExpr &expr)
     Value object = expr.object->accept(*this);
 
     std::shared_ptr<Instance> instance = object.toInstance();
-    const std::vector<Value> args;
+    std::vector<Value> args;
 
-    return expr.method->call(*this, instance, args);
+    // Evaluate all arguments
+    for (auto &argExpr : expr.args)
+        args.push_back(argExpr->accept(*this));
+
+    return expr.method->call(*this, instance, std::move(args));
 }
 
 Value Interpreter::visitAsk(const AskExpr &expr)

--- a/src/jesus/interpreter/runtime/method.cpp
+++ b/src/jesus/interpreter/runtime/method.cpp
@@ -4,19 +4,32 @@
 
 Value Method::call(Interpreter &interpreter, std::shared_ptr<Instance> instance, const std::vector<Value> args)
 {
-    // 1. Add instance attributes to the scope
+    // 1. Add instance 'attributes' to the scope
     interpreter.addScope(instance->attributes);
 
-    // 2. Create and push the 'params' scope (frame) for this call
+    // 2. Create the method 'params' scope for this call
     auto paramsScope = params->clone("call-" + name);
+
+    // Bind the actual 'arguments' to the 'param' names
+    int index = 0;
+    for (const auto &name : paramsScope->getVariableNames())
+    {
+        if (index < args.size())
+            paramsScope->updateVar(name, args[index++]);
+        else
+            // FIXME: speed it up: Validate params at parse time, not at rutime
+            throw std::runtime_error("Missing argument for parameter '" + name + "'");
+    }
+
     interpreter.addScope(paramsScope);
 
+    // 3. Execute method body
     for (auto stmt : body)
     {
         interpreter.execute(stmt);
     }
 
-    // 3. Pop 'attributes' and 'params' scope
+    // 4. Pop 'attributes' and 'params' scope
     interpreter.popScope();
     interpreter.popScope();
 

--- a/src/jesus/parser/grammar/expr/postfix/get_attr_rule.cpp
+++ b/src/jesus/parser/grammar/expr/postfix/get_attr_rule.cpp
@@ -28,7 +28,22 @@ std::unique_ptr<Expr> GetAttributeRule::parse(ParserContext &ctx)
             // If it is a method
             else if (std::shared_ptr<Method> method = klass->findMethod(member))
             {
-                expr = std::make_unique<MethodCallExpr>(std::move(expr), method);
+                std::vector<std::unique_ptr<Expr>> args;
+
+                // If the next token(s) indicate arguments, parse them
+                if (!ctx.check(TokenType::NEWLINE) && !ctx.check(TokenType::END_OF_FILE))
+                {
+                    do
+                    {
+                        auto argExpr = primary->parse(ctx); // parse any expression
+                        if (!argExpr)
+                            throw std::runtime_error("Expected argument for method " + member);
+
+                        args.push_back(std::move(argExpr));
+                    } while (ctx.match(TokenType::COMMA));
+                }
+
+                expr = std::make_unique<MethodCallExpr>(std::move(expr), method, std::move(args));
             }
             else
             {

--- a/src/jesus/spirit/heart.cpp
+++ b/src/jesus/spirit/heart.cpp
@@ -10,6 +10,8 @@ void Heart::createVar(const std::string &type, const std::string &name, const Va
 
     variables[name] = value;
     registerVarType(type, name);
+
+    variableOrder.push_back(name); // preserve insertion order to assign 'args' to method 'params' by index.
 }
 
 Value Heart::getVar(const std::string &name) const

--- a/src/jesus/spirit/heart.hpp
+++ b/src/jesus/spirit/heart.hpp
@@ -43,6 +43,7 @@ public:
     {
         auto copy = std::make_shared<Heart>(scope_name);
         copy->variables = variables;
+        copy->variableOrder = variableOrder;
         copy->semantics_analyzer = semantics_analyzer;
         return copy;
     }
@@ -116,6 +117,11 @@ public:
         return type;
     }
 
+    const std::vector<std::string> &getVariableNames() const
+    {
+        return variableOrder;
+    }
+
     const std::string toString() const
     {
         std::string str = "";
@@ -140,6 +146,7 @@ public:
     }
 
 private:
+    std::vector<std::string> variableOrder; // insertion order
     std::unordered_map<std::string, Value> variables;
     std::shared_ptr<SpiritOfUnderstanding> semantics_analyzer;
 };

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -250,3 +250,6 @@ say adam functionWithoutParams
 say adam aToB
 say "The new name is: "
 say adam name
+say adam aToB 7, 49
+say "The new name v2 is: "
+say adam name

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -186,10 +186,13 @@ What is your age again? (Jesus) (double) 2025.000000
 }
 (Jesus) I am inside functionWithoutParams
 null
+(Jesus) ❌ Error: Missing argument for parameter 'a'
+(Jesus) The new name is: 
+(Jesus) Adam
 (Jesus) a before
-(int) 1
+(int) 7
 b before
-(int) 1
+(int) 49
 before update b
 before update a
 a updated
@@ -198,6 +201,6 @@ a updated
 Adam
 Adopted by Jesus Christ
 null
-(Jesus) The new name is: 
+(Jesus) The new name v2 is: 
 (Jesus) Adopted by Jesus Christ
 (Jesus) 


### PR DESCRIPTION
# Description

This PR introduces full support for passing arguments to methods.

**Changes included:**

* **AST + Parser**

  * Extended `MethodCallExpr` to store a list of argument expressions.
  * Updated `GetAttributeRule::parse` to handle argument parsing (`instance methodName 1, 2`).

* **Interpreter**

  * `visitMethodCallExpr` now evaluates/extracts arguments before invocation.
  * `Method::call` binds evaluated **_arguments_** to _**parameter**_ names in the method scope.
  * Correctly throws an error when arguments are missing.

**Example usage:**

```jesus
let there be Exchanger:
    purpose aToB(number a; number b):
        say a
        say b
    amen
amen

create Exchanger changer = 1
say changer aToB 700, 300 
```
It outputs:
> (int) 700
> (int) 300
> null

**Impact:**

* Methods are no longer limited to parameter declarations.
* Arguments are now evaluated, forwarded, and bound correctly.
* Enables writing real, reusable methods that take input.

# ✝️ Wisdom

> "**_Call_** to me and I will answer you, and will tell you great and hidden things that you have not known." — **Jeremiah 33:3**

