### PR TITLE
Step 43: feat(method-return): Full return statement support for methods, and 'nothing' type added with its 'void' alias

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ set(JESUS_CPP_FILES
     src/jesus/ast/stmt/repeat_times_stmt.cpp
     src/jesus/ast/stmt/repeat_while_stmt.cpp
     src/jesus/ast/stmt/update_var_stmt.cpp
+    src/jesus/ast/stmt/return_stmt.cpp
 
     # --------------
     # Parser classes

--- a/src/jesus/ast/stmt/create_method_stmt.hpp
+++ b/src/jesus/ast/stmt/create_method_stmt.hpp
@@ -36,15 +36,16 @@ public:
 
     std::string name;
     std::shared_ptr<Heart> params;
+    std::shared_ptr<CreationType> returnType;
     std::vector<std::shared_ptr<Stmt>> body;
     bool isGenesis; ///< true if this is the special constructor "genesis"
 
     CreateMethodStmt(const std::string &name,
-                     //  const std::vector<Param> &params,
                      const std::shared_ptr<Heart> &params,
+                     const std::shared_ptr<CreationType> &returnType,
                      const std::vector<std::shared_ptr<Stmt>> &body,
                      bool isGenesis = false)
-        : name(name), params(std::move(params)), body(body), isGenesis(isGenesis)
+        : name(name), params(std::move(params)), returnType(std::move(returnType)), body(body), isGenesis(isGenesis)
     {
     }
 

--- a/src/jesus/ast/stmt/return_stmt.cpp
+++ b/src/jesus/ast/stmt/return_stmt.cpp
@@ -1,0 +1,16 @@
+#include "return_stmt.hpp"
+#include "../../interpreter/stmt_visitor.hpp"
+#include "../../types/known_types.hpp"
+
+void ReturnStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visitReturnStmt(*this);
+}
+
+std::shared_ptr<CreationType> ReturnStmt::getReturnType(ParserContext &ctx) const
+{
+    if (value != nullptr)
+        return value->getReturnType(ctx);
+
+    return KnownTypes::VOID;
+}

--- a/src/jesus/ast/stmt/return_stmt.hpp
+++ b/src/jesus/ast/stmt/return_stmt.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include "stmt.hpp"
+#include "../expr/expr.hpp"
+
+/**
+ * @brief Represents a `return` statement in the Jesus Programming Language.
+ *
+ * A `ReturnStmt` optionally carries an expression whose value is returned
+ * from the current method. If no expression is provided, the method returns
+ * `void` (we call it `nothing`).
+ *
+ * 📖 Verse: "Return (your heart) to the LORD your God, for he is gracious and merciful,
+ * slow to anger, and abounding in steadfast love; and he relents over disaster."
+ * — Joel 2:13
+ */
+class ReturnStmt : public Stmt
+{
+public:
+    std::unique_ptr<Expr> value;
+
+public:
+    explicit ReturnStmt(std::unique_ptr<Expr> value) : value(std::move(value)) {}
+
+    void accept(StmtVisitor &visitor) const override;
+
+    std::shared_ptr<CreationType> getReturnType(ParserContext &ctx) const;
+};

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -202,8 +202,7 @@ void Interpreter::visitCreateClass(const CreateClassStmt &stmt)
                 methodStmt->params,
                 methodStmt->body,
                 userClass,
-                KnownTypes::BOOLEAN // FIXME: Allow methods to define return types
-            );
+                methodStmt->returnType);
 
             userClass->addMethod(methodStmt->name, method);
         }
@@ -345,4 +344,16 @@ void Interpreter::visitBreak(const BreakStmt &)
 void Interpreter::visitContinue(const ContinueStmt &)
 {
     throw ContinueSignal();
+}
+
+void Interpreter::visitReturnStmt(const ReturnStmt &stmt)
+{
+    Value result;
+
+    if (stmt.value)
+    {
+        result = evaluate(stmt.value);
+    }
+
+    throw ReturnSignal(result); // return execution flow to caller, Method::call.
 }

--- a/src/jesus/interpreter/interpreter.hpp
+++ b/src/jesus/interpreter/interpreter.hpp
@@ -292,4 +292,6 @@ private:
      *    say name
      */
     void visitContinue(const ContinueStmt &stmt) override;
+
+    void visitReturnStmt(const ReturnStmt &stmt) override;
 };

--- a/src/jesus/interpreter/runtime/method.cpp
+++ b/src/jesus/interpreter/runtime/method.cpp
@@ -24,14 +24,18 @@ Value Method::call(Interpreter &interpreter, std::shared_ptr<Instance> instance,
     interpreter.addScope(paramsScope);
 
     // 3. Execute method body
-    for (auto stmt : body)
-    {
-        interpreter.execute(stmt);
+    Value returnValue = Value::formless(); // default return
+
+    try {
+        for (auto stmt : body)
+            interpreter.execute(stmt);
+    } catch (const ReturnSignal &ret) {
+        returnValue = ret.value;
     }
 
     // 4. Pop 'attributes' and 'params' scope
     interpreter.popScope();
     interpreter.popScope();
 
-    return Value::formless(); // default return
+    return returnValue;
 }

--- a/src/jesus/interpreter/runtime/method.hpp
+++ b/src/jesus/interpreter/runtime/method.hpp
@@ -9,6 +9,15 @@
 
 class Interpreter; // Forward declaration
 
+class ReturnSignal
+{
+public:
+    Value value;
+
+public:
+    ReturnSignal(Value value) : value(std::move(value)) {}
+};
+
 class Method
 {
 public:

--- a/src/jesus/interpreter/stmt_visitor.hpp
+++ b/src/jesus/interpreter/stmt_visitor.hpp
@@ -12,6 +12,7 @@
 #include "../ast/stmt/for_each_stmt.hpp"
 #include "../ast/stmt/break_stmt.hpp"
 #include "../ast/stmt/continue_stmt.hpp"
+#include "../ast/stmt/return_stmt.hpp"
 
 /**
  * @brief Interface for visiting and executing statement nodes in the AST.
@@ -60,6 +61,7 @@ public:
     virtual void visitForEach(const ForEachStmt &stmt) = 0;
     virtual void visitBreak(const BreakStmt &stmt) = 0;
     virtual void visitContinue(const ContinueStmt &stmt) = 0;
+    virtual void visitReturnStmt(const ReturnStmt &stmt) = 0;
 
     virtual ~StmtVisitor() = default;
 };

--- a/src/jesus/lexer/lexer.cpp
+++ b/src/jesus/lexer/lexer.cpp
@@ -218,6 +218,9 @@ TokenType recognize_token_type(const std::string &word)
     if (word == "if" || word == "se")
         return TokenType::IF;
 
+    if (word == "return")
+        return TokenType::RETURN;
+
     if (word == "otherwise" || word == "senão")
         return TokenType::OTHERWISE;
 
@@ -288,6 +291,14 @@ std::vector<Token> lex(const std::string &raw_input)
 
         if (c == "-")
         {
+            // Lookahead for "->"
+            if (i + 1 < utf8_input.size() && utf8_input[i + 1] == ">")
+            {
+                tokens.emplace_back(TokenType::ARROW, "->", Value("->"));
+                i += 2; // consume both '-' and '>'
+                continue;
+            }
+
             tokens.emplace_back(TokenType::MINUS, "-", Value("-"));
             i++;
             continue;

--- a/src/jesus/lexer/token.hpp
+++ b/src/jesus/lexer/token.hpp
@@ -68,6 +68,8 @@ public:
             return "CREATE";
         case TokenType::PURPOSE:
             return "PURPOSE";
+        case TokenType::RETURN:
+            return "RETURN";
         case TokenType::Note:
             return "NOTE";
         case TokenType::Todo:
@@ -124,6 +126,8 @@ public:
             return "SEMICOLON";
         case TokenType::COMMA:
             return "COMMA";
+        case TokenType::ARROW:
+            return "ARROW";
 
         case TokenType::INT:
             return "INT(" + lexeme + ")";

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -45,12 +45,14 @@ enum class TokenType
     COLON,          // ':' (Begining of a block)
     SEMICOLON,      // ';' To separate method args by type: int x, y, z; text name, surname
     COMMA,          // ',' To separate var names: int x, y, z
+    ARROW,          // '->' To define method return types. purpose praise() -> GloryToGod: amen
 
     LET,            // let there be Person: amen (class in other langs)
     THERE,          // let there be Person: amen (class in other langs)
     BE,             // let there be Person: amen (class in other langs)
     HAJA,           // haja Luz: amén (portuguese way of creating class)
     PURPOSE,        // create method: purpose praise(): amen
+    RETURN,         // Function returns: return 144000
     CREATE,         // create days = 7
     ASK,            // create int age = ask "What is your age?"
     SAY,            // "say" prints to stdout

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -266,3 +266,30 @@ say 'Hi {adam} (single-quoted)'
 say "Hi, {adam} (double-quoted)"
 say "Your name is {adam name}"
 say "Forbidden:  {600 + 60 + 6}"
+let there be SonOfMan:
+    purpose age() -> number:
+        return 33
+    amen
+    purpose saySomething():
+        say 'I am the way, the truth, the life.'
+        return
+        say "This should not appear."
+    amen
+    purpose forgive() -> number :
+        say "forgive: seventy times seven"
+        return 70 * 7
+    amen
+amen
+create SonOfMan sonOfMan = 1
+say sonOfMan
+say sonOfMan age
+say sonOfMan saySomething
+say sonOfMan forgive
+let there be TestSpirits:
+    purpose promiseA() -> number:
+        return "lie"
+    amen
+amen
+create number edade = sonOfMan age
+say "La edad es: {edade}"
+create text ageStr = sonOfMan age

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -216,4 +216,17 @@ null
 } (double-quoted)
 (Jesus) Your name is Adopted by Jesus Christ
 (Jesus) ❌ Error: NasaRules: Only simple variables or attribute chains are allowed inside formatted strings. This restriction ensures code clarity and safety, following Object Calisthenics and the 10 NASA rules for maintainable software. Expression rejected: '600 + 60 + 6'.
+(Jesus) (Jesus) (Jesus) {type: "instance",
+ class: "SonOfMan",
+ attributes: { }
+}
+(Jesus) (int) 33
+(Jesus) I am the way, the truth, the life.
+null
+(Jesus) forgive: seventy times seven
+(int) 490
+(Jesus) ❌ Error: Type mismatch in method 'promiseA': expected return type '{class: "number"}', but found '{class: "text"}'.
+(Jesus) ❌ Error: Unknown expression type (parser.cpp)
+(Jesus) (Jesus) La edad es: (int) 33
+(Jesus) ❌ Error: Invalid value type 'number' for variable 'ageStr' declared as type text
 (Jesus) 

--- a/src/jesus/types/atomic/literals/nothing.hpp
+++ b/src/jesus/types/atomic/literals/nothing.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../../creation_type.hpp"
+
+/**
+ * @brief In Jesus Programming Language, the 'void' type is called 'nothing'.
+ *
+ * It represents methods that don't return any values.
+ * For compatibility, void.hpp exists as an alias.
+ *
+ * "Now the earth was formless and empty..." — Genesis 1:2
+ */
+class NothingType : public CreationType
+{
+public:
+    NothingType() : CreationType(PrimitiveType::Null, "nothing", "core") {}
+
+    bool validate(const Value &value) const override
+    {
+        return value.IS_FORMLESS;
+    }
+};

--- a/src/jesus/types/atomic/literals/void.hpp
+++ b/src/jesus/types/atomic/literals/void.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "nothing.hpp"
+
+/**
+ * @brief Literal value: nothing
+ *
+ * VoidType is just an alias for NothingType.
+ *
+ * "Now the earth was formless and empty,
+ * darkness was over the surface of the deep,
+ * and the Spirit of God was hovering over the waters." — Genesis 1:2
+ */
+using VoidType = NothingType;

--- a/src/jesus/types/creation_type.hpp
+++ b/src/jesus/types/creation_type.hpp
@@ -8,6 +8,7 @@ class Method; // Forward declaration
 
 enum class PrimitiveType
 {
+    Null,
     Boolean,
     Number,
     Text,
@@ -148,9 +149,89 @@ public:
         return nullptr;
     }
 
+    const bool isNull() const
+    {
+        return primitive_type == PrimitiveType::Null;
+    }
+
+    const bool isVoid() const
+    {
+        return isNull();
+    }
+
+    const bool isBoolean() const
+    {
+        return primitive_type == PrimitiveType::Boolean;
+    }
+
+    const bool isNumber() const
+    {
+        return primitive_type == PrimitiveType::Number;
+    }
+
+    const bool isString() const
+    {
+        return primitive_type == PrimitiveType::Text;
+    }
+
     const bool isClass() const
     {
         return primitive_type == PrimitiveType::Class;
+    }
+
+    /**
+     * @brief Checks if this CreationType can accept a value of another type.
+     *
+     * This function determines whether the current CreationType is compatible
+     * with the provided `assigningValueType`, i.e., whether a value of that
+     * type can be safely or meaningfully assigned to this one.
+     *
+     * "Can two walk together, except they be agreed?" — Amos 3:3 (KJV)
+     *
+     * @param assigningValueType A shared pointer to the CreationType that represents
+     *      the type of value being assigned.
+     * @return true if the assignment is considered valid; false otherwise.
+     */
+    bool isCompatibleWith(const std::shared_ptr<CreationType> &assigningValueType) const
+    {
+        if (!assigningValueType)
+            return false;
+
+        // -------------------------------
+        // Same exact type (by id or name)
+        // -------------------------------
+        if (this->id == assigningValueType->id)
+            return true;
+
+        if (this->name == assigningValueType->name && this->module_name == assigningValueType->module_name)
+            return true;
+
+        // ----------------------------------------------------------------------
+        // Null assignability: allow assigning "null" to any reference/class type
+        // ----------------------------------------------------------------------
+        if (this->isClass() && assigningValueType->isNull())
+            return true;
+
+        // --------------------------------
+        // Primitive compatibility (number)
+        // --------------------------------
+        if (this->isNumber() && assigningValueType->isNumber())
+            return true;
+
+        if (this->isString() && assigningValueType->isString())
+            return true;
+
+        if (this->isBoolean() && assigningValueType->isBoolean())
+            return true;
+
+        // Class assignability (TODO: add inheritance checks)
+        if (this->isClass() && assigningValueType->isClass())
+        {
+            // TODO: Add subclassing logic
+            return false;
+        }
+
+        return false;
     }
 
     const std::string toString()

--- a/src/jesus/types/known_types.cpp
+++ b/src/jesus/types/known_types.cpp
@@ -1,5 +1,6 @@
 #include "known_types.hpp"
 #include "atomic/literals/truth.hpp"
+#include "atomic/literals/nothing.hpp"
 #include "atomic/literals/sex.hpp"
 #include "atomic/literals/weekday.hpp"
 #include "atomic/numbers/number_type.hpp"
@@ -16,6 +17,7 @@
 void KnownTypes::registerBuiltInTypes()
 {
     auto truth = std::make_shared<TruthType>();
+    auto nothing = std::make_shared<NothingType>();
     auto sex = std::make_shared<SexType>();
     auto weekday = std::make_shared<WeekdayType>();
 
@@ -27,6 +29,7 @@ void KnownTypes::registerBuiltInTypes()
     auto klass = std::make_shared<ClassType>();
 
     BOOLEAN = TRUTH = truth;
+    VOID = NOTHING = nothing;
     BORN = SEX = sex;
     WEEKDAY = weekday;
 
@@ -38,6 +41,7 @@ void KnownTypes::registerBuiltInTypes()
     CLASS = klass;
 
     registerType(truth);
+    registerType(nothing);
     registerType(sex);
     registerType(weekday);
 

--- a/src/jesus/types/known_types.hpp
+++ b/src/jesus/types/known_types.hpp
@@ -19,6 +19,9 @@ public:
     // -------------------------------------------------------------------
     // Direct access for common types for fast type analysis at parse time
     // -------------------------------------------------------------------
+    inline static std::shared_ptr<CreationType> VOID;
+    inline static std::shared_ptr<CreationType> NOTHING;
+
     inline static std::shared_ptr<CreationType> SEX;
     inline static std::shared_ptr<CreationType> BORN;
 


### PR DESCRIPTION
# Description

This PR adds full support for _**return**_ statements in methods and introduces the '**_nothing_**' type (with 'void' alias) for methods that do not return a value. 

## Key changes

The following changes are included:

1. **Lexer**: Added support for `return` keyword and the `->` token for method return types.
2. **AST**: Added `ReturnStmt` class to represent return statements in the AST.
3. **Parser**: Updated `CreateMethodStmtRule` to parse return statements inside method bodies and enforce explicit return on non-void methods.
4. **Interpreter**: Implemented `visitReturnStmt` so return statements correctly propagate values during method execution.

## Example

```
let there be SonOfMan:
    purpose age() -> number:
        return 33
    amen
    purpose saySomething():
        say 'I am the way, the truth, the life.'
        return
        say "This should not appear."
    amen
    purpose forgive() -> number :
        say "forgive: seventy times seven"
        return 70 * 7
    amen
amen
create SonOfMan sonOfMan = 1
say sonOfMan
say sonOfMan age
say sonOfMan saySomething
say sonOfMan forgive
create number edade = sonOfMan age
say "The age is: {edade}"
create text ageStr = sonOfMan age
```

The code above outputs something like the following in the current state of the language:
> {type: "instance",
>  class: "SonOfMan",
>  attributes: { }
> }
> 
> (int) 33
>  I am the way, the truth, the life.
> null
>  forgive: seventy times seven
> (int) 490
>  The age is: (int) 33
>  ❌ Error: Invalid value type 'number' for variable 'ageStr' declared as type text

## What else

Things worth knowing:

- Methods that don't return any type don't have to define the return type, as we see on `purpose saySomething():` above.
- If you are going to return a value, you must inform its type, like `purpose forgive() -> number :` above.
- If you don't define a return type, the default return type is `void`, which we call `nothing`.
- If the method return type is `nothing` and you try to return a value, an error will be raised at parse time.

# ✝️ Wisdom

> “For a good tree does not bear bad fruit, nor does a bad tree bear good fruit." — **Luke 6:43**
