### PR TITLE
Step 47: Added support for if–otherwise conditional statements in the Jesus language

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ set(JESUS_CPP_FILES
     src/jesus/ast/stmt/repeat_forever_stmt.cpp
     src/jesus/ast/stmt/update_var_stmt.cpp
     src/jesus/ast/stmt/return_stmt.cpp
+    src/jesus/ast/stmt/if_stmt.cpp
 
     # --------------
     # Parser classes
@@ -155,6 +156,7 @@ set(JESUS_CPP_FILES
     src/jesus/parser/grammar/stmt/update_var_stmt_rule.cpp
     src/jesus/parser/grammar/stmt/create_method_stmt_rule.cpp
     src/jesus/parser/grammar/stmt/repeat_stmt_rule.cpp
+    src/jesus/parser/grammar/stmt/if_stmt_rule.cpp
 
     # -----------
     # Interpreter

--- a/src/jesus/ast/stmt/if_stmt.cpp
+++ b/src/jesus/ast/stmt/if_stmt.cpp
@@ -1,0 +1,7 @@
+#include "break_stmt.hpp"
+#include "../../interpreter/stmt_visitor.hpp"
+
+void IfStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visitIfStmt(*this);
+}

--- a/src/jesus/ast/stmt/if_stmt.hpp
+++ b/src/jesus/ast/stmt/if_stmt.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include "stmt.hpp"
+#include "../expr/expr.hpp"
+
+/**
+ * if name == 'Jesus Christ':
+ *    say 'Lamb of God'
+ * amen
+ */
+class IfStmt : public Stmt
+{
+public:
+  const std::unique_ptr<Expr> condition;
+  std::vector<std::unique_ptr<Stmt>> thenBranch;
+  std::vector<std::unique_ptr<Stmt>> otherwiseBranch;
+
+  IfStmt(std::unique_ptr<Expr> condition,
+         std::vector<std::unique_ptr<Stmt>> thenBranch,
+         std::vector<std::unique_ptr<Stmt>> otherwiseBranch)
+      : condition(std::move(condition)),
+        thenBranch(std::move(thenBranch)),
+        otherwiseBranch(std::move(otherwiseBranch)) {}
+
+  void accept(StmtVisitor &visitor) const override;
+};

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -379,3 +379,19 @@ void Interpreter::visitReturnStmt(const ReturnStmt &stmt)
 
     throw ReturnSignal(result); // return execution flow to caller, Method::call.
 }
+
+void Interpreter::visitIfStmt(const IfStmt &stmt)
+{
+    Value conditionValue = evaluate(stmt.condition);
+
+    if (conditionValue.AS_BOOLEAN)
+    {
+        for (auto &stmt : stmt.thenBranch)
+            execute(stmt);
+    }
+    else
+    {
+        for (auto &stmt : stmt.otherwiseBranch)
+            execute(stmt);
+    }
+}

--- a/src/jesus/interpreter/interpreter.hpp
+++ b/src/jesus/interpreter/interpreter.hpp
@@ -300,4 +300,6 @@ private:
     void visitSkipStmt(const SkipStmt &stmt) override;
 
     void visitReturnStmt(const ReturnStmt &stmt) override;
+
+    void visitIfStmt(const IfStmt &stmt) override;
 };

--- a/src/jesus/interpreter/stmt_visitor.hpp
+++ b/src/jesus/interpreter/stmt_visitor.hpp
@@ -14,6 +14,7 @@
 #include "../ast/stmt/break_stmt.hpp"
 #include "../ast/stmt/skip_stmt.hpp"
 #include "../ast/stmt/return_stmt.hpp"
+#include "../ast/stmt/if_stmt.hpp"
 
 /**
  * @brief Interface for visiting and executing statement nodes in the AST.
@@ -64,6 +65,7 @@ public:
     virtual void visitBreak(const BreakStmt &stmt) = 0;
     virtual void visitSkipStmt(const SkipStmt &stmt) = 0;
     virtual void visitReturnStmt(const ReturnStmt &stmt) = 0;
+    virtual void visitIfStmt(const IfStmt &stmt) = 0;
 
     virtual ~StmtVisitor() = default;
 };

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -30,6 +30,7 @@
 #include "stmt/create_var_stmt_rule.hpp"
 #include "stmt/update_var_stmt_rule.hpp"
 #include "stmt/repeat_stmt_rule.hpp"
+#include "stmt/if_stmt_rule.hpp"
 #include "unary_rule.hpp"
 
 /**
@@ -90,6 +91,7 @@ namespace grammar
     inline auto CreateMethod = std::make_shared<CreateMethodStmtRule>(CreateVar, UpdateVar, Print);
     inline auto CreateClass = std::make_shared<CreateClassStmtRule>(CreateVar, CreateMethod);
     inline auto RepeatWhile = std::make_shared<RepeatStmtRule>();
+    inline auto IfStmt = std::make_shared<IfStmtRule>();
 
     /**
      * @brief Set the Expression rule to something (for now just Primary)

--- a/src/jesus/parser/grammar/stmt/create_method_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_method_stmt_rule.cpp
@@ -95,6 +95,8 @@ std::unique_ptr<Stmt> CreateMethodStmtRule::parse(ParserContext &ctx)
         {
             body.push_back(std::move(print));
         }
+        else if (auto stmt = grammar::IfStmt->parse(ctx))
+            body.push_back(std::move(stmt));
         else if (ctx.match(TokenType::RETURN))
         {
             std::unique_ptr<Expr> returnExpr = nullptr;

--- a/src/jesus/parser/grammar/stmt/if_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/if_stmt_rule.cpp
@@ -1,0 +1,114 @@
+#include "if_stmt_rule.hpp"
+#include "../../../ast/stmt/if_stmt.hpp"
+#include "../../../ast/stmt/update_var_stmt.hpp"
+#include "../../../ast/stmt/update_var_with_ask_stmt.hpp"
+#include "../../../ast/stmt/repeat_while_stmt.hpp"
+#include "../../../ast/stmt/repeat_times_stmt.hpp"
+#include "../../../ast/stmt/repeat_forever_stmt.hpp"
+#include "../../../ast/stmt/skip_stmt.hpp"
+#include "../../../ast/stmt/break_stmt.hpp"
+#include "../../../ast/stmt/incomplete_block_stmt.hpp"
+#include "../jesus_grammar.hpp"
+#include <stdexcept>
+
+class IncompleteBlockStmtSignal : public std::exception
+{
+public:
+    const char *what() const noexcept override
+    {
+        return "Incomplete block detected (waiting for more input)";
+    }
+};
+
+std::unique_ptr<Stmt> IfStmtRule::parse(ParserContext &ctx)
+{
+    // -----------------------------------------
+    // Grammar:
+    //  if <condition> : ... amen
+    //  if <condition> : ... otherwise: ... amen
+    // -----------------------------------------
+
+    if (!ctx.match(TokenType::IF))
+        return nullptr;
+
+    auto condition = grammar::Expression->parse(ctx);
+    if (!condition)
+        throw std::runtime_error("Expected expression after 'if' statement.");
+
+    if (!ctx.match(TokenType::COLON))
+        throw std::runtime_error("Expected ':' after if condition.");
+
+    std::vector<std::unique_ptr<Stmt>> thenBranch;
+    std::vector<std::unique_ptr<Stmt>> otherwiseBranch;
+
+    ctx.consumeAllNewLines();
+
+    // -------------------
+    // Parse the 'if' body
+    // -------------------
+    while (!ctx.check(TokenType::OTHERWISE) && !ctx.check(TokenType::AMEN) && !ctx.isAtEnd())
+    {
+        if (auto stmt = grammar::Print->parse(ctx))
+            thenBranch.push_back(std::move(stmt));
+        else if (auto stmt = grammar::CreateVar->parse(ctx))
+            thenBranch.push_back(std::move(stmt));
+        else if (auto stmt = grammar::UpdateVar->parse(ctx))
+            thenBranch.push_back(std::move(stmt));
+        else if (auto stmt = grammar::RepeatWhile->parse(ctx))
+            thenBranch.push_back(std::move(stmt));
+        else if (ctx.match(TokenType::SKIP))
+            thenBranch.push_back(std::make_unique<SkipStmt>());
+        else if (ctx.match(TokenType::BREAK))
+            thenBranch.push_back(std::make_unique<BreakStmt>());
+        else
+            throw std::runtime_error("Unexpected statement inside 'if' body.");
+
+        ctx.consumeAllNewLines();
+    }
+
+    // ------------------
+    // Parse 'otherwise:'
+    // ------------------
+    if (ctx.match(TokenType::OTHERWISE))
+    {
+        if (!ctx.match(TokenType::COLON))
+            throw std::runtime_error("Expected ':' after 'otherwise'.");
+
+        ctx.consumeAllNewLines();
+
+        while (!ctx.check(TokenType::AMEN) && !ctx.isAtEnd())
+        {
+            if (auto stmt = grammar::Print->parse(ctx))
+                otherwiseBranch.push_back(std::move(stmt));
+            else if (auto stmt = grammar::CreateVar->parse(ctx))
+                otherwiseBranch.push_back(std::move(stmt));
+            else if (auto stmt = grammar::UpdateVar->parse(ctx))
+                otherwiseBranch.push_back(std::move(stmt));
+            else if (auto stmt = grammar::RepeatWhile->parse(ctx))
+                otherwiseBranch.push_back(std::move(stmt));
+            else if (ctx.match(TokenType::SKIP))
+                otherwiseBranch.push_back(std::make_unique<SkipStmt>());
+            else if (ctx.match(TokenType::BREAK))
+                otherwiseBranch.push_back(std::make_unique<BreakStmt>());
+
+            else
+                throw std::runtime_error("Unexpected statement inside 'otherwise' body.");
+
+            ctx.consumeAllNewLines();
+        }
+    }
+
+    if (ctx.isAtEnd())
+    {
+        // FIXME: Each time an IncompleteBlockStmt is returned, all code is parsed again. Too expensive.
+        return std::make_unique<IncompleteBlockStmt>();
+    }
+
+    if (!ctx.match(TokenType::AMEN))
+        throw std::runtime_error("Expected 'amen' to close 'if' statement.");
+
+    return std::make_unique<IfStmt>(
+        std::move(condition),
+        std::move(thenBranch),
+        std::move(otherwiseBranch));
+}

--- a/src/jesus/parser/grammar/stmt/if_stmt_rule.hpp
+++ b/src/jesus/parser/grammar/stmt/if_stmt_rule.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "../../parser_context.hpp"
+#include "../../../ast/stmt/stmt.hpp"
+
+/**
+ * @brief Parser for 'if-otherwise' statements
+ *
+ *  if name == "Jesus":
+ *      say "Jesus, name above all names."
+ *  amen
+ */
+class IfStmtRule
+{
+public:
+    std::unique_ptr<Stmt> parse(ParserContext &ctx);
+
+    std::vector<std::unique_ptr<Stmt>> parseBody(ParserContext &ctx);
+};

--- a/src/jesus/parser/grammar/stmt/repeat_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/repeat_stmt_rule.cpp
@@ -133,6 +133,8 @@ std::vector<std::unique_ptr<Stmt>> RepeatStmtRule::parseBody(ParserContext &ctx)
             body.push_back(std::move(stmt));
         else if (auto stmt = grammar::UpdateVar->parse(ctx))
             body.push_back(std::move(stmt));
+        else if (auto stmt = grammar::IfStmt->parse(ctx))
+            body.push_back(std::move(stmt));
         else if (ctx.match(TokenType::SKIP))
             body.push_back(std::make_unique<SkipStmt>());
         else if (ctx.match(TokenType::BREAK))

--- a/src/jesus/parser/parser.cpp
+++ b/src/jesus/parser/parser.cpp
@@ -42,6 +42,10 @@ std::unique_ptr<Stmt> parse(const std::vector<Token> &tokens, ParserContext &con
     if (repeatWhileStmt)
         return repeatWhileStmt;
 
+    auto ifStmt = grammar::IfStmt->parse(context);
+    if (ifStmt)
+        return ifStmt;
+
     // If no match, fall back to expression parsing
     auto expr = grammar::Expression->parse(context);
     if (!expr)

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -309,7 +309,24 @@ create text _two = "two"
 repeat _two times:
     say 'This should not be printed'
 amen
+create number limit = 3
 repeat forever:
- say 'Forever...'
- break
+  limit = limit - 1
+  say "Decreasing... {limit}"
+  if (limit == 0):
+    break
+  amen
+amen
+create truth isEven = yes
+repeat 10 times:
+  isEven = not isEven
+  limit = limit + 1
+  if limit < 4:
+    skip
+  amen
+  if isEven:
+    say "Even: {limit}"
+  otherwise:
+    say "Odd:  {limit}"
+  amen
 amen

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -243,5 +243,14 @@ two times
 (Jesus) (Jesus) ❌ Error: NasaRule2: repeat times expects an integer variable or attribute, but '_two' is of type text
 (Jesus) This should not be printed
 (Jesus) ❌ Error: Unknown expression type (parser.cpp)
-(Jesus) Forever...
+(Jesus) (Jesus) Decreasing... (int) 2
+Decreasing... (int) 1
+Decreasing... (int) 0
+(Jesus) (Jesus) Even: (int) 4
+Odd:  (int) 5
+Even: (int) 6
+Odd:  (int) 7
+Even: (int) 8
+Odd:  (int) 9
+Even: (int) 10
 (Jesus) 


### PR DESCRIPTION
# Description

This pull request introduces full support for conditional **control flow** using `if`, `otherwise`, and `amen` blocks.  

It enables programs to express decisions in natural syntax that aligns with the expressivity goals of the Jesus language.  

Example usage:  
```jesus
create truth righteous = yes

if righteous:
    say "Blessed is the one who walks in the light."
otherwise:
    say "Repent and turn to God."
amen
```

#### Details  
- Added `IfStmt` AST node for interpreter execution.  
- Added `CreateIfStmtRule` for parsing conditional statements.  
- Supports both:
  - `if condition: ... amen`  
  - `if condition: ... otherwise: ... amen`  
- Integrated with the existing parser.  

#### Motivation  

This feature allows developers to express logic in a way that reads as natural language — a step toward the core vision of the Jesus language: *code that reads like a natural conversation*.  

#### Example  
```jesus
create truth forgiven = yes

if forgiven:
    say "You are free indeed."
otherwise:
    warn "Seek His mercy."
amen
```

---

# ✝️ Wisdom

> “**If** you remain in me and my words remain in you, ask whatever you wish, and it will be done for you.”   **— John 15:7**

and

> "**If** you are willing and obedient, you shall eat the good of the land." — **Isaiah 1:19**