### PR TITLE
Step 40: Static var type analysis - Validating types at parse time, rather than at runtime

### DIFF
--- a/src/jesus/ast/expr/ask_expr.cpp
+++ b/src/jesus/ast/expr/ask_expr.cpp
@@ -1,5 +1,6 @@
 #include "ask_expr.hpp"
 #include "../../interpreter/expr_visitor.hpp"
+#include "../../types/creation_type.hpp"
 
 Value AskExpr::evaluate(std::shared_ptr<Heart> heart) const
 {
@@ -12,3 +13,8 @@ Value AskExpr::accept(ExprVisitor &visitor) const
     Value answer = visitor.visitAsk(*this);
     return answer;
 }
+
+std::shared_ptr<CreationType> AskExpr::getReturnType(ParserContext &ctx) const
+{
+    return prompt->getReturnType(ctx);
+};

--- a/src/jesus/ast/expr/ask_expr.hpp
+++ b/src/jesus/ast/expr/ask_expr.hpp
@@ -41,6 +41,14 @@ public:
      */
     Value accept(ExprVisitor &visitor) const override;
 
+    /**
+     * @brief Get the return type of the expression, so that variable
+     *  creation and update can be enforced at parse time.
+     *
+     * "Flesh gives birth to flesh, but the Spirit gives birth to spirit." — John 3:6
+     */
+    std::shared_ptr<CreationType> getReturnType(ParserContext &ctx) const override;
+
     std::string toString() const override
     {
         // TODO: Add toJesus() that returns: return "ask \"" + prompt + "\"";

--- a/src/jesus/ast/expr/binary_expr.cpp
+++ b/src/jesus/ast/expr/binary_expr.cpp
@@ -1,7 +1,13 @@
 #include "binary_expr.hpp"
 #include "../../interpreter/expr_visitor.hpp"
+#include "../../types/creation_type.hpp"
 
 Value BinaryExpr::accept(ExprVisitor &visitor) const
 {
     return visitor.visitBinary(*this);
 }
+
+std::shared_ptr<CreationType> BinaryExpr::getReturnType(ParserContext &ctx) const
+{
+    return right->getReturnType(ctx);
+};

--- a/src/jesus/ast/expr/binary_expr.hpp
+++ b/src/jesus/ast/expr/binary_expr.hpp
@@ -95,21 +95,26 @@ public:
             return Value(leftVal >= rightVal);
         }
 
-        if (op.type == TokenType::OR) {
+        if (op.type == TokenType::OR)
+        {
             return leftVal.AS_BOOLEAN ? leftVal : rightVal;
         }
 
-        if (op.type == TokenType::AND) {
+        if (op.type == TokenType::AND)
+        {
             return leftVal.AS_BOOLEAN ? rightVal : leftVal;
         }
 
-        if (op.type == TokenType::VERSUS) {
-            if (leftVal.IS_BOOLEAN && rightVal.IS_BOOLEAN) {
+        if (op.type == TokenType::VERSUS)
+        {
+            if (leftVal.IS_BOOLEAN && rightVal.IS_BOOLEAN)
+            {
                 // Logical XOR
                 return Value(leftVal.AS_BOOLEAN != rightVal.AS_BOOLEAN);
             }
 
-            if (leftVal.IS_NUMBER && rightVal.IS_NUMBER) {
+            if (leftVal.IS_NUMBER && rightVal.IS_NUMBER)
+            {
                 // Bitwise XOR
                 return Value(leftVal.toInt() ^ rightVal.toInt());
             }
@@ -120,6 +125,16 @@ public:
         // TODO: Support plus, minus, multiply, divide, is, has, etc
         throw std::runtime_error("Unknown binary operator: " + op.lexeme);
     }
+
+    Value accept(ExprVisitor &visitor) const override;
+
+    /**
+     * @brief Get the return type of the expression, so that variable
+     *  creation and update can be enforced at parse time.
+     *
+     * "Flesh gives birth to flesh, but the Spirit gives birth to spirit." — John 3:6
+     */
+    std::shared_ptr<CreationType> getReturnType(ParserContext &ctx) const override;
 
     /**
      * @brief Returns a string representation of the node.
@@ -143,6 +158,4 @@ public:
 
         return str;
     }
-
-    Value accept(ExprVisitor &visitor) const override;
 };

--- a/src/jesus/ast/expr/conditional_expr.cpp
+++ b/src/jesus/ast/expr/conditional_expr.cpp
@@ -1,7 +1,13 @@
 #include "conditional_expr.hpp"
 #include "../../interpreter/expr_visitor.hpp"
+#include "../../types/creation_type.hpp"
 
 Value ConditionalExpr::accept(ExprVisitor &visitor) const
 {
     return visitor.visitConditional(*this);
 }
+
+std::shared_ptr<CreationType> ConditionalExpr::getReturnType(ParserContext &ctx) const
+{
+    return thenBranch->getReturnType(ctx);
+};

--- a/src/jesus/ast/expr/conditional_expr.hpp
+++ b/src/jesus/ast/expr/conditional_expr.hpp
@@ -43,40 +43,50 @@ public:
           thenBranch(std::move(thenBranch)),
           elseBranch(std::move(elseBranch)) {}
 
-  /**
-   * @brief  Evaluates a condition and returns the result of either the
-   * `thenBranch` or `elseBranch` branch based on the logic outcome of the condition.
-   *
-   * - If the condition evaluates to "true", it evaluates and returns the `thenBranch` branch.
-   * - If the condition evaluates to anything else (or fails), it evaluates and returns the `elseBranch` branch if available.
-   *
-   * @param heart The "Symbol table"
-   * @return std::optional<std::string>
-   */
-  Value evaluate(std::shared_ptr<Heart> heart) const override
-  {
-    Value result = condition->evaluate(heart);
-
-    if (result.AS_BOOLEAN)
+    /**
+     * @brief  Evaluates a condition and returns the result of either the
+     * `thenBranch` or `elseBranch` branch based on the logic outcome of the condition.
+     *
+     * - If the condition evaluates to "true", it evaluates and returns the `thenBranch` branch.
+     * - If the condition evaluates to anything else (or fails), it evaluates and returns the `elseBranch` branch if available.
+     *
+     * @param heart The "Symbol table"
+     * @return std::optional<std::string>
+     */
+    Value evaluate(std::shared_ptr<Heart> heart) const override
     {
-      return thenBranch->evaluate(heart);
+        Value result = condition->evaluate(heart);
+
+        if (result.AS_BOOLEAN)
+        {
+            return thenBranch->evaluate(heart);
+        }
+
+        if (elseBranch)
+        {
+            return elseBranch->evaluate(heart);
+        }
+
+        return Value::formless();
     }
 
-    if (elseBranch)
-    {
-      return elseBranch->evaluate(heart);
-    }
+    Value accept(ExprVisitor &visitor) const override;
 
-    return Value::formless();
-  }
+    /**
+     * @brief Get the return type of the expression, so that variable
+     *  creation and update can be enforced at parse time.
+     *
+     * "Flesh gives birth to flesh, but the Spirit gives birth to spirit." — John 3:6
+     */
+    std::shared_ptr<CreationType> getReturnType(ParserContext &ctx) const override;
 
-  /**
-   * @brief Returns a string representation of the expression.
-   *
-   * "For nothing is hidden that will not be made manifest, nor is anything
-   * secret that will not be known and come to light." — Luke 8:17
-   */
-  virtual std::string toString() const override
+    /**
+     * @brief Returns a string representation of the expression.
+     *
+     * "For nothing is hidden that will not be made manifest, nor is anything
+     * secret that will not be known and come to light." — Luke 8:17
+     */
+    virtual std::string toString() const override
     {
         std::string str = "ConditionalExpr";
 
@@ -91,6 +101,4 @@ public:
 
         return str;
     }
-
-  Value accept(ExprVisitor &visitor) const override;
 };

--- a/src/jesus/ast/expr/expr.hpp
+++ b/src/jesus/ast/expr/expr.hpp
@@ -2,7 +2,8 @@
 #include <string>
 #include "../../spirit/heart.hpp"
 
-class ExprVisitor; // Forward declaration
+class ExprVisitor;   // Forward declaration
+class ParserContext; // Forward declaration
 
 /**
  * @brief The base class for all expression types in the AST.
@@ -27,6 +28,14 @@ public:
     virtual Value evaluate(std::shared_ptr<Heart> heart) const = 0;
 
     virtual Value accept(ExprVisitor &visitor) const = 0;
+
+    /**
+     * @brief Get the return type of the expression, so that variable
+     *  creation and update can be enforced at parse time.
+     *
+     * "Flesh gives birth to flesh, but the Spirit gives birth to spirit." — John 3:6
+     */
+    virtual std::shared_ptr<CreationType> getReturnType(ParserContext &ctx) const = 0;
 
     virtual ~Expr() = default;
 

--- a/src/jesus/ast/expr/get_attr_expr.cpp
+++ b/src/jesus/ast/expr/get_attr_expr.cpp
@@ -1,7 +1,14 @@
 #include "get_attr_expr.hpp"
 #include "../../interpreter/expr_visitor.hpp"
+#include "../../types/creation_type.hpp"
+#include "../../parser/parser_context.hpp"
 
 Value GetAttributeExpr::accept(ExprVisitor &visitor) const
 {
     return visitor.visitGetAttribute(*this);
 }
+
+std::shared_ptr<CreationType> GetAttributeExpr::getReturnType(ParserContext &ctx) const
+{
+    return ctx.getVarType(attribute);
+};

--- a/src/jesus/ast/expr/get_attr_expr.hpp
+++ b/src/jesus/ast/expr/get_attr_expr.hpp
@@ -17,4 +17,12 @@ public:
     }
 
     Value accept(ExprVisitor &visitor) const override;
+
+    /**
+     * @brief Get the return type of the expression, so that variable
+     *  creation and update can be enforced at parse time.
+     *
+     * "Flesh gives birth to flesh, but the Spirit gives birth to spirit." — John 3:6
+     */
+    std::shared_ptr<CreationType> getReturnType(ParserContext &ctx) const override;
 };

--- a/src/jesus/ast/expr/grouping_expr.cpp
+++ b/src/jesus/ast/expr/grouping_expr.cpp
@@ -5,3 +5,8 @@ Value GroupingExpr::accept(ExprVisitor &visitor) const
 {
     return visitor.visitGrouping(*this);
 }
+
+std::shared_ptr<CreationType> GroupingExpr::getReturnType(ParserContext &ctx) const
+{
+    return expression->getReturnType(ctx);
+};

--- a/src/jesus/ast/expr/grouping_expr.hpp
+++ b/src/jesus/ast/expr/grouping_expr.hpp
@@ -41,6 +41,16 @@ public:
         return expression->evaluate(heart);
     }
 
+    Value accept(ExprVisitor &visitor) const override;
+
+    /**
+     * @brief Get the return type of the expression, so that variable
+     *  creation and update can be enforced at parse time.
+     *
+     * "Flesh gives birth to flesh, but the Spirit gives birth to spirit." — John 3:6
+     */
+    std::shared_ptr<CreationType> getReturnType(ParserContext &ctx) const override;
+
     /**
      * @brief Returns a string representation of the expression.
      *
@@ -48,6 +58,4 @@ public:
      * secret that will not be known and come to light." — Luke 8:17
      */
     virtual std::string toString() const override { return "GroupingExpr(" + expression->toString() + ")"; }
-
-    Value accept(ExprVisitor &visitor) const override;
 };

--- a/src/jesus/ast/expr/literal_expr.cpp
+++ b/src/jesus/ast/expr/literal_expr.cpp
@@ -5,3 +5,8 @@ Value LiteralExpr::accept(ExprVisitor &visitor) const
 {
     return visitor.visitLiteral(*this);
 }
+
+std::shared_ptr<CreationType> LiteralExpr::getReturnType(ParserContext &ctx) const
+{
+    return type;
+};

--- a/src/jesus/ast/expr/literal_expr.hpp
+++ b/src/jesus/ast/expr/literal_expr.hpp
@@ -15,6 +15,7 @@ class LiteralExpr : public Expr
 {
 public:
     Value value;
+    std::shared_ptr<CreationType> type;
 
     /**
      * @brief Construct a new LiteralExpr with a given value.
@@ -27,12 +28,23 @@ public:
      *
      * @param value  The literal value (e.g., 7, "Jesus", true, "Wisdom").
      */
-    explicit LiteralExpr(Value value) : value(value) {}
+    explicit LiteralExpr(Value value, std::shared_ptr<CreationType> type)
+        : value(value), type(std::move(type)) {}
 
     Value evaluate(std::shared_ptr<Heart> heart) const override
     {
         return value;
     }
+
+    Value accept(ExprVisitor &visitor) const override;
+
+    /**
+     * @brief Get the return type of the expression, so that variable
+     *  creation and update can be enforced at parse time.
+     *
+     * "Flesh gives birth to flesh, but the Spirit gives birth to spirit." — John 3:6
+     */
+    std::shared_ptr<CreationType> getReturnType(ParserContext &ctx) const override;
 
     /**
      * @brief Returns a string representation of the expression.
@@ -41,6 +53,4 @@ public:
      * secret that will not be known and come to light." — Luke 8:17
      */
     virtual std::string toString() const override { return "LiteralExpr(" + value.toString() + ")"; }
-
-    Value accept(ExprVisitor &visitor) const override;
 };

--- a/src/jesus/ast/expr/method_call_expr.cpp
+++ b/src/jesus/ast/expr/method_call_expr.cpp
@@ -1,7 +1,13 @@
 #include "method_call_expr.hpp"
 #include "../../interpreter/expr_visitor.hpp"
+#include "../../interpreter/runtime/method.hpp"
 
 Value MethodCallExpr::accept(ExprVisitor &visitor) const
 {
     return visitor.visitMethodCallExpr(*this);
 }
+
+std::shared_ptr<CreationType> MethodCallExpr::getReturnType(ParserContext &ctx) const
+{
+    return method->getReturnType(ctx);
+};

--- a/src/jesus/ast/expr/method_call_expr.hpp
+++ b/src/jesus/ast/expr/method_call_expr.hpp
@@ -32,4 +32,12 @@ public:
     }
 
     Value accept(ExprVisitor &visitor) const override;
+
+    /**
+     * @brief Get the method return type, so that variable
+     *  creation and update can be enforced at parse time.
+     *
+     * "Flesh gives birth to flesh, but the Spirit gives birth to spirit." — John 3:6
+     */
+    std::shared_ptr<CreationType> getReturnType(ParserContext &ctx) const override;
 };

--- a/src/jesus/ast/expr/unary_expr.cpp
+++ b/src/jesus/ast/expr/unary_expr.cpp
@@ -5,3 +5,8 @@ Value UnaryExpr::accept(ExprVisitor &visitor) const
 {
     return visitor.visitUnary(*this);
 }
+
+std::shared_ptr<CreationType> UnaryExpr::getReturnType(ParserContext &ctx) const
+{
+    return right->getReturnType(ctx);
+};

--- a/src/jesus/ast/expr/unary_expr.hpp
+++ b/src/jesus/ast/expr/unary_expr.hpp
@@ -72,6 +72,16 @@ public:
         throw std::runtime_error("Unknown unary operator: " + op.lexeme);
     }
 
+    Value accept(ExprVisitor &visitor) const override;
+
+    /**
+     * @brief Get the return type of the expression, so that variable
+     *  creation and update can be enforced at parse time.
+     *
+     * "Flesh gives birth to flesh, but the Spirit gives birth to spirit." — John 3:6
+     */
+    std::shared_ptr<CreationType> getReturnType(ParserContext &ctx) const override;
+
     /**
      * @brief Returns a string representation of the expression.
      *
@@ -79,6 +89,4 @@ public:
      * secret that will not be known and come to light." — Luke 8:17
      */
     virtual std::string toString() const override { return "UnaryExpr(" + op.lexeme + ")"; }
-
-    Value accept(ExprVisitor &visitor) const override;
 };

--- a/src/jesus/ast/expr/variable_expr.cpp
+++ b/src/jesus/ast/expr/variable_expr.cpp
@@ -1,7 +1,13 @@
 #include "variable_expr.hpp"
 #include "../../interpreter/expr_visitor.hpp"
+#include "../../parser/parser_context.hpp"
 
 Value VariableExpr::accept(ExprVisitor &visitor) const
 {
     return visitor.visitVariable(*this);
 }
+
+std::shared_ptr<CreationType> VariableExpr::getReturnType(ParserContext &ctx) const
+{
+    return ctx.getVarType(name);
+};

--- a/src/jesus/ast/expr/variable_expr.hpp
+++ b/src/jesus/ast/expr/variable_expr.hpp
@@ -40,6 +40,16 @@ public:
         return heart->getVar(name);
     }
 
+    Value accept(ExprVisitor &visitor) const override;
+
+    /**
+     * @brief Get the return type of the expression, so that variable
+     *  creation and update can be enforced at parse time.
+     *
+     * "Flesh gives birth to flesh, but the Spirit gives birth to spirit." — John 3:6
+     */
+    std::shared_ptr<CreationType> getReturnType(ParserContext &ctx) const override;
+
     /**
      * @brief Returns a string representation of the expression.
      *
@@ -47,6 +57,4 @@ public:
      * secret that will not be known and come to light." — Luke 8:17
      */
     virtual std::string toString() const override { return "VariableExpr(" + name + ")"; }
-
-    Value accept(ExprVisitor &visitor) const override;
 };

--- a/src/jesus/ast/stmt/create_var_with_ask_stmt.hpp
+++ b/src/jesus/ast/stmt/create_var_with_ask_stmt.hpp
@@ -16,11 +16,11 @@
 class CreateVarWithAskStmt : public Stmt
 {
 public:
-    const CreationType var_type;
+    const std::shared_ptr<CreationType> var_type;
     std::string var_name;
     std::shared_ptr<Expr> ask_expr; // Type is AskExpr
 
-    CreateVarWithAskStmt(const CreationType type, std::string name, std::unique_ptr<Expr> ask_expr)
+    CreateVarWithAskStmt(const std::shared_ptr<CreationType> type, std::string name, std::unique_ptr<Expr> ask_expr)
         : var_type(type), var_name(name), ask_expr(std::move(ask_expr)) {}
 
     void accept(StmtVisitor &visitor) const override;

--- a/src/jesus/ast/stmt/update_var_with_ask_stmt.hpp
+++ b/src/jesus/ast/stmt/update_var_with_ask_stmt.hpp
@@ -14,11 +14,11 @@
 class UpdateVarWithAskStmt : public Stmt
 {
 public:
-    const CreationType var_type;
+    const std::shared_ptr<CreationType> var_type;
     const std::string var_name;
     std::shared_ptr<Expr> ask_expr; // Type is AskExpr
 
-    UpdateVarWithAskStmt(const CreationType type, std::string name, std::unique_ptr<Expr> ask_expr)
+    UpdateVarWithAskStmt(const std::shared_ptr<CreationType> type, std::string name, std::unique_ptr<Expr> ask_expr)
         : var_type(type), var_name(name), ask_expr(std::move(ask_expr)) {}
 
     void accept(StmtVisitor &visitor) const override;

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -107,7 +107,7 @@ void Interpreter::visitCreateVar(const CreateVarStmt &stmt)
     createVariable(stmt.base_type, stmt.name, val);
 }
 
-Value Interpreter::askAndValidate(const std::shared_ptr<Expr> ask_expr, const CreationType &var_type)
+Value Interpreter::askAndValidate(const std::shared_ptr<Expr> ask_expr, std::shared_ptr<CreationType> var_type)
 {
     // Step 1: Evaluate the ask expression (e.g., ask "Your age?")
     Value question = ask_expr->evaluate(symbol_table.currentScope());
@@ -125,8 +125,8 @@ Value Interpreter::askAndValidate(const std::shared_ptr<Expr> ask_expr, const Cr
         try
         {
             // Step 4: Validate the value according to the variable type
-            Value value = var_type.parseFromString(answer);
-            var_type.validate(value);
+            Value value = var_type->parseFromString(answer);
+            var_type->validate(value);
 
             // Step 5: return validated value
             return value;
@@ -141,7 +141,7 @@ Value Interpreter::askAndValidate(const std::shared_ptr<Expr> ask_expr, const Cr
 void Interpreter::visitCreateVarWithAsk(const CreateVarWithAskStmt &stmt)
 {
     Value value = askAndValidate(stmt.ask_expr, stmt.var_type);
-    createVariable(stmt.var_type.name, stmt.var_name, value);
+    createVariable(stmt.var_type->name, stmt.var_name, value);
 }
 
 void Interpreter::visitUpdateVarWithAsk(const UpdateVarWithAskStmt &stmt)
@@ -178,7 +178,9 @@ void Interpreter::visitCreateClass(const CreateClassStmt &stmt)
                 methodStmt->name,
                 methodStmt->params,
                 methodStmt->body,
-                userClass);
+                userClass,
+                KnownTypes::BOOLEAN // FIXME: Allow methods to define return types
+            );
 
             userClass->addMethod(methodStmt->name, method);
         }

--- a/src/jesus/interpreter/interpreter.hpp
+++ b/src/jesus/interpreter/interpreter.hpp
@@ -221,7 +221,7 @@ private:
      *
      * This enables type-safe variable assignment with built-in validation.
      */
-    Value askAndValidate(const std::shared_ptr<Expr> ask_expr, const CreationType &var_type);
+    Value askAndValidate(const std::shared_ptr<Expr> ask_expr, std::shared_ptr<CreationType> var_type);
 
     /**
      * @brief Handles the creation of a variable initialized via an 'ask' expression.

--- a/src/jesus/interpreter/runtime/method.hpp
+++ b/src/jesus/interpreter/runtime/method.hpp
@@ -17,14 +17,28 @@ public:
     const std::vector<std::shared_ptr<Stmt>> body;
 
     const std::shared_ptr<CreationType> klass;
+    const std::shared_ptr<CreationType> returnType;
 
     Method(std::string name,
            std::shared_ptr<Heart> params,
            std::vector<std::shared_ptr<Stmt>> body,
-           std::shared_ptr<CreationType> klass)
-        : name(std::move(name)), params(std::move(params)), body(std::move(body)), klass(std::move(klass)) {}
+           std::shared_ptr<CreationType> klass,
+           std::shared_ptr<CreationType> returnType)
+        : name(std::move(name)), params(std::move(params)),
+          body(std::move(body)), klass(std::move(klass)), returnType(std::move(returnType)) {}
 
     Value call(Interpreter &interp, std::shared_ptr<Instance> instance, std::vector<Value> args);
+
+    /**
+     * @brief Get the return type, so that variable
+     *  creation and update can be enforced at parse time.
+     *
+     * "Flesh gives birth to flesh, but the Spirit gives birth to spirit." — John 3:6
+     */
+    std::shared_ptr<CreationType> getReturnType(ParserContext &ctx)
+    {
+        return returnType;
+    }
 
     std::string toString()
     {

--- a/src/jesus/parser/grammar/expr/ask_expr_rule.cpp
+++ b/src/jesus/parser/grammar/expr/ask_expr_rule.cpp
@@ -2,7 +2,7 @@
 #include "../../../ast/expr/ask_expr.hpp"
 #include "../../../ast/expr/literal_expr.hpp"
 #include "../../../ast/expr/variable_expr.hpp"
-#include "../../../types/creation_type.hpp"
+#include "../../../types/known_types.hpp"
 
 #include <memory>
 
@@ -14,7 +14,7 @@ std::unique_ptr<Expr> AskExprRule::parse(ParserContext &ctx)
     if (ctx.match(TokenType::STRING))
     {
         Value prompt = ctx.previous().literal;
-        return std::make_unique<AskExpr>(std::make_unique<LiteralExpr>(prompt));
+        return std::make_unique<AskExpr>(std::make_unique<LiteralExpr>(prompt, KnownTypes::STRING));
     }
 
     if (!ctx.match(TokenType::IDENTIFIER))

--- a/src/jesus/parser/grammar/expr/atomic/literals/born_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/born_rule.cpp
@@ -1,13 +1,14 @@
 #include "born_rule.hpp"
 #include "../../../../../ast/expr/literal_expr.hpp"
+#include "../../../../../types/known_types.hpp"
 
 std::unique_ptr<Expr> BornRule::parse(ParserContext &ctx)
 {
     if (ctx.match(TokenType::MALE))
-        return std::make_unique<LiteralExpr>(Value(true));
+        return std::make_unique<LiteralExpr>(Value(true), KnownTypes::SEX);
 
     if (ctx.match(TokenType::FEMALE))
-        return std::make_unique<LiteralExpr>(Value(false));
+        return std::make_unique<LiteralExpr>(Value(false), KnownTypes::SEX);
 
     return nullptr;
 }

--- a/src/jesus/parser/grammar/expr/atomic/literals/number_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/number_rule.cpp
@@ -1,12 +1,14 @@
 #include "number_rule.hpp"
 #include "../../../../../ast/expr/literal_expr.hpp"
+#include "../../../../../types/known_types.hpp"
 
 std::unique_ptr<Expr> NumberRule::parse(ParserContext &ctx)
 {
-    if (ctx.matchAny({TokenType::INT, TokenType::DOUBLE}))
-    {
-        return std::make_unique<LiteralExpr>(ctx.previous().literal);
-    }
+    if (ctx.match(TokenType::INT))
+        return std::make_unique<LiteralExpr>(ctx.previous().literal, KnownTypes::INT);
+
+    if (ctx.match(TokenType::DOUBLE))
+        return std::make_unique<LiteralExpr>(ctx.previous().literal, KnownTypes::DOUBLE);
 
     return nullptr;
 }

--- a/src/jesus/parser/grammar/expr/atomic/literals/string_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/string_rule.cpp
@@ -1,11 +1,12 @@
 #include "string_rule.hpp"
 #include "../../../../../ast/expr/literal_expr.hpp"
+#include "../../../../../types/known_types.hpp"
 
 std::unique_ptr<Expr> StringRule::parse(ParserContext &ctx)
 {
     if (ctx.match(TokenType::STRING))
     {
-        return std::make_unique<LiteralExpr>(ctx.previous().literal);
+        return std::make_unique<LiteralExpr>(ctx.previous().literal, KnownTypes::STRING);
     }
 
     return nullptr;

--- a/src/jesus/parser/grammar/expr/atomic/literals/weekday_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/weekday_rule.cpp
@@ -1,28 +1,29 @@
 #include "weekday_rule.hpp"
 #include "../../../../../ast/expr/literal_expr.hpp"
+#include "../../../../../types/known_types.hpp"
 
 std::unique_ptr<Expr> WeekdayRule::parse(ParserContext &ctx)
 {
     if (ctx.match(TokenType::LIGHDAY))
-        return std::make_unique<LiteralExpr>(Value(1));
+        return std::make_unique<LiteralExpr>(Value(1), KnownTypes::WEEKDAY);
 
     if (ctx.match(TokenType::SKYDAY))
-        return std::make_unique<LiteralExpr>(Value(2));
+        return std::make_unique<LiteralExpr>(Value(2), KnownTypes::WEEKDAY);
 
     if (ctx.match(TokenType::TREEDAY))
-        return std::make_unique<LiteralExpr>(Value(3));
+        return std::make_unique<LiteralExpr>(Value(3), KnownTypes::WEEKDAY);
 
     if (ctx.match(TokenType::LAMPDAY))
-        return std::make_unique<LiteralExpr>(Value(4));
+        return std::make_unique<LiteralExpr>(Value(4), KnownTypes::WEEKDAY);
 
     if (ctx.match(TokenType::FISHDAY))
-        return std::make_unique<LiteralExpr>(Value(5));
+        return std::make_unique<LiteralExpr>(Value(5), KnownTypes::WEEKDAY);
 
     if (ctx.match(TokenType::WALKDAY))
-        return std::make_unique<LiteralExpr>(Value(6));
+        return std::make_unique<LiteralExpr>(Value(6), KnownTypes::WEEKDAY);
 
     if (ctx.match(TokenType::SHABBAT))
-        return std::make_unique<LiteralExpr>(Value(7));
+        return std::make_unique<LiteralExpr>(Value(7), KnownTypes::WEEKDAY);
 
     return nullptr;
 }

--- a/src/jesus/parser/grammar/expr/atomic/literals/yes_no_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/yes_no_rule.cpp
@@ -1,13 +1,14 @@
 #include "yes_no_rule.hpp"
 #include "../../../../../ast/expr/literal_expr.hpp"
+#include "../../../../../types/known_types.hpp"
 
 std::unique_ptr<Expr> YesNoRule::parse(ParserContext &ctx)
 {
     if (ctx.match(TokenType::YES))
-        return std::make_unique<LiteralExpr>(Value(true));
+        return std::make_unique<LiteralExpr>(Value(true), KnownTypes::BOOLEAN);
 
     if (ctx.match(TokenType::NO))
-        return std::make_unique<LiteralExpr>(Value(false));
+        return std::make_unique<LiteralExpr>(Value(false), KnownTypes::BOOLEAN);
 
     return nullptr;
 }

--- a/src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
@@ -14,17 +14,17 @@ std::unique_ptr<Stmt> CreateVarStmtRule::parse(ParserContext &ctx)
     if (!ctx.match(TokenType::IDENTIFIER))
         throw std::runtime_error("Expected variable type after 'create'");
 
-    std::string varType = ctx.previous().lexeme;
+    std::string varType_ = ctx.previous().lexeme;
 
     if (!ctx.match(TokenType::IDENTIFIER))
         throw std::runtime_error("Expected variable name after 'create type'");
 
     std::string varName = ctx.previous().lexeme;
 
-    auto creationType = KnownTypes::resolve(varType, "core");
-    if (!creationType)
+    auto varType = KnownTypes::resolve(varType_, "core");
+    if (!varType)
     {
-        throw std::runtime_error("Unknown variable type: '" + varType + "'");
+        throw std::runtime_error("Unknown variable type: '" + varType_ + "'");
     }
 
     std::unique_ptr<Expr> value = nullptr;
@@ -40,33 +40,40 @@ std::unique_ptr<Stmt> CreateVarStmtRule::parse(ParserContext &ctx)
             if (!ask_expr)
                 throw std::runtime_error("Expected a text literal or a text-typed variable after 'ask' (e.g., ask \"What is your name?\" or ask question).");
 
-            ctx.registerVarType(creationType->name, varName);
+            ctx.registerVarType(varType->name, varName);
 
-            return std::make_unique<CreateVarWithAskStmt>(*creationType, varName, std::move(ask_expr));
+            return std::make_unique<CreateVarWithAskStmt>(varType, varName, std::move(ask_expr));
         }
         value = expression->parse(ctx);
         if (!value)
             throw std::runtime_error("Expected expression after '=' in create statement.");
+
+        auto valueType = value->getReturnType(ctx);
+        bool typesMatch = varType == valueType;
+        if (!typesMatch)
+        {
+            throw std::runtime_error("Invalid value type \"" + valueType->name + "\" to variable '" + varName + "' declared as type " + varType->name);
+        }
 
         // Evaluating functions that could send an 'ok' to bomb explosions is not safe.
         // Let's warn this until we can check the return type from functions
         std::cerr << "🔴️ FIXME: Should not call interpreter here. Remove this once functions and static type inference are implemented.\n";
 
         Value evaluated = ctx.interpreter->evaluate(value);
-        if (!creationType->validate(evaluated))
+        if (!varType->validate(evaluated))
         {
             throw std::runtime_error("Error: Invalid value value \"" + evaluated.toString() + "\" to variable '" + varName + "' declared as type " + creationType->name);
         }
 
-        if (creationType->isClass())
+        if (varType->isClass())
         {
-            auto instance = std::make_shared<Instance>(creationType);
+            auto instance = std::make_shared<Instance>(varType);
             evaluated = Value(instance);
-            value = std::make_unique<LiteralExpr>(evaluated); // TODO: Consider constructor and 'if' expression
+            value = std::make_unique<LiteralExpr>(evaluated, value->getReturnType(ctx)); // TODO: Consider constructor and 'if' expression
         }
 
-        ctx.registerVarType(creationType->name, varName);
+        ctx.registerVarType(varType->name, varName);
     }
 
-    return std::make_unique<CreateVarStmt>(varType, varName, std::move(value));
+    return std::make_unique<CreateVarStmt>(varType_, varName, std::move(value));
 }

--- a/src/jesus/parser/grammar/stmt/update_var_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/update_var_stmt_rule.cpp
@@ -28,7 +28,7 @@ std::unique_ptr<Stmt> UpdateVarStmtRule::parse(ParserContext &ctx)
         if (!ask_expr)
             throw std::runtime_error("Expected a text literal or a text-typed variable after 'ask' (e.g., ask \"What is your name again?\" or ask question).");
 
-        return std::make_unique<UpdateVarWithAskStmt>(*varType, varName, std::move(ask_expr));
+        return std::make_unique<UpdateVarWithAskStmt>(varType, varName, std::move(ask_expr));
     }
 
     std::unique_ptr<Expr> value = expression->parse(ctx);

--- a/src/jesus/spirit/symbol_table.hpp
+++ b/src/jesus/spirit/symbol_table.hpp
@@ -93,7 +93,7 @@ public:
                 return type;
         }
 
-        return nullptr;
+        throw std::runtime_error("Variable '" + varName + "' not found. Are you really sure it has been declared?");
     }
 
     void registerVarType(const std::string &type, const std::string &name)

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -223,6 +223,8 @@ let there be Person:
     purpose aToB(number a; number b):
         say "a before"
         say a
+        create number c = 1
+        create number d = a
         say "b before"
         say b
         say "before update b"
@@ -231,10 +233,15 @@ let there be Person:
         a = b
         say "a updated"
         say a
+        b = d
         say b
         say name
         name = "Adopted by Jesus Christ"
         say name
+        c = d
+        say c
+        c = age
+        say c
     amen
     purpose functionWithoutParams():
         say "I am inside functionWithoutParams"

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -135,19 +135,19 @@
 (Jesus) ❌ Error: Undefined variable: abc (scope: global)
 (Jesus) (Jesus) (int) 9
 (Jesus) (Jesus) (Jesus) (double) -6.000000
-(Jesus) ❌ Error: Expected value < (double) 0.000000
+(Jesus) ❌ Error: Variable 'debit' expects a Negative, but got: 'number'.
 (Jesus) (Jesus) (Jesus) (int) 7
 (Jesus) ❌ Error: Expected value >= (double) 7.000000
 (Jesus) (Jesus) (Jesus) ❌ Error: Expected value <= (double) 12.000000
 (Jesus) (int) 12
-(Jesus) (Jesus) (Jesus) ❌ Error: Value "no" does not match expected pattern.
+(Jesus) (Jesus) (Jesus) ❌ Error: Variable 'sure' expects a Confirm, but got: 'text'.
 (Jesus) Yes
 (Jesus) (Jesus) What is your age? (Jesus) (double) 18.000000
 (Jesus) Qual sua idade? Validation failed: Invalid number: 'seven'
 Qual sua idade? Validation failed: Invalid number: 'fourteen'
 Qual sua idade? (Jesus) (double) 33.000000
-(Jesus) ❌ Error: Variable 'PI' not found. Are you really sure it was declared?
-(Jesus) ❌ Error: Variable 'temperature' not found. Are you really sure it was declared?
+(Jesus) ❌ Error: Variable 'PI' not found. Are you really sure it has been declared?
+(Jesus) ❌ Error: Variable 'temperature' not found. Are you really sure it has been declared?
 (Jesus) What is your age again? Validation failed: Invalid number: 'fourty'
 What is your age again? Validation failed: Invalid number: 'eternal'
 What is your age again? (Jesus) (double) 2025.000000
@@ -197,9 +197,11 @@ before update b
 before update a
 a updated
 (int) 99
-(int) 99
+(int) 7
 Adam
 Adopted by Jesus Christ
+(int) 7
+(int) 930
 null
 (Jesus) The new name v2 is: 
 (Jesus) Adopted by Jesus Christ

--- a/src/jesus/types/atomic/literals/boolean.hpp
+++ b/src/jesus/types/atomic/literals/boolean.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "truth.hpp"
+
+using BooleanType = TruthType;

--- a/src/jesus/types/atomic/literals/born.hpp
+++ b/src/jesus/types/atomic/literals/born.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "sex.hpp"
+
+/**
+ * @brief Literal values: male, female
+ *
+ * BornType is just an alias for SexType.
+ *
+ * "So God created mankind in his own image,
+ * in the image of God he created them;
+ * male and female he created them." — Genesis 1:27
+ */
+using BornType = SexType;

--- a/src/jesus/types/atomic/literals/sex.hpp
+++ b/src/jesus/types/atomic/literals/sex.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "../../creation_type.hpp"
+
+/**
+ * @brief Literal values: male, female
+ *
+ * "So God created mankind in his own image,
+ * in the image of God he created them;
+ * male and female he created them." — Genesis 1:27
+ */
+class SexType : public CreationType
+{
+public:
+    SexType() : CreationType(PrimitiveType::Boolean, "sex", "core") {}
+
+    bool validate(const Value &value) const override
+    {
+        return value.IS_BOOLEAN;
+    }
+};

--- a/src/jesus/types/atomic/literals/truth.hpp
+++ b/src/jesus/types/atomic/literals/truth.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../../creation_type.hpp"
+
+/**
+ * @brief In Jesus Programming Language, the boolean type is called Truth.
+ *
+ * It represents alignment with truth (yes/no).
+ * For compatibility, boolean.hpp exists as an alias.
+ *
+ * Jesus answered, "I am the way and the truth and the life. No one comes to the Father except through me." — John 14:6
+ */
+class TruthType : public CreationType
+{
+public:
+    TruthType() : CreationType(PrimitiveType::Boolean, "truth", "core") {}
+
+    bool validate(const Value &value) const override
+    {
+        return value.IS_BOOLEAN;
+    }
+};

--- a/src/jesus/types/atomic/literals/weekday.hpp
+++ b/src/jesus/types/atomic/literals/weekday.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "../../creation_type.hpp"
+
+/**
+ * @brief Values: lightday, skyday, treeday, lampday, fishday, walkday, shabbat
+ *
+ * It represents alignment with the numbers and 'secular' weekday names:
+ *  sunday      = lightday  = 1
+ *  monday      = skyday    = 2
+ *  tuesday     = treeday   = 3
+ *  wednesday   = lampday   = 4
+ *  thursday    = fishday   = 5
+ *  friday      = walkday   = 6
+ *  saturday    = shabbat   = 7
+ *
+ * And God said, "Let there be light,"" and there was light.
+ * God saw that the light was good, and he separated the light from the darkness.
+ * God called the light "day,"" and the darkness he called "night."
+ * And there was evening, and there was morning—the first day. — Genesis 1:3-5
+ */
+class WeekdayType : public CreationType
+{
+public:
+    WeekdayType() : CreationType(PrimitiveType::Boolean, "weekday", "core") {}
+
+    bool validate(const Value &value) const override
+    {
+        if (!value.IS_INT)
+            return false;
+
+        int number = value.toInt();
+
+        return number >= 1 && number <= 7;
+    }
+};

--- a/src/jesus/types/composite/class_type.hpp
+++ b/src/jesus/types/composite/class_type.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "../creation_type.hpp"
+
+/**
+ * @brief Represents a user-defined class type in the language.
+ *
+ * Just as man is the crown of creation, made in God’s image,
+ * classes represent the highest form of creation in the program,
+ * shaping structure and behavior.
+ *
+ * "So God created mankind in his own image,
+ * in the image of God he created them;
+ * male and female he created them."
+ * — Genesis 1:27
+ */
+class ClassType : public CreationType
+{
+public:
+    ClassType() : CreationType(PrimitiveType::Class, "class", "core") {}
+
+    bool validate(const Value &value) const override
+    {
+        return value.IS_INSTANCE;
+    }
+};

--- a/src/jesus/types/creation_type.hpp
+++ b/src/jesus/types/creation_type.hpp
@@ -8,9 +8,10 @@ class Method; // Forward declaration
 
 enum class PrimitiveType
 {
-    Class,
+    Boolean,
     Number,
-    Text
+    Text,
+    Class
 };
 
 class CreationType

--- a/src/jesus/types/known_types.cpp
+++ b/src/jesus/types/known_types.cpp
@@ -10,6 +10,7 @@
 #include "atomic/strings/text_type.hpp"
 #include "atomic/strings/word_type.hpp"
 #include "atomic/strings/phrase_type.hpp"
+#include "composite/class_type.hpp"
 #include <memory>
 
 void KnownTypes::registerBuiltInTypes()
@@ -23,6 +24,8 @@ void KnownTypes::registerBuiltInTypes()
     auto floating = std::make_shared<RealType>();
     auto text = std::make_shared<TextType>();
 
+    auto klass = std::make_shared<ClassType>();
+
     BOOLEAN = TRUTH = truth;
     BORN = SEX = sex;
     WEEKDAY = weekday;
@@ -32,6 +35,7 @@ void KnownTypes::registerBuiltInTypes()
     FLOAT = floating;
     DOUBLE = floating; // TODO: Really differentiate 'float' from 'double'
     STRING = text;
+    CLASS = klass;
 
     registerType(truth);
     registerType(sex);
@@ -46,6 +50,8 @@ void KnownTypes::registerBuiltInTypes()
     registerType(text);
     registerType(std::make_shared<WordType>());
     registerType(std::make_shared<PhraseType>());
+
+    registerType(klass);
 }
 
 void KnownTypes::registerType(std::shared_ptr<CreationType> type)

--- a/src/jesus/types/known_types.cpp
+++ b/src/jesus/types/known_types.cpp
@@ -1,4 +1,7 @@
 #include "known_types.hpp"
+#include "atomic/literals/truth.hpp"
+#include "atomic/literals/sex.hpp"
+#include "atomic/literals/weekday.hpp"
 #include "atomic/numbers/number_type.hpp"
 #include "atomic/numbers/real_type.hpp"
 #include "atomic/numbers/natural_type.hpp"
@@ -11,15 +14,38 @@
 
 void KnownTypes::registerBuiltInTypes()
 {
-    registerType(std::make_unique<WordType>());
-    registerType(std::make_unique<PhraseType>());
-    registerType(std::make_unique<TextType>());
+    auto truth = std::make_shared<TruthType>();
+    auto sex = std::make_shared<SexType>();
+    auto weekday = std::make_shared<WeekdayType>();
 
-    registerType(std::make_unique<RealType>());
-    registerType(std::make_unique<NumberType>());
-    registerType(std::make_unique<NaturalType>());
-    registerType(std::make_unique<PercentageType>());
-    registerType(std::make_unique<DecimalType>());
+    auto integer = std::make_shared<NumberType>();
+    auto natural = std::make_shared<NaturalType>();
+    auto floating = std::make_shared<RealType>();
+    auto text = std::make_shared<TextType>();
+
+    BOOLEAN = TRUTH = truth;
+    BORN = SEX = sex;
+    WEEKDAY = weekday;
+
+    INT = integer;
+    NATURAL = natural;
+    FLOAT = floating;
+    DOUBLE = floating; // TODO: Really differentiate 'float' from 'double'
+    STRING = text;
+
+    registerType(truth);
+    registerType(sex);
+    registerType(weekday);
+
+    registerType(integer);
+    registerType(natural);
+    registerType(floating);
+    registerType(std::make_shared<PercentageType>());
+    registerType(std::make_shared<DecimalType>());
+
+    registerType(text);
+    registerType(std::make_shared<WordType>());
+    registerType(std::make_shared<PhraseType>());
 }
 
 void KnownTypes::registerType(std::shared_ptr<CreationType> type)

--- a/src/jesus/types/known_types.hpp
+++ b/src/jesus/types/known_types.hpp
@@ -33,6 +33,8 @@ public:
     inline static std::shared_ptr<CreationType> DOUBLE;
 
     inline static std::shared_ptr<CreationType> STRING;
+
+    inline static std::shared_ptr<CreationType> CLASS;
     // -------------------------------------------------------------------
 
 private:

--- a/src/jesus/types/known_types.hpp
+++ b/src/jesus/types/known_types.hpp
@@ -16,6 +16,25 @@ public:
 
     static bool isValid(const CreationType *type, const Value &value);
 
+    // -------------------------------------------------------------------
+    // Direct access for common types for fast type analysis at parse time
+    // -------------------------------------------------------------------
+    inline static std::shared_ptr<CreationType> SEX;
+    inline static std::shared_ptr<CreationType> BORN;
+
+    inline static std::shared_ptr<CreationType> TRUTH;
+    inline static std::shared_ptr<CreationType> BOOLEAN;
+
+    inline static std::shared_ptr<CreationType> WEEKDAY;
+
+    inline static std::shared_ptr<CreationType> INT;
+    inline static std::shared_ptr<CreationType> NATURAL; // unsigned int
+    inline static std::shared_ptr<CreationType> FLOAT;
+    inline static std::shared_ptr<CreationType> DOUBLE;
+
+    inline static std::shared_ptr<CreationType> STRING;
+    // -------------------------------------------------------------------
+
 private:
     /**
      * @brief  Joins module and type name (e.g. core.born)


### PR DESCRIPTION
# Description

This PR introduces major improvements to the Jesus language type system and AST consistency:  

- **Types**  
  - Added new types and aliases:  
    - `BooleanType` → `TruthType`  
    - `BornType` → `SexType`  
    - Added `WeekdayType`  
  - Improved semantic clarity and alignment with domain concepts.  

- **AST**  
  - Added `getReturnType()` method to `Expr` and all derived classes.  
  - Enables the parser to infer expression types without evaluation (without calling the interpreter).  
  - Strengthens static analysis and compile-time safety.  

- **Parser**  
  - Passes type information directly to `LiteralExpr` during parsing.  
  - Guarantees stronger type consistency in the AST.  

- **Interpreter**  
  - Ensures the `CLASS` type is passed when creating instances.  
  - Enables static type validation at parse time instead of only at runtime.  

Together, these changes refine the type system, make the AST safer and more expressive, and align instance handling with the static type checker.  

### Future improvements

When creating variables, we are still calling the interpreter. 

* In the next PRs, we will improve this to avoid calling the interpreter at parse time.

# ✝️ Wisdom

>  " For God is not a God of disorder but of peace—as in all the congregations of the Lord’s people." — **1 Corinthians 14:33**
