### PR TITLE
Step 44: feat(repeat-while): Added support for 'repeat while' loops. Ref: PR #8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ set(JESUS_CPP_FILES
     src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
     src/jesus/parser/grammar/stmt/update_var_stmt_rule.cpp
     src/jesus/parser/grammar/stmt/create_method_stmt_rule.cpp
+    src/jesus/parser/grammar/stmt/repeat_while_stmt_rule.cpp
 
     # -----------
     # Interpreter

--- a/src/jesus/ast/stmt/repeat_times_stmt.hpp
+++ b/src/jesus/ast/stmt/repeat_times_stmt.hpp
@@ -12,17 +12,12 @@
 class RepeatTimesStmt : public Stmt
 {
 public:
-    int count = 0;
     std::unique_ptr<Expr> countExpr;
     std::vector<std::unique_ptr<Stmt>> body;
-    std::unique_ptr<ASTNode> body2;
 
     RepeatTimesStmt(std::unique_ptr<Expr> countExpr,
                     std::vector<std::unique_ptr<Stmt>> body)
         : countExpr(std::move(countExpr)), body(std::move(body)) {}
-
-    RepeatTimesStmt(int count, std::unique_ptr<Stmt> body)
-        : count(count), body2(std::move(body)) {}
 
     void accept(StmtVisitor &visitor) const override;
 };

--- a/src/jesus/lexer/lexer.cpp
+++ b/src/jesus/lexer/lexer.cpp
@@ -221,6 +221,15 @@ TokenType recognize_token_type(const std::string &word)
     if (word == "return")
         return TokenType::RETURN;
 
+    if (word == "repeat")
+        return TokenType::REPEAT;
+
+    if (word == "times")
+        return TokenType::TIMES;
+
+    if (word == "while")
+        return TokenType::WHILE;
+
     if (word == "otherwise" || word == "senão")
         return TokenType::OTHERWISE;
 

--- a/src/jesus/lexer/token.hpp
+++ b/src/jesus/lexer/token.hpp
@@ -152,6 +152,15 @@ public:
         case TokenType::OTHERWISE:
             return "OTHERWISE";
 
+        case TokenType::REPEAT:
+            return "REPEAT";
+
+        case TokenType::TIMES:
+            return "TIMES";
+
+        case TokenType::WHILE:
+            return "WHILE";
+
         case TokenType::AMEN:
             return "AMEN";
 

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -74,6 +74,7 @@ enum class TokenType
     SHABBAT,        // shabbat = saturday = 7
 
     REPEAT,         // `repeat` 3 times
+    WHILE,          // repeat while count < 100: ... amen
     TIMES,          // repeat 3 `times`
 
     IF,

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -29,6 +29,7 @@
 #include "stmt/create_var_type_stmt_rule.hpp"
 #include "stmt/create_var_stmt_rule.hpp"
 #include "stmt/update_var_stmt_rule.hpp"
+#include "stmt/repeat_while_stmt_rule.hpp"
 #include "unary_rule.hpp"
 
 /**
@@ -88,6 +89,7 @@ namespace grammar
     inline auto UpdateVar = std::make_shared<UpdateVarStmtRule>(Expression, Ask);
     inline auto CreateMethod = std::make_shared<CreateMethodStmtRule>(CreateVar, UpdateVar, Print);
     inline auto CreateClass = std::make_shared<CreateClassStmtRule>(CreateVar, CreateMethod);
+    inline auto RepeatWhile = std::make_shared<RepeatWhileStmtRule>();
 
     /**
      * @brief Set the Expression rule to something (for now just Primary)

--- a/src/jesus/parser/grammar/stmt/repeat_while_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/repeat_while_stmt_rule.cpp
@@ -1,0 +1,76 @@
+#include "repeat_while_stmt_rule.hpp"
+#include "update_var_stmt_rule.hpp"
+#include "../../../ast/stmt/update_var_stmt.hpp"
+#include "../../../ast/stmt/update_var_with_ask_stmt.hpp"
+#include "../../../ast/stmt/repeat_while_stmt.hpp"
+#include "../../../ast/stmt/incomplete_block_stmt.hpp"
+#include "../jesus_grammar.hpp"
+#include <stdexcept>
+
+std::unique_ptr<Stmt> RepeatWhileStmtRule::parse(ParserContext &ctx)
+{
+    // --------------------------------
+    // Step 1: Must start with 'repeat'
+    // --------------------------------
+    if (!ctx.match(TokenType::REPEAT))
+        return nullptr;
+
+    // -------------------------
+    // Step 2: Must have 'while'
+    // -------------------------
+    if (!ctx.match(TokenType::WHILE))
+        throw std::runtime_error("Expected 'while' after 'repeat'.");
+
+    // --------------------------------------
+    // Step 3: Parse the condition expression
+    // --------------------------------------
+    auto condition = grammar::Expression->parse(ctx);
+    if (!condition)
+        throw std::runtime_error("Expected a condition expression after 'repeat while'.");
+
+    // --------------------
+    // Step 4: Expect colon
+    // --------------------
+    if (!ctx.match(TokenType::COLON))
+        throw std::runtime_error("Expected ':' after repeat while condition.");
+
+    // ------------------------------------------
+    // Step 5: Parse body statements until 'amen'
+    // ------------------------------------------
+    std::vector<std::unique_ptr<Stmt>> body;
+    ctx.consumeAllNewLines();
+
+    while (!ctx.check(TokenType::AMEN) && !ctx.isAtEnd())
+    {
+        // Reuse existing statements parsers
+        if (auto stmt = grammar::Print->parse(ctx))
+        {
+            body.push_back(std::move(stmt));
+        }
+        else if (auto stmt = grammar::CreateVar->parse(ctx))
+        {
+            body.push_back(std::move(stmt));
+        }
+        else if (auto stmt = grammar::UpdateVar->parse(ctx))
+        {
+            body.push_back(std::move(stmt));
+        }
+        else
+        {
+            throw std::runtime_error("Unexpected statement inside repeat-while block.");
+        }
+
+        ctx.consumeAllNewLines();
+    }
+
+    if (ctx.isAtEnd())
+    {
+        // FIXME: Each time an IncompleteBlockStmt is returned, all code is parsed again. Too expensive.
+        return std::make_unique<IncompleteBlockStmt>();
+    }
+
+    if (!ctx.match(TokenType::AMEN))
+        throw std::runtime_error("Expected 'amen' to close repeat-while block.");
+
+    return std::make_unique<RepeatWhileStmt>(std::move(condition), std::move(body));
+}

--- a/src/jesus/parser/grammar/stmt/repeat_while_stmt_rule.hpp
+++ b/src/jesus/parser/grammar/stmt/repeat_while_stmt_rule.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "../../parser_context.hpp"
+#include "../../../ast/stmt/stmt.hpp"
+
+/**
+ * @brief Parser for 'repeat while (condition): amen
+ */
+class RepeatWhileStmtRule
+{
+public:
+    std::unique_ptr<Stmt> parse(ParserContext &ctx);
+};

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -293,3 +293,8 @@ amen
 create number edade = sonOfMan age
 say "La edad es: {edade}"
 create text ageStr = sonOfMan age
+create number naaman = 1
+repeat while naaman <= 7:
+    say " Naaman faith count: {naaman}"
+    naaman = naaman + 1
+amen

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -229,4 +229,11 @@ null
 (Jesus) ❌ Error: Unknown expression type (parser.cpp)
 (Jesus) (Jesus) La edad es: (int) 33
 (Jesus) ❌ Error: Invalid value type 'number' for variable 'ageStr' declared as type text
+(Jesus) (Jesus)  Naaman faith count: (int) 1
+ Naaman faith count: (int) 2
+ Naaman faith count: (int) 3
+ Naaman faith count: (int) 4
+ Naaman faith count: (int) 5
+ Naaman faith count: (int) 6
+ Naaman faith count: (int) 7
 (Jesus) 


### PR DESCRIPTION
# Description

This PR finishes `repeat while` loops in the Jesus language.

This completes what we started on PR #8.

### Changes:

* Added `REPEAT` and `WHILE` tokens in the lexer
* Implemented `RepeatWhileStmtRule` in the parser
* Supports syntax: `repeat while <condition>: <statements> amen`

## Example usage:

```jesus
create number naaman = 1
repeat while naaman <= 7:
    say " Naaman faith count: {naaman}"
    naaman = naaman + 1
amen
```

The code above produces the following output:

>  Naaman faith count: (int) 1
>   Naaman faith count: (int) 2
>  Naaman faith count: (int) 3
>  Naaman faith count: (int) 4
>  Naaman faith count: (int) 5
>  Naaman faith count: (int) 6
>  Naaman faith count: (int) 7 

This allows users to express looping constructs with clear syntax.

# ✝️ Wisdom 

> "Then Jesus told his disciples a parable to show them that they should **_always pray_**  and not give up." — **Luke 18:1**
