### PR TITLE
Step 46: Added support for 'skip' (continue) and 'break' statements for loop control. Ref PRs #8, #44, #45.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ set(JESUS_CPP_FILES
     # AST Statements
     # --------------
     src/jesus/ast/stmt/break_stmt.cpp
-    src/jesus/ast/stmt/continue_stmt.cpp
+    src/jesus/ast/stmt/skip_stmt.cpp
     src/jesus/ast/stmt/create_class_stmt.cpp
     src/jesus/ast/stmt/create_var_type_stmt.cpp
     src/jesus/ast/stmt/create_var_stmt.cpp

--- a/src/jesus/ast/stmt/continue_stmt.cpp
+++ b/src/jesus/ast/stmt/continue_stmt.cpp
@@ -1,7 +1,0 @@
-#include "continue_stmt.hpp"
-#include "../../interpreter/stmt_visitor.hpp"
-
-void ContinueStmt::accept(StmtVisitor &visitor) const
-{
-    visitor.visitContinue(*this);
-}

--- a/src/jesus/ast/stmt/skip_stmt.cpp
+++ b/src/jesus/ast/stmt/skip_stmt.cpp
@@ -1,0 +1,7 @@
+#include "skip_stmt.hpp"
+#include "../../interpreter/stmt_visitor.hpp"
+
+void SkipStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visitSkipStmt(*this);
+}

--- a/src/jesus/ast/stmt/skip_stmt.hpp
+++ b/src/jesus/ast/stmt/skip_stmt.hpp
@@ -1,18 +1,19 @@
 #pragma once
+
 #include "stmt.hpp"
 
 /**
  * set disciples to ["Peter", "James", "John"]
  * for each name in disciples:
- *    if name == James:
- *      continue # or next; skip;
+ *    if name == 'James':
+ *      skip
  *
  *    say name
  */
-class ContinueStmt : public Stmt
+class SkipStmt : public Stmt
 {
 public:
-  ContinueStmt() = default;
+  SkipStmt() = default;
 
   void accept(StmtVisitor &visitor) const override;
 };

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -13,7 +13,7 @@
 class BreakSignal : public std::exception
 {
 };
-class ContinueSignal : public std::exception
+class SkipSignal : public std::exception
 {
 };
 
@@ -261,7 +261,7 @@ void Interpreter::visitRepeatWhile(const RepeatWhileStmt &stmt)
                 execute(statement);
             }
         }
-        catch (const ContinueSignal &)
+        catch (const SkipSignal &)
         {
             continue;
         }
@@ -291,7 +291,7 @@ void Interpreter::visitRepeatTimes(const RepeatTimesStmt &stmt)
                 execute(statement);
             }
         }
-        catch (const ContinueSignal &)
+        catch (const SkipSignal &)
         {
             continue;
         }
@@ -313,7 +313,7 @@ void Interpreter::visitRepeatForeverStmt(const RepeatForeverStmt &stmt)
                 execute(statement);
             }
         }
-        catch (const ContinueSignal &)
+        catch (const SkipSignal &)
         {
             continue;
         }
@@ -347,7 +347,7 @@ void Interpreter::visitForEach(const ForEachStmt &stmt)
                 execute(statement);
             }
         }
-        catch (const ContinueSignal &)
+        catch (const SkipSignal &)
         {
             continue;
         }
@@ -363,9 +363,9 @@ void Interpreter::visitBreak(const BreakStmt &)
     throw BreakSignal();
 }
 
-void Interpreter::visitContinue(const ContinueStmt &)
+void Interpreter::visitSkipStmt(const SkipStmt &)
 {
-    throw ContinueSignal();
+    throw SkipSignal();
 }
 
 void Interpreter::visitReturnStmt(const ReturnStmt &stmt)

--- a/src/jesus/interpreter/interpreter.hpp
+++ b/src/jesus/interpreter/interpreter.hpp
@@ -19,7 +19,7 @@
 #include "../ast/stmt/repeat_times_stmt.hpp"
 #include "../ast/stmt/for_each_stmt.hpp"
 #include "../ast/stmt/break_stmt.hpp"
-#include "../ast/stmt/continue_stmt.hpp"
+#include "../ast/stmt/skip_stmt.hpp"
 #include "../spirit/heart.hpp"
 #include "../spirit/symbol_table.hpp"
 
@@ -292,12 +292,12 @@ private:
     /**
      * set disciples to ["Peter", "James", "John"]
      * for each name in disciples:
-     *    if name == James:
-     *      continue # or next; skip;
+     *    if name == 'James':
+     *      skip
      *
      *    say name
      */
-    void visitContinue(const ContinueStmt &stmt) override;
+    void visitSkipStmt(const SkipStmt &stmt) override;
 
     void visitReturnStmt(const ReturnStmt &stmt) override;
 };

--- a/src/jesus/interpreter/stmt_visitor.hpp
+++ b/src/jesus/interpreter/stmt_visitor.hpp
@@ -12,7 +12,7 @@
 #include "../ast/stmt/repeat_forever_stmt.hpp"
 #include "../ast/stmt/for_each_stmt.hpp"
 #include "../ast/stmt/break_stmt.hpp"
-#include "../ast/stmt/continue_stmt.hpp"
+#include "../ast/stmt/skip_stmt.hpp"
 #include "../ast/stmt/return_stmt.hpp"
 
 /**
@@ -62,7 +62,7 @@ public:
     virtual void visitRepeatForeverStmt(const RepeatForeverStmt &stmt) = 0;
     virtual void visitForEach(const ForEachStmt &stmt) = 0;
     virtual void visitBreak(const BreakStmt &stmt) = 0;
-    virtual void visitContinue(const ContinueStmt &stmt) = 0;
+    virtual void visitSkipStmt(const SkipStmt &stmt) = 0;
     virtual void visitReturnStmt(const ReturnStmt &stmt) = 0;
 
     virtual ~StmtVisitor() = default;

--- a/src/jesus/lexer/lexer.cpp
+++ b/src/jesus/lexer/lexer.cpp
@@ -212,6 +212,12 @@ TokenType recognize_token_type(const std::string &word)
     if (isDouble(word))
         return TokenType::DOUBLE;
 
+    if (word == "skip" || word == "pular")
+        return TokenType::SKIP;
+
+    if (word == "break")
+        return TokenType::BREAK;
+
     if (word == "create" || word == "criar")
         return TokenType::CREATE;
 

--- a/src/jesus/lexer/token.hpp
+++ b/src/jesus/lexer/token.hpp
@@ -164,6 +164,12 @@ public:
         case TokenType::FOREVER:
             return "FOREVER";
 
+        case TokenType::SKIP:
+            return "SKIP";
+
+        case TokenType::BREAK:
+            return "BREAK";
+
         case TokenType::AMEN:
             return "AMEN";
 

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -77,6 +77,8 @@ enum class TokenType
     WHILE,          // repeat while count < 100: ... amen
     TIMES,          // repeat 3 `times`
     FOREVER,        // repeat forever: ... amen
+    SKIP,           // 'continue' in other languages.
+    BREAK,          // loop break
 
     IF,
     OTHERWISE,

--- a/src/jesus/parser/grammar/stmt/repeat_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/repeat_stmt_rule.cpp
@@ -5,6 +5,8 @@
 #include "../../../ast/stmt/repeat_while_stmt.hpp"
 #include "../../../ast/stmt/repeat_times_stmt.hpp"
 #include "../../../ast/stmt/repeat_forever_stmt.hpp"
+#include "../../../ast/stmt/skip_stmt.hpp"
+#include "../../../ast/stmt/break_stmt.hpp"
 #include "../../../ast/stmt/incomplete_block_stmt.hpp"
 #include "../jesus_grammar.hpp"
 #include <stdexcept>
@@ -131,6 +133,10 @@ std::vector<std::unique_ptr<Stmt>> RepeatStmtRule::parseBody(ParserContext &ctx)
             body.push_back(std::move(stmt));
         else if (auto stmt = grammar::UpdateVar->parse(ctx))
             body.push_back(std::move(stmt));
+        else if (ctx.match(TokenType::SKIP))
+            body.push_back(std::make_unique<SkipStmt>());
+        else if (ctx.match(TokenType::BREAK))
+            body.push_back(std::make_unique<BreakStmt>());
         else
             throw std::runtime_error("Unexpected statement inside repeat block.");
 

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -309,3 +309,7 @@ create text _two = "two"
 repeat _two times:
     say 'This should not be printed'
 amen
+repeat forever:
+ say 'Forever...'
+ break
+amen

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -243,4 +243,5 @@ two times
 (Jesus) (Jesus) ❌ Error: NasaRule2: repeat times expects an integer variable or attribute, but '_two' is of type text
 (Jesus) This should not be printed
 (Jesus) ❌ Error: Unknown expression type (parser.cpp)
+(Jesus) Forever...
 (Jesus) 


### PR DESCRIPTION
# Description

This pull request introduces **loop control statements** to the Jesus language:

### New Features

* **`break`** — immediately stops the current loop.
* **`skip`** — jumps to the next iteration of the loop (equivalent to `continue` in other languages).

- **BUT**, we still don't have support for 'if' statements.

These statements improve control flow inside `repeat forever`, `repeat <n> times`, and `repeat while <condition>`, loops while keeping syntax expressive and intuitive.

###  Design Notes

* Implemented as `BreakStmt` and `SkipStmt` in the AST.
* Supported by the interpreter through `BreakSignal` and `BreakSignal`.
* No logic changes required for `visitRepeatTimes` or `visitRepeatWhile`, as the control signals were already supported.
* The keyword `skip` was chosen for its simplicity and natural meaning in both English and translation contexts.


### Example

The following code works:
```jesus
repeat forever:
  say "Forever..."
  break
amen
```

Output:

> Forever...

### Important

We still don't have support for 'if' statements. It will be implemented in a future PR, that is why in the example above we don't have `if <condition>: break`

# ✝️ Wisdom

The following verses back this PR up:

> "There is a time for everything, and a season for every activity under the heavens." — **Ecclesiastes 3:1**

and

>   But in the church I would rather **speak five intelligible words** to instruct others than ten thousand words in a tongue.  — **1 Corinthians 14:19**
