### PR TITLE
Step 49: Added support for ‘mod’, ‘is even’, and ‘is odd’ to bring natural expressiveness to numeric operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ set(JESUS_CPP_FILES
     src/jesus/ast/expr/variable_expr.cpp
     src/jesus/ast/expr/create_instance_expr.cpp
     src/jesus/ast/expr/get_attr_expr.cpp
+    src/jesus/ast/expr/parity_check_expr.cpp
     src/jesus/ast/expr/method_call_expr.cpp
     src/jesus/ast/expr/formatted_string_expr.cpp
     src/jesus/ast/expr/grouping_expr.cpp

--- a/src/jesus/ast/expr/binary_expr.hpp
+++ b/src/jesus/ast/expr/binary_expr.hpp
@@ -70,6 +70,11 @@ public:
             return leftVal / rightVal;
         }
 
+        if (op.type == TokenType::MOD)
+        {
+            return leftVal % rightVal;
+        }
+
         if (op.type == TokenType::LESS)
         {
             return Value(leftVal < rightVal);

--- a/src/jesus/ast/expr/parity_check_expr.hpp
+++ b/src/jesus/ast/expr/parity_check_expr.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "expr.hpp"
+#include <memory>
+
+/**
+ * @brief Represents expressions like `x is odd` or `y is not even`.
+ *
+ * Internally, this is equivalent to a modulo check: (x mod 2 == 1) or (x mod 2 == 0).
+ * It simplifies common numeric parity tests into natural language syntax.
+ *
+ * "He has made everything beautiful in its time." — Ecclesiastes 3:11
+ */
+class ParityCheckExpr : public Expr
+{
+public:
+    std::unique_ptr<Expr> target;
+    bool negate;
+    bool checkOdd;
+
+    ParityCheckExpr(std::unique_ptr<Expr> target, bool negate, bool checkOdd)
+        : target(std::move(target)), negate(negate), checkOdd(checkOdd) {}
+
+    Value evaluate(std::shared_ptr<Heart> heart) const override
+    {
+        Value val = target->evaluate(heart);
+
+        if (!val.IS_NUMBER)
+            // FIXME: Check this at PARSE time, not RUNTIME
+            throw std::runtime_error("❌ Error: Parity checks ('odd'/'even') only support integer types.");
+
+        int n = val.toInt();
+        bool result = checkOdd ? (n % 2 != 0) : (n % 2 == 0);
+
+        if (negate)
+            result = !result;
+
+        return Value(result);
+    }
+
+    Value accept(ExprVisitor &visitor) const override;
+
+    bool canEvaluateAtParseTime() const override
+    {
+        return target->canEvaluateAtParseTime();
+    }
+
+    std::shared_ptr<CreationType> getReturnType(ParserContext &ctx) const override;
+
+    std::string toString() const override
+    {
+        std::string desc = "ParityCheckExpr(";
+        desc += "" + target->toString();
+        desc += (negate ? "is not" : "is");
+        desc += (checkOdd ? "odd" : "even");
+
+        desc += ")";
+        return desc;
+    }
+};

--- a/src/jesus/interpreter/expr_visitor.hpp
+++ b/src/jesus/interpreter/expr_visitor.hpp
@@ -10,6 +10,7 @@
 #include "../ast/expr/ask_expr.hpp"
 #include "../ast/expr/create_instance_expr.hpp"
 #include "../ast/expr/get_attr_expr.hpp"
+#include "../ast/expr/parity_check_expr.hpp"
 #include "../ast/expr/method_call_expr.hpp"
 #include "../ast/expr/formatted_string_expr.hpp"
 
@@ -59,6 +60,7 @@ public:
     virtual Value visitGetAttribute(const GetAttributeExpr &expr) = 0;
     virtual Value visitMethodCallExpr(const MethodCallExpr &expr) = 0;
     virtual Value visitFormattedStringExpr(const FormattedStringExpr &expr) = 0;
+    virtual Value visitParityCheckExpr(const ParityCheckExpr &expr) = 0;
 
     virtual ~ExprVisitor() = default;
 };

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -77,6 +77,11 @@ Value Interpreter::visitGetAttribute(const GetAttributeExpr &expr)
     return instance->getAttribute(expr.attribute);
 }
 
+Value Interpreter::visitParityCheckExpr(const ParityCheckExpr &expr)
+{
+    return expr.evaluate(symbol_table.currentScope());
+}
+
 Value Interpreter::visitMethodCallExpr(const MethodCallExpr &expr)
 {
     Value object = expr.object->accept(*this);

--- a/src/jesus/interpreter/interpreter.hpp
+++ b/src/jesus/interpreter/interpreter.hpp
@@ -170,6 +170,8 @@ private:
      */
     Value visitGetAttribute(const GetAttributeExpr &expr) override;
 
+    Value visitParityCheckExpr(const ParityCheckExpr &expr) override;
+
     Value visitMethodCallExpr(const MethodCallExpr &expr) override;
 
     Value visitFormattedStringExpr(const FormattedStringExpr &expr) override;

--- a/src/jesus/lexer/lexer.cpp
+++ b/src/jesus/lexer/lexer.cpp
@@ -212,6 +212,12 @@ TokenType recognize_token_type(const std::string &word)
     if (word == "mod")
         return TokenType::MOD;
 
+    if (word == "odd" || word == "ímpar")
+        return TokenType::ODD;
+
+    if (word == "even" || word == "par")
+        return TokenType::EVEN;
+
     if (word == "skip" || word == "pular")
         return TokenType::SKIP;
 

--- a/src/jesus/lexer/lexer.cpp
+++ b/src/jesus/lexer/lexer.cpp
@@ -209,6 +209,9 @@ TokenType recognize_token_type(const std::string &word)
     if (isDouble(word))
         return TokenType::DOUBLE;
 
+    if (word == "mod")
+        return TokenType::MOD;
+
     if (word == "skip" || word == "pular")
         return TokenType::SKIP;
 
@@ -458,6 +461,9 @@ std::vector<Token> lex(const std::string &raw_input)
 
             throw std::runtime_error(msg);
         }
+
+        if (c == "%")
+            throw std::runtime_error("Use 'mod' for modulo instead of '%'.");
 
         // Unexpected character
         throw std::runtime_error("Unexpected character: '" + c + "'");

--- a/src/jesus/lexer/token.hpp
+++ b/src/jesus/lexer/token.hpp
@@ -116,6 +116,8 @@ public:
 
         case TokenType::SLASH:
             return "SLASH";
+        case TokenType::MOD:
+            return "MOD";
 
         case TokenType::PLUS:
             return "PLUS";

--- a/src/jesus/lexer/token.hpp
+++ b/src/jesus/lexer/token.hpp
@@ -118,6 +118,10 @@ public:
             return "SLASH";
         case TokenType::MOD:
             return "MOD";
+        case TokenType::ODD:
+            return "ODD";
+        case TokenType::EVEN:
+            return "EVEN";
 
         case TokenType::PLUS:
             return "PLUS";
@@ -139,6 +143,13 @@ public:
             return "DOUBLE(" + lexeme + ")";
         case TokenType::IDENTIFIER:
             return "IDENTIFIER(" + lexeme + ")";
+
+        case TokenType::RAW_STRING:
+            return "RAW_STRING(" + lexeme + ")";
+
+        case TokenType::FORMATTED_STRING:
+            return "FORMATTED_STRING(" + lexeme + ")";
+
         case TokenType::SAY:
             return "SAY";
         case TokenType::ASK:

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -42,6 +42,7 @@ enum class TokenType
     MINUS,          // -
     STAR,           // *
     SLASH,          // /
+    MOD,            // mod ('%' in other languages)
     COLON,          // ':' (Begining of a block)
     SEMICOLON,      // ';' To separate method args by type: int x, y, z; text name, surname
     COMMA,          // ',' To separate var names: int x, y, z

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -43,6 +43,8 @@ enum class TokenType
     STAR,           // *
     SLASH,          // /
     MOD,            // mod ('%' in other languages)
+    ODD,            //
+    EVEN,           //
     COLON,          // ':' (Begining of a block)
     SEMICOLON,      // ';' To separate method args by type: int x, y, z; text name, surname
     COMMA,          // ',' To separate var names: int x, y, z

--- a/src/jesus/parser/grammar/expr/atomic/operators/equality_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/operators/equality_rule.cpp
@@ -1,5 +1,6 @@
 #include "equality_rule.hpp"
 #include "../../../../../ast/expr/binary_expr.hpp"
+#include "../../../../../ast/expr/parity_check_expr.hpp"
 
 std::unique_ptr<Expr> EqualityRule::parse(ParserContext &ctx)
 {
@@ -28,6 +29,18 @@ std::unique_ptr<Expr> EqualityRule::parse(ParserContext &ctx)
             // Combine tokens into a single virtual operator 'is not'
             op.lexeme = "is not";
             op.type = TokenType::NOT_EQUAL; // Treat as inequality internally
+        }
+
+        // ---------------------------------------
+        // Handle “is [not] odd/even” immediately
+        // ---------------------------------------
+        if (ctx.match(TokenType::ODD))
+        {
+            return std::make_unique<ParityCheckExpr>(std::move(left), isNegated, true);
+        }
+        else if (ctx.match(TokenType::EVEN))
+        {
+            return std::make_unique<ParityCheckExpr>(std::move(left), isNegated, false);
         }
 
         // -------------------------------

--- a/src/jesus/parser/grammar/expr/atomic/operators/multiplication_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/operators/multiplication_rule.cpp
@@ -7,7 +7,7 @@ std::unique_ptr<Expr> MultiplicationRule::parse(ParserContext &ctx)
     if (!left)
         return nullptr;
 
-    while (ctx.matchAny({TokenType::STAR, TokenType::SLASH}))
+    while (ctx.matchAny({TokenType::STAR, TokenType::SLASH, TokenType::MOD}))
     {
         Token op = ctx.previous();
         auto right = unary->parse(ctx);

--- a/src/jesus/spirit/value.hpp
+++ b/src/jesus/spirit/value.hpp
@@ -171,6 +171,20 @@ public:
         throw std::runtime_error("Operator '/' not supported for given types");
     }
 
+    friend Value operator%(const Value &left, const Value &right)
+    {
+        if (left.IS_NUMBER && right.IS_NUMBER)
+        {
+            if (left.IS_DOUBLE || right.IS_DOUBLE)
+                throw std::runtime_error("'" + std::to_string(left.toNumber()) + " mod " + std::to_string(right.toNumber()) + "' invalid — 'mod' only supports integers.");
+
+            return Value(left.toInt() % right.toInt());
+        }
+
+        // FIXME: Detect at PARSE time if numbers are 'int'
+        throw std::runtime_error("Operator 'mod' not supported for given types");
+    }
+
     friend bool operator==(const Value &left, const Value &right)
     {
         if (left.IS_FORMLESS && right.IS_FORMLESS)

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -337,3 +337,10 @@ say not 8
 'text' mod 9
 1 % 2
 1 mod 2
+1 is odd
+1 is even
+1 is not odd
+1 is not even
+'test' is even
+2 é par
+1 é ímpar

--- a/src/jesus/tests/040-many-tests.jesus
+++ b/src/jesus/tests/040-many-tests.jesus
@@ -334,3 +334,6 @@ say ! 8
 say not 8
 1 != 9
 1 is not 9
+'text' mod 9
+1 % 2
+1 mod 2

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -256,4 +256,7 @@ Even: (int) 10
 (Jesus) (logic) 0
 (Jesus) ❌ Error: Use 'is not' for inequality instead of '!='.
 (Jesus) (logic) 1
+(Jesus) ❌ Error: Operator 'mod' not supported for given types
+(Jesus) ❌ Error: Use 'mod' for modulo instead of '%'.
+(Jesus) (int) 1
 (Jesus) 

--- a/src/jesus/tests/040-many-tests.jesus.expected
+++ b/src/jesus/tests/040-many-tests.jesus.expected
@@ -259,4 +259,11 @@ Even: (int) 10
 (Jesus) ❌ Error: Operator 'mod' not supported for given types
 (Jesus) ❌ Error: Use 'mod' for modulo instead of '%'.
 (Jesus) (int) 1
+(Jesus) (logic) 1
+(Jesus) (logic) 0
+(Jesus) (logic) 0
+(Jesus) (logic) 1
+(Jesus) ❌ Error: ❌ Error: Parity checks ('odd'/'even') only support integer types.
+(Jesus) (logic) 1
+(Jesus) (logic) 1
 (Jesus) 


### PR DESCRIPTION
# Description

This PR introduces two key improvements that make working with numbers in **Jesus Programming Language** more expressive, readable, and closer to natural language.

#### What’s New

* **`mod` operator** — provides a natural, language-level way to express modular arithmetic.
  Example:

  ```jesus
  say 10 mod 3  # prints 1
  ```

  Using `%` now suggests:

  > “Use 'mod' for modulo instead of '%'.”

* **`is even` / `is odd` expressions** — allows direct parity checks in human-like syntax.
  Examples:

```jesus
create number x = 144000

 if x is even:
      say "Even number"
amen
 
if x is not odd:
      say "Also even"
amen
```

#### Motivation

These changes simplify common arithmetic checks and align the syntax with how people naturally think and speak.
They remove the need for low-level comparisons like `x mod 2 == 0`, emphasizing clarity and intent.

#### Implementation Details

* `mod` implemented in `MultiplicationRule`, restricted to integer operands.
* `is even` / `is odd` handled in the `EqualityRule`, producing a specialized `ParityCheckExpr`.

# ✝️ Wisdom

> “For everything God created is good, and nothing is to be rejected if it is received with thanksgiving.” — *1 Timothy 4:4*
