### PR TITLE
Step 48: Using 'is' and 'is not' for '==' and '!=' operators (equality, inequality)

### DIFF
--- a/src/jesus/ast/ast_node.hpp
+++ b/src/jesus/ast/ast_node.hpp
@@ -46,7 +46,7 @@ public:
      * "For nothing is hidden that will not be made manifest, nor is anything
      * secret that will not be known and come to light." — Luke 8:17
      */
-    virtual std::string toString() const { return "ASTNode"; }
+    virtual std::string toString() const { return  typeid(*this).name(); }
 };
 
 /**

--- a/src/jesus/ast/expr/binary_expr.hpp
+++ b/src/jesus/ast/expr/binary_expr.hpp
@@ -45,7 +45,7 @@ public:
         Value leftVal = left->evaluate(heart);
         Value rightVal = right->evaluate(heart);
 
-        if (op.type == TokenType::EQUAL_EQUAL)
+        if (op.type == TokenType::IS)
         {
             return Value(leftVal == rightVal);
         }

--- a/src/jesus/lexer/lexer.cpp
+++ b/src/jesus/lexer/lexer.cpp
@@ -110,9 +110,6 @@ TokenType recognize_token_type(const std::string &word)
     if (word == "=")
         return TokenType::EQUAL;
 
-    if (word == "!=")
-        return TokenType::NOT_EQUAL;
-
     if (word == ">") // greater than
         return TokenType::GREATER;
 
@@ -357,6 +354,13 @@ std::vector<Token> lex(const std::string &raw_input)
             continue;
         }
 
+        if (c == "=")
+        {
+            tokens.emplace_back(TokenType::EQUAL, "=", Value("="));
+            i++;
+            continue;
+        }
+
         if (c == single_quote || c == double_quote)
         {
             const std::string quote_char = c;
@@ -432,7 +436,7 @@ std::vector<Token> lex(const std::string &raw_input)
             continue;
         }
 
-        if (c == "=" || c == "!" || c == "<" || c == ">")
+        if (c == "<" || c == ">")
         {
             // Comparison operators
             std::string op;
@@ -443,6 +447,16 @@ std::vector<Token> lex(const std::string &raw_input)
             tokens.emplace_back(recognize_token_type(op), op, Value(op));
             i++;
             continue;
+        }
+
+        if (c == "!")
+        {
+            std::string msg = "Use 'not' for negation instead of '!'.";
+
+            if (i + 1 < utf8_input.size() && utf8_input[i + 1] == "=")
+                msg = "Use 'is not' for inequality instead of '!='.";
+
+            throw std::runtime_error(msg);
         }
 
         // Unexpected character

--- a/src/jesus/lexer/lexer.cpp
+++ b/src/jesus/lexer/lexer.cpp
@@ -92,6 +92,9 @@ TokenType recognize_token_type(const std::string &word)
     if (word == "end")
         return TokenType::EndNote;
 
+    if (word == "is" || word == "é")
+        return TokenType::IS;
+
     if (word == "not" || word == "não")
         return TokenType::NOT;
 
@@ -106,9 +109,6 @@ TokenType recognize_token_type(const std::string &word)
 
     if (word == "=")
         return TokenType::EQUAL;
-
-    if (word == "==")
-        return TokenType::EQUAL_EQUAL;
 
     if (word == "!=")
         return TokenType::NOT_EQUAL;
@@ -262,7 +262,7 @@ std::vector<Token> lex(const std::string &raw_input)
 
     auto utf8_input = utils::to_utf8(raw_input);
 
-    const std::string single_quote = "'"; // single ASCII quote
+    const std::string single_quote = "'";  // single ASCII quote
     const std::string double_quote = "\""; // double quote
     const std::string space = " ";
     const std::string tab = "\t";

--- a/src/jesus/lexer/token.hpp
+++ b/src/jesus/lexer/token.hpp
@@ -80,6 +80,8 @@ public:
             return "EXPLAIN";
         case TokenType::BeginNote:
             return "BEGIN_NOTE";
+        case TokenType::IS:
+            return "IS";
         case TokenType::NOT:
             return "NOT";
         case TokenType::AND:
@@ -88,8 +90,6 @@ public:
             return "OR";
         case TokenType::VERSUS:
             return "VERSUS";
-        case TokenType::EQUAL_EQUAL:
-            return "EQUAL_EQUAL";
         case TokenType::NOT_EQUAL:
             return "NOT_EQUAL";
         case TokenType::GREATER:

--- a/src/jesus/lexer/token.hpp
+++ b/src/jesus/lexer/token.hpp
@@ -80,8 +80,10 @@ public:
             return "EXPLAIN";
         case TokenType::BeginNote:
             return "BEGIN_NOTE";
+        case TokenType::EQUAL:
+            return "EQUAL"; // variable assignment
         case TokenType::IS:
-            return "IS";
+            return "IS"; // equality  ('==' in other languages)
         case TokenType::NOT:
             return "NOT";
         case TokenType::AND:

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -17,12 +17,12 @@ enum class TokenType
     Word,        // 6
     Unknown,
 
-    NOT,            // not
+    IS,             // 'is': ==
+    NOT,            // not: !
     AND,            // and
     OR,             // or
     VERSUS,         // versus or vs (it's called XOR, represented as "^" in other languages)
-    EQUAL,          // =
-    EQUAL_EQUAL,    // ==
+    EQUAL,          // '=' for variable assignments. For 'equality' comparison, we use 'is' and 'is not'
     NOT_EQUAL,      // !=
     GREATER,        // >
     GREATER_EQUAL,  // >=

--- a/src/jesus/main.cpp
+++ b/src/jesus/main.cpp
@@ -46,14 +46,41 @@ int main(int argc, char **argv)
         {
 
             auto tokens = lex(buffer);
+
             ParserContext context(tokens, &jesus);
-            auto you = parse(tokens, context); // AST - Abstract Syntax Tree
+            std::vector<std::unique_ptr<Stmt>> statements;
+            bool waitingForMoreTokens = false;
 
-            if (you)
+            // --------------------------------
+            // Make sure all tokens are parsed
+            // Otherwise, '9 = 9' just prints 9
+            // --------------------------------
+            while (!context.isAtEnd())
             {
-                if (you->inProgress())
-                    continue;
+                auto stmt = parse(tokens, context); // AST - Abstract Syntax Tree
+                if (stmt)
+                {
+                    if (stmt->inProgress())
+                    {
+                        waitingForMoreTokens = true;
+                        break;
+                    }
 
+                    statements.push_back(std::move(stmt));
+                }
+            }
+
+            // ----------------------------------------
+            // ENTER pressed but still need more tokens
+            // ----------------------------------------
+            if (waitingForMoreTokens)
+                continue;
+
+            // ----------------------------------------
+            // Execute the statements (run the program)
+            // ----------------------------------------
+            for (auto &you : statements)
+            {
                 jesus.loves(you);
             }
         }
@@ -61,14 +88,6 @@ int main(int argc, char **argv)
         {
             std::cerr << "❌ Error: " << e.what() << "\n";
         }
-
-        // ----------------
-        // Print the tokens
-        // ----------------
-        // for (const auto &token : tokens)
-        // {
-        //     std::cout << "[" << token.type << ": " << token.value << "]\n";
-        // }
 
         buffer.clear();
         std::cout << "(Jesus) ";

--- a/src/jesus/parser/grammar/expr/atomic/operators/equality_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/operators/equality_rule.cpp
@@ -7,7 +7,7 @@ std::unique_ptr<Expr> EqualityRule::parse(ParserContext &ctx)
     if (!left)
         return nullptr;
 
-    while (ctx.matchAny({TokenType::EQUAL_EQUAL, TokenType::NOT_EQUAL}))
+    while (ctx.matchAny({TokenType::IS, TokenType::NOT_EQUAL}))
     {
         Token op = ctx.previous();
         auto right = operand->parse(ctx);

--- a/src/jesus/parser/grammar/expr/atomic/operators/equality_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/operators/equality_rule.cpp
@@ -7,9 +7,37 @@ std::unique_ptr<Expr> EqualityRule::parse(ParserContext &ctx)
     if (!left)
         return nullptr;
 
-    while (ctx.matchAny({TokenType::IS, TokenType::NOT_EQUAL}))
+    int snapshot = ctx.snapshot();
+    if (ctx.match(TokenType::EQUAL) && ctx.match(TokenType::EQUAL))
+    {
+        throw std::runtime_error("Use 'is' for equality instead of '=='.");
+    }
+
+    ctx.restore(snapshot);
+    while (ctx.match(TokenType::IS))
     {
         Token op = ctx.previous();
+
+        // ----------------------------------
+        // Handle optional 'not' for 'is not'
+        // ----------------------------------
+        bool isNegated = false;
+        if (ctx.match(TokenType::NOT))
+        {
+            isNegated = true;
+            // Combine tokens into a single virtual operator 'is not'
+            op.lexeme = "is not";
+            op.type = TokenType::NOT_EQUAL; // Treat as inequality internally
+        }
+
+        // -------------------------------
+        // Otherwise it's a plain equality
+        // -------------------------------
+        if (!isNegated)
+        {
+            op.type = TokenType::IS; // Equivalent to equality (== in other languages)
+        }
+
         auto right = operand->parse(ctx);
         if (!right)
         {

--- a/src/jesus/parser/parser.cpp
+++ b/src/jesus/parser/parser.cpp
@@ -13,6 +13,10 @@ std::unique_ptr<Stmt> parse(const std::vector<Token> &tokens, ParserContext &con
     if (!tokens_count)
         return nullptr;
 
+    context.consumeAllNewLines();
+    if (context.isAtEnd())
+        return nullptr;
+
     int snapshot = context.snapshot();
     auto outputStmt = grammar::Print->parse(context);
     if (outputStmt)
@@ -42,11 +46,13 @@ std::unique_ptr<Stmt> parse(const std::vector<Token> &tokens, ParserContext &con
     if (repeatWhileStmt)
         return repeatWhileStmt;
 
+    context.restore(snapshot);
     auto ifStmt = grammar::IfStmt->parse(context);
     if (ifStmt)
         return ifStmt;
 
     // If no match, fall back to expression parsing
+    context.restore(snapshot);
     auto expr = grammar::Expression->parse(context);
     if (!expr)
     {

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -330,3 +330,7 @@ repeat 10 times:
     say "Odd:  {limit}"
   amen
 amen
+say ! 8
+say not 8
+1 != 9
+1 is not 9

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -14,7 +14,7 @@ say "adult" if (( age >= 18 ) ) otherwise "minor"
 (age + 4)
 ((( age + 3 + age )))
 ( age/ ( 3 + 3) * 4 )
-1+2*3 == 7
+1+2*3 is 7
 (-1)
 ---++age
 not age
@@ -38,8 +38,8 @@ create text name = "Jesus"
 say name if ( 1 vs 1 ) otherwise "final"
 (age*4)
 say "adult" if ((age>=18)) otherwise "minor"
-( age == 4 )
-( age == age )
+( age is 4 )
+( age is age )
 ( age > age )
 ( age >= age )
 ( age < age )
@@ -66,7 +66,7 @@ say "adult" if ( ( age >= 18 ) ) otherwise "minor"
 ( age / 3 )
 ( age / 3 + 3 * 4 )
 ( age / ( 3 + 3 ) * 4 )
-1 + 2 * 3 == 7
+1 + 2 * 3 is 7
 (  -1 )
 - - - + + age
 not age
@@ -199,13 +199,13 @@ let there be MultiLineClass:
 amen
 create MultiLineClass multiline = 12
 say multiline
-say "igual" se 1 == 1 senão "diferente"
+say "igual" se 1 is 1 senão "diferente"
 criar text nome = "Jesus"
 say não nome
 criar number sim = 1
 criar number nao = 0
-say sim ==  1 e nao == 0
-say sim == 1 ou nao == 0
+say sim é 1 e nao é 0
+say sim é 1 ou nao é 0
 haja Luz: amém
 criar Luz dia = 1
 say dia
@@ -313,7 +313,7 @@ create number limit = 3
 repeat forever:
   limit = limit - 1
   say "Decreasing... {limit}"
-  if (limit == 0):
+  if (limit is 0):
     break
   amen
 amen

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -40,8 +40,7 @@
 (Jesus) (logic) 1
 (Jesus) (logic) 0
 (Jesus) (logic) 0
-(Jesus) ❌ Error: Unknown expression type (parser.cpp)
-(Jesus) ❌ Error: The variable 'age' already exists (scope: global).
+(Jesus) (Jesus) ❌ Error: The variable 'age' already exists (scope: global).
 (Jesus) adult
 (Jesus) (int) 2
 (Jesus) (int) 9
@@ -253,4 +252,8 @@ Odd:  (int) 7
 Even: (int) 8
 Odd:  (int) 9
 Even: (int) 10
+(Jesus) ❌ Error: Use 'not' for negation instead of '!'.
+(Jesus) (logic) 0
+(Jesus) ❌ Error: Use 'is not' for inequality instead of '!='.
+(Jesus) (logic) 1
 (Jesus) 


### PR DESCRIPTION
# Description

This PR improves the Jesus language in three key areas:

1. **Natural equality operator**
   - Replaced '==' with 'is' to make comparisons read more like natural language.

2. **Natural inequality operator**
   - Added support for 'is not' as a replacement for '!='.

3. **Graceful handling of empty input**  
   - Skips empty or whitespace-only lines when the user just presses ENTER.
   - Returns nullptr instead of throwing an "unknown expression" error.

These changes make the language more expressive, intuitive, and user-friendly.

### Example

```jesus
create text winner = 'Christian'

if winner is 'Christian': 
    say 'In Christ we are more than conquerors'
otherwise:
   say 'Something is definitely wrong'
amen

winner = 'someone else'

if winner is not 'Christian':
    say 'The winner is not a Christian? Something is DEFINITELY WRONG'
amen
```

The code above outputs:
> In Christ we are more than conquerors
> The winner is not a Christian? Something is DEFINITELY WRONG

# ✝️ Wisdom

> But in the church I would rather speak five **intelligible words** to instruct others than ten thousand words in a tongue. — **1 Corinthians 14:19**

