### PR TITLE
Step 42: Introduced full f-string support with vars and  attribute access -  feat(f-string)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 ignore-this-folder
 build
 src/jesus/utils/version.hpp
+test_runner

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ set(JESUS_CPP_FILES
     src/jesus/ast/expr/create_instance_expr.cpp
     src/jesus/ast/expr/get_attr_expr.cpp
     src/jesus/ast/expr/method_call_expr.cpp
+    src/jesus/ast/expr/formatted_string_expr.cpp
     src/jesus/ast/expr/grouping_expr.cpp
     src/jesus/ast/expr/conditional_expr.cpp
 
@@ -127,6 +128,7 @@ set(JESUS_CPP_FILES
 
     src/jesus/parser/grammar/expr/atomic/literals/number_rule.cpp
     src/jesus/parser/grammar/expr/atomic/literals/string_rule.cpp
+    src/jesus/parser/grammar/expr/atomic/literals/formatted_string_rule.cpp
     src/jesus/parser/grammar/expr/atomic/literals/yes_no_rule.cpp
     src/jesus/parser/grammar/expr/atomic/literals/variable_rule.cpp
     src/jesus/parser/grammar/expr/atomic/literals/born_rule.cpp

--- a/src/jesus/ast/expr/expr.hpp
+++ b/src/jesus/ast/expr/expr.hpp
@@ -8,6 +8,8 @@ class ParserContext; // Forward declaration
 enum class ExprKind
 {
     Literal,
+    Variable,
+    GetAttribute,
     Other
 };
 
@@ -40,6 +42,25 @@ public:
     virtual bool canEvaluateAtParseTime() const
     {
         return kind == ExprKind::Literal;
+    }
+
+    /**
+     * @brief Indicates whether the expression can be used inside a formatted string.
+     *
+     * Only certain expression types — currently variables and attribute accesses —
+     * are allowed in formatted strings. This restriction enforces clarity and
+     * predictability, following the principles of Object Calisthenics and the
+     * 10 NASA rules for safer and more maintainable code.
+     *
+     * By limiting the allowed expression types, we prevent complex or side-effecting
+     * expressions from appearing inside string interpolation, which helps avoid
+     * subtle bugs and makes the interpreter logic simpler.
+     *
+     * @return true if this expression is safe to use in a formatted string.
+     */
+    virtual bool canBeUsedInFormattedString() const
+    {
+        return kind == ExprKind::Variable || kind == ExprKind::GetAttribute;
     }
 
     /**

--- a/src/jesus/ast/expr/formatted_string_expr.cpp
+++ b/src/jesus/ast/expr/formatted_string_expr.cpp
@@ -1,0 +1,13 @@
+#include "formatted_string_expr.hpp"
+#include "../../types/known_types.hpp"
+#include "../../interpreter/expr_visitor.hpp"
+
+Value FormattedStringExpr::accept(ExprVisitor &visitor) const
+{
+    return visitor.visitFormattedStringExpr(*this);
+}
+
+std::shared_ptr<CreationType> FormattedStringExpr::getReturnType(ParserContext &ctx) const
+{
+    return KnownTypes::STRING;
+}

--- a/src/jesus/ast/expr/formatted_string_expr.hpp
+++ b/src/jesus/ast/expr/formatted_string_expr.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "expr.hpp"
+
+/**
+ * @brief AST node representing a formatted string literal.
+ *
+ * A formatted string is introduced with double quotes ("...") and may contain
+ * placeholders in curly braces (e.g. "Hello, {name}").
+ *
+ * Parsing splits the string into:
+ *   - literal parts (text between placeholders),
+ *   - variable names (identifiers inside braces).
+ *
+ * At runtime, the interpreter evaluates each variable and constructs
+ * the final string. This allows safe string interpolation without manual
+ * concatenation.
+ *
+ * Compared to LiteralExpr:
+ *   - LiteralExpr: stores a static, raw string (no substitution).
+ *   - FormattedStringExpr: stores both literal parts and variables,
+ *     enabling dynamic substitution at evaluation time.
+ *
+ * This design supports internationalization (i18n) and ensures safety by
+ * checking that all variables are declared at parse time.
+ *
+ * "I too will have my say; I too will tell what I know." — Job 32:17
+ */
+class FormattedStringExpr : public Expr
+{
+public:
+    const std::string raw;              // original string e.g., "Hello {name}"
+    std::vector<std::string> parts;     // literal parts
+    std::vector<std::string> variables; // variable names
+
+    explicit FormattedStringExpr(const std::string rawStr,
+                                 std::vector<std::string> parts,
+                                 std::vector<std::string> vars)
+        : raw(rawStr), parts(std::move(parts)), variables(std::move(vars)) {}
+
+    Value evaluate(std::shared_ptr<Heart> heart) const override
+    {
+        return Value(raw);
+    }
+
+    Value accept(ExprVisitor &visitor) const override;
+
+    /**
+     * @brief Get the return type of the expression, so that variable
+     *  creation and update can be enforced at parse time.
+     *
+     * "Flesh gives birth to flesh, but the Spirit gives birth to spirit." — John 3:6
+     */
+    std::shared_ptr<CreationType> getReturnType(ParserContext &ctx) const override;
+
+    /**
+     * @brief Returns a string representation of the expression.
+     *
+     * "For nothing is hidden that will not be made manifest, nor is anything
+     * secret that will not be known and come to light." — Luke 8:17
+     */
+    virtual std::string toString() const override { return "FormattedStringExpr('" + raw + ")'"; }
+};

--- a/src/jesus/ast/expr/formatted_string_expr.hpp
+++ b/src/jesus/ast/expr/formatted_string_expr.hpp
@@ -31,12 +31,12 @@ class FormattedStringExpr : public Expr
 public:
     const std::string raw;              // original string e.g., "Hello {name}"
     std::vector<std::string> parts;     // literal parts
-    std::vector<std::string> variables; // variable names
+    std::vector<std::unique_ptr<Expr>> expressions;
 
     explicit FormattedStringExpr(const std::string rawStr,
                                  std::vector<std::string> parts,
-                                 std::vector<std::string> vars)
-        : raw(rawStr), parts(std::move(parts)), variables(std::move(vars)) {}
+                                 std::vector<std::unique_ptr<Expr>> expressions)
+        : raw(rawStr), parts(std::move(parts)), expressions(std::move(expressions)) {}
 
     Value evaluate(std::shared_ptr<Heart> heart) const override
     {

--- a/src/jesus/ast/expr/get_attr_expr.hpp
+++ b/src/jesus/ast/expr/get_attr_expr.hpp
@@ -9,7 +9,7 @@ public:
     std::string attribute;
 
     GetAttributeExpr(std::unique_ptr<Expr> object, std::string attribute)
-        : object(std::move(object)), attribute(std::move(attribute)) {}
+        : object(std::move(object)), attribute(std::move(attribute)), Expr(ExprKind::GetAttribute) {}
 
     Value evaluate(std::shared_ptr<Heart> heart) const override
     {

--- a/src/jesus/ast/expr/variable_expr.hpp
+++ b/src/jesus/ast/expr/variable_expr.hpp
@@ -33,7 +33,7 @@ public:
      * @param name The name of the variable being referenced (e.g., prophet).
      */
     explicit VariableExpr(const std::string &name)
-        : name(name) {}
+        : name(name), Expr(ExprKind::Variable) {}
 
     Value evaluate(std::shared_ptr<Heart> heart) const override
     {

--- a/src/jesus/interpreter/expr_visitor.hpp
+++ b/src/jesus/interpreter/expr_visitor.hpp
@@ -11,6 +11,7 @@
 #include "../ast/expr/create_instance_expr.hpp"
 #include "../ast/expr/get_attr_expr.hpp"
 #include "../ast/expr/method_call_expr.hpp"
+#include "../ast/expr/formatted_string_expr.hpp"
 
 /**
  * @brief Interface for visiting and evaluating expression nodes in the AST.
@@ -57,6 +58,7 @@ public:
     virtual Value visitCreateInstanceExpr(const CreateInstanceExpr &expr) = 0;
     virtual Value visitGetAttribute(const GetAttributeExpr &expr) = 0;
     virtual Value visitMethodCallExpr(const MethodCallExpr &expr) = 0;
+    virtual Value visitFormattedStringExpr(const FormattedStringExpr &expr) = 0;
 
     virtual ~ExprVisitor() = default;
 };

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -110,7 +110,7 @@ Value Interpreter::visitFormattedStringExpr(const FormattedStringExpr &expr)
 
 Value Interpreter::visitAsk(const AskExpr &expr)
 {
-    auto question = expr.evaluate(symbol_table.currentScope());
+    Value question = expr.prompt->accept(*this);
     return question;
 }
 
@@ -133,7 +133,7 @@ void Interpreter::visitCreateVar(const CreateVarStmt &stmt)
 Value Interpreter::askAndValidate(const std::shared_ptr<Expr> ask_expr, std::shared_ptr<CreationType> var_type)
 {
     // Step 1: Evaluate the ask expression (e.g., ask "Your age?")
-    Value question = ask_expr->evaluate(symbol_table.currentScope());
+    Value question = ask_expr->accept(*this);
 
     while (true)
     {

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -62,7 +62,8 @@ Value Interpreter::visitVariable(const VariableExpr &expr)
     return symbol_table.getVar(expr.name);
 }
 
-Value Interpreter::visitCreateInstanceExpr(const CreateInstanceExpr &expr) {
+Value Interpreter::visitCreateInstanceExpr(const CreateInstanceExpr &expr)
+{
     auto instance = std::make_shared<Instance>(expr.klass);
     return Value(instance);
 }
@@ -88,6 +89,23 @@ Value Interpreter::visitMethodCallExpr(const MethodCallExpr &expr)
         args.push_back(argExpr->accept(*this));
 
     return expr.method->call(*this, instance, std::move(args));
+}
+
+Value Interpreter::visitFormattedStringExpr(const FormattedStringExpr &expr)
+{
+    std::string result;
+
+    for (size_t i = 0; i < expr.parts.size(); ++i)
+    {
+        result += expr.parts[i];
+        if (i < expr.variables.size())
+        {
+            Value val = symbol_table.getVar(expr.variables[i]);
+            result += val.toString();
+        }
+    }
+
+    return Value(result);
 }
 
 Value Interpreter::visitAsk(const AskExpr &expr)

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -98,9 +98,9 @@ Value Interpreter::visitFormattedStringExpr(const FormattedStringExpr &expr)
     for (size_t i = 0; i < expr.parts.size(); ++i)
     {
         result += expr.parts[i];
-        if (i < expr.variables.size())
+        if (i < expr.expressions.size())
         {
-            Value val = symbol_table.getVar(expr.variables[i]);
+            Value val = expr.expressions[i]->accept(*this);
             result += val.toString();
         }
     }

--- a/src/jesus/interpreter/interpreter.hpp
+++ b/src/jesus/interpreter/interpreter.hpp
@@ -84,6 +84,11 @@ public:
     void execute(const std::shared_ptr<Stmt> &stmt);
     inline void loves(const std::unique_ptr<Stmt> &stmt) { execute(stmt); }
 
+    const bool variableExists(const std::string &varName)
+    {
+        return symbol_table.variableExists(varName);
+    }
+
     std::shared_ptr<CreationType> getVarType(const std::string &varName)
     {
         return symbol_table.getVarType(varName);
@@ -166,6 +171,8 @@ private:
     Value visitGetAttribute(const GetAttributeExpr &expr) override;
 
     Value visitMethodCallExpr(const MethodCallExpr &expr) override;
+
+    Value visitFormattedStringExpr(const FormattedStringExpr &expr) override;
 
     /**
      * @brief Evaluates an AskExpr by evaluating its prompt expression.

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -32,7 +32,8 @@ enum class TokenType
     NO,             // 18
     INT,            // 19
     DOUBLE,         // 20
-    STRING,         // 21
+    RAW_STRING,         // With single quotes, like in bash: 'hello world'
+    FORMATTED_STRING,   // Double quotes: "Hi, {user}"
     IDENTIFIER,     // varname, attribute
     LEFT_PAREN,     // (
     RIGHT_PAREN,    // )

--- a/src/jesus/parser/grammar/expr/ask_expr_rule.cpp
+++ b/src/jesus/parser/grammar/expr/ask_expr_rule.cpp
@@ -11,7 +11,7 @@ std::unique_ptr<Expr> AskExprRule::parse(ParserContext &ctx)
     if (!ctx.match(TokenType::ASK))
         return nullptr;
 
-    if (ctx.match(TokenType::STRING))
+    if (ctx.matchAny({TokenType::RAW_STRING, TokenType::FORMATTED_STRING}))
     {
         Value prompt = ctx.previous().literal;
         return std::make_unique<AskExpr>(std::make_unique<LiteralExpr>(prompt, KnownTypes::STRING));

--- a/src/jesus/parser/grammar/expr/ask_expr_rule.cpp
+++ b/src/jesus/parser/grammar/expr/ask_expr_rule.cpp
@@ -3,6 +3,7 @@
 #include "../../../ast/expr/literal_expr.hpp"
 #include "../../../ast/expr/variable_expr.hpp"
 #include "../../../types/known_types.hpp"
+#include "../jesus_grammar.hpp"
 
 #include <memory>
 
@@ -11,10 +12,21 @@ std::unique_ptr<Expr> AskExprRule::parse(ParserContext &ctx)
     if (!ctx.match(TokenType::ASK))
         return nullptr;
 
-    if (ctx.matchAny({TokenType::RAW_STRING, TokenType::FORMATTED_STRING}))
+    if (ctx.match(TokenType::RAW_STRING))
     {
         Value prompt = ctx.previous().literal;
         return std::make_unique<AskExpr>(std::make_unique<LiteralExpr>(prompt, KnownTypes::STRING));
+    }
+
+    int snapshot = ctx.snapshot();
+    if (ctx.match(TokenType::FORMATTED_STRING))
+    {
+        ctx.restore(snapshot);
+        auto formattedExpr = grammar::FormattedString->parse(ctx);
+        if (!formattedExpr)
+            throw std::runtime_error("Failed to parse formatted string for 'ask' prompt.");
+
+        return std::make_unique<AskExpr>(std::move(formattedExpr));
     }
 
     if (!ctx.match(TokenType::IDENTIFIER))

--- a/src/jesus/parser/grammar/expr/atomic/literals/formatted_string_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/formatted_string_rule.cpp
@@ -1,0 +1,52 @@
+#include "formatted_string_rule.hpp"
+#include "../../../../../ast/expr/literal_expr.hpp"
+#include "../../../../../ast/expr/formatted_string_expr.hpp"
+#include "../../../../../types/known_types.hpp"
+
+std::unique_ptr<Expr> FormattedStringRule::parse(ParserContext &ctx)
+{
+    if (!ctx.match(TokenType::FORMATTED_STRING))
+        return nullptr;
+
+    Token token = ctx.previous();
+    const std::string raw = token.literal.toString();
+
+    std::vector<std::string> parts;
+    std::vector<std::string> variables;
+
+    size_t pos = 0;
+    while (pos < raw.size())
+    {
+        // Each part goes until until the next brace '{'
+        size_t open = raw.find('{', pos);
+        if (open == std::string::npos)
+        {
+            parts.push_back(raw.substr(pos));
+            break;
+        }
+
+        // Find the closing brace '}'
+        size_t close = raw.find('}', open);
+        if (close == std::string::npos)
+            throw std::runtime_error("Unclosed brace '}' in formatted string: " + raw);
+
+        // literal before the next brace
+        parts.push_back(raw.substr(pos, open - pos));
+
+        // variable name inside the brace
+        std::string varName = raw.substr(open + 1, close - open - 1);
+
+        // Validate it's a declared variable (only identifiers allowed)
+        if (!ctx.variableExists(varName))
+            throw std::runtime_error("Undeclared variable in formatted string: " + varName);
+
+        variables.push_back(varName);
+
+        pos = close + 1;
+    }
+
+    if (variables.empty())
+        return std::make_unique<LiteralExpr>(token.literal, KnownTypes::STRING);
+
+    return std::make_unique<FormattedStringExpr>(std::move(raw), std::move(parts), std::move(variables));
+}

--- a/src/jesus/parser/grammar/expr/atomic/literals/formatted_string_rule.hpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/formatted_string_rule.hpp
@@ -1,0 +1,22 @@
+
+#pragma once
+#include "../../../grammar_rule.hpp"
+
+/**
+ * @brief Matches a formatted string literal: "Hi, {user}".
+ *
+ * A formatted string is like a raw string, but may include {varname} placeholders.
+ * Only variables are allowed inside braces (no full expressions).
+ *
+ * Formatted strings also use double quotes, '"', whereas raw strings use single quotes.
+ */
+class FormattedStringRule : public IGrammarRule
+{
+public:
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override;
+
+    std::string toStr(GrammarRuleHashTable &visitedTable) const override
+    {
+        return "FormattedStringRule";
+    }
+};

--- a/src/jesus/parser/grammar/expr/atomic/literals/string_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/string_rule.cpp
@@ -4,7 +4,7 @@
 
 std::unique_ptr<Expr> StringRule::parse(ParserContext &ctx)
 {
-    if (ctx.match(TokenType::STRING))
+    if (ctx.match(TokenType::RAW_STRING))
     {
         return std::make_unique<LiteralExpr>(ctx.previous().literal, KnownTypes::STRING);
     }

--- a/src/jesus/parser/grammar/expr/atomic/literals/string_rule.hpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/string_rule.hpp
@@ -3,7 +3,7 @@
 #include "../../../grammar_rule.hpp"
 
 /**
- * @brief Matches a string literal.
+ * @brief Matches a string literal with single quotes: 'Jesus loves you'.
  */
 class StringRule : public IGrammarRule
 {

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -14,6 +14,7 @@
 
 #include "expr/atomic/literals/number_rule.hpp"
 #include "expr/atomic/literals/string_rule.hpp"
+#include "expr/atomic/literals/formatted_string_rule.hpp"
 #include "expr/atomic/literals/variable_rule.hpp"
 #include "expr/atomic/literals/yes_no_rule.hpp"
 #include "expr/atomic/literals/born_rule.hpp"
@@ -65,6 +66,7 @@ namespace grammar
 
     inline auto Number = std::make_shared<NumberRule>();
     inline auto String = std::make_shared<StringRule>();
+    inline auto FormattedString = std::make_shared<FormattedStringRule>();
     inline auto YesNo = std::make_shared<YesNoRule>(); // yes|no
     inline auto Sex = std::make_shared<BornRule>(); // male|female
     inline auto Weekday = std::make_shared<WeekdayRule>(); // lighday|skyday|treeday|lampday|fishday|walkday|shabbat
@@ -74,7 +76,7 @@ namespace grammar
     /**
      * @brief Primary is anything that can be evaluated directly: number, string, or a grouped expression.
      */
-    inline auto Primary = Number | String | YesNo | Sex | Weekday | Variable | Group(Expression);
+    inline auto Primary = Number | String | FormattedString | YesNo | Sex | Weekday | Variable | Group(Expression);
     inline auto GetAttribute = std::make_shared<GetAttributeRule>(Primary);
 
     // ----------

--- a/src/jesus/parser/grammar/stmt/create_var_type_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_var_type_stmt_rule.cpp
@@ -99,7 +99,7 @@ std::unique_ptr<Stmt> CreateVarTypeStmtRule::parse(ParserContext &ctx)
                 throw std::runtime_error("Expected a text value after 'matches' (e.g., matches \"abc\")");
 
             if (! expr->canEvaluateAtParseTime()) {
-                throw std::runtime_error("Expected a string literal after 'matches', not a formatted string. (e.g., matches \"yes\")");
+                throw std::runtime_error("Expected a string literal after 'matches', not a formatted string. (e.g., matches \"IForgive\")");
             }
 
             Value value = ctx.interpreter->evaluate(expr);

--- a/src/jesus/parser/grammar/stmt/create_var_type_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_var_type_stmt_rule.cpp
@@ -91,8 +91,16 @@ std::unique_ptr<Stmt> CreateVarTypeStmtRule::parse(ParserContext &ctx)
         else if (ctx.match(TokenType::MATCHES))
         {
             auto expr = grammar::String->parse(ctx);
+            if (!expr) {
+                expr = grammar::FormattedString->parse(ctx);
+            }
+
             if (!expr)
                 throw std::runtime_error("Expected a text value after 'matches' (e.g., matches \"abc\")");
+
+            if (! expr->canEvaluateAtParseTime()) {
+                throw std::runtime_error("Expected a string literal after 'matches', not a formatted string. (e.g., matches \"yes\")");
+            }
 
             Value value = ctx.interpreter->evaluate(expr);
             constraints.emplace_back(std::make_shared<MatchesRegexConstraint>(value.toString()));

--- a/src/jesus/parser/parser_context.cpp
+++ b/src/jesus/parser/parser_context.cpp
@@ -10,6 +10,10 @@ void ParserContext::registerVarType(const std::string &type, const std::string &
     interpreter->registerVarType(type, name);
 }
 
+const bool ParserContext::variableExists(const std::string &varName) {
+    return interpreter->variableExists(varName);
+}
+
 const std::shared_ptr<CreationType> ParserContext::getVarType(const std::string &varName)
 {
     return interpreter->getVarType(varName);

--- a/src/jesus/parser/parser_context.hpp
+++ b/src/jesus/parser/parser_context.hpp
@@ -163,6 +163,8 @@ public:
 
     void registerClassName(const std::string &className);
 
+    const bool variableExists(const std::string &varName);
+
     const std::shared_ptr<CreationType> getVarType(const std::string &varName);
 
     void addScope(std::shared_ptr<Heart> scope);

--- a/src/jesus/spirit/symbol_table.hpp
+++ b/src/jesus/spirit/symbol_table.hpp
@@ -45,6 +45,22 @@ public:
         current_scope->createVar(type, name, value);
     }
 
+    bool variableExists(const std::string &name) const
+    {
+        // FIXME: speed it up:
+        //  1 - Store scope level 'enum class ScopeLevel { PARAMS, INSTANCE_ATTR, GLOBAL };' at parseTime on GetParamExpr|GetAttributeExpr|GetGlobalVarExpr
+        //  2 - store an index into the Heart (like int slot) at parse time, so getVar doesn’t even need to hash the 'name' at runtime — just array access.
+
+        // Iterate over the scopes in reverse order (rbegin, rend)
+        for (auto scope = scopes.rbegin(); scope != scopes.rend(); ++scope)
+        {
+            if ((*scope)->varExists(name))
+                return true;
+        }
+
+        return false;
+    }
+
     Value getVar(const std::string &name) const
     {
         // FIXME: speed it up:

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -264,3 +264,5 @@ say adam name
 say 'single-quote string'
 say 'Hi {adam} (single-quoted)'
 say "Hi, {adam} (double-quoted)"
+say "Your name is {adam name}"
+say "Forbidden:  {600 + 60 + 6}"

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -167,6 +167,7 @@ create Tribe israel = 12
 create Tribe israel = 13
 say israel
 create text Confirm matches "(Y|y)es"
+create text IsraelVar matches "WakeUp, {israel}"
 create Confirm sure = "Yes"
 sure = "no"
 say sure
@@ -260,3 +261,6 @@ say adam name
 say adam aToB 7, 49
 say "The new name v2 is: "
 say adam name
+say 'single-quote string'
+say 'Hi {adam} (single-quoted)'
+say "Hi, {adam} (double-quoted)"

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -182,7 +182,7 @@ fourteen
 say idade
 create number year = ask PI
 create number year2 = ask temperature
-age = ask "What is your age again? "
+age = ask "What is your age again (curent: {age})? "
 fourty
 eternal
 2025

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -138,7 +138,8 @@
 (Jesus) ❌ Error: Expected value >= (double) 7.000000
 (Jesus) (Jesus) (Jesus) ❌ Error: Expected value <= (double) 12.000000
 (Jesus) (int) 12
-(Jesus) (Jesus) (Jesus) ❌ Error: Variable 'sure' expects a Confirm, but got: 'text'.
+(Jesus) (Jesus) ❌ Error: Expected a string literal after 'matches', not a formatted string. (e.g., matches "IForgive")
+(Jesus) (Jesus) ❌ Error: Variable 'sure' expects a Confirm, but got: 'text'.
 (Jesus) Yes
 (Jesus) (Jesus) What is your age? (Jesus) (double) 18.000000
 (Jesus) Qual sua idade? Validation failed: Invalid number: 'seven'
@@ -203,4 +204,14 @@ Adopted by Jesus Christ
 null
 (Jesus) The new name v2 is: 
 (Jesus) Adopted by Jesus Christ
+(Jesus) single-quote string
+(Jesus) Hi {adam} (single-quoted)
+(Jesus) Hi, {type: "instance",
+ class: "Person",
+ attributes: {
+  age: "(int) 930",
+  wife: "Eve",
+  name: "Adopted by Jesus Christ"
+ }
+} (double-quoted)
 (Jesus) 

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -214,4 +214,6 @@ null
   name: "Adopted by Jesus Christ"
  }
 } (double-quoted)
+(Jesus) Your name is Adopted by Jesus Christ
+(Jesus) ❌ Error: NasaRules: Only simple variables or attribute chains are allowed inside formatted strings. This restriction ensures code clarity and safety, following Object Calisthenics and the 10 NASA rules for maintainable software. Expression rejected: '600 + 60 + 6'.
 (Jesus) 

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -147,9 +147,9 @@ Qual sua idade? Validation failed: Invalid number: 'fourteen'
 Qual sua idade? (Jesus) (double) 33.000000
 (Jesus) ❌ Error: Error: 'ask' expects a variable of primitive type 'text' as its prompt, but received variable 'PI' of primitive type 'number'.
 (Jesus) ❌ Error: Error: 'ask' expects a variable of primitive type 'text' as its prompt, but received variable 'temperature' of primitive type 'number'.
-(Jesus) What is your age again? Validation failed: Invalid number: 'fourty'
-What is your age again? Validation failed: Invalid number: 'eternal'
-What is your age again? (Jesus) (double) 2025.000000
+(Jesus) What is your age again (curent: (int) 33)? Validation failed: Invalid number: 'fourty'
+What is your age again (curent: (int) 33)? Validation failed: Invalid number: 'eternal'
+What is your age again (curent: (int) 33)? (Jesus) (double) 2025.000000
 (Jesus) What is your age? (Jesus) What is the new question?
 (Jesus) (Jesus) (Jesus) {type: "instance",
  class: "User",


### PR DESCRIPTION
# Description

This PR implements _**f-string**_–like syntax in Jesus Programming Language, enabling safer and clearer
string interpolation across the language. 

### Key changes

Key changes include:

1. Lexer updates for single-quoted and double-quoted strings, preparing the
   foundation for formatted strings.
2. FormattedStringRule parser rule that splits strings into literal parts and
   variable/expression references.
3. Interpreter support via visitFormattedStringExpr, ensuring {varname} is
   replaced with actual variable values.
4. Extension of f-strings to support attribute chains (e.g., 'person name') in
   addition to simple variables, following Object Calisthenics and NASA
   coding rules for clarity and safety.
5. Correct evaluation of f-strings inside `ask` expressions, so prompts
   now display interpolated values instead of raw literals.

**Example:**
```jesus
create text name = "Adam"
say "Hello, {name}"  
create text answer = ask "Is your name really {name}? " 
say "You said '{answer}'"
```

The code above outputs:
> Hello, Adam
> Is your name really  Adam?
> You said 'yes'

# ✝️ Wisdom 
> "A word fitly spoken is like apples of gold in a setting of silver." — **Proverbs 25:11**


