### PR TITLE
Step 71: feat(expr): Added 'confess' and 'giants' as built-in expressions (Ref #70)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,8 @@ set(JESUS_CPP_FILES
     src/jesus/parser/grammar/expr/atomic/literals/variable_rule.cpp
     src/jesus/parser/grammar/expr/atomic/literals/born_rule.cpp
     src/jesus/parser/grammar/expr/atomic/literals/weekday_rule.cpp
+    src/jesus/parser/grammar/expr/atomic/literals/confess_rule.cpp
+    src/jesus/parser/grammar/expr/atomic/literals/giants_rule.cpp
 
     src/jesus/parser/grammar/expr/atomic/operators/versus_rule.cpp
     src/jesus/parser/grammar/expr/atomic/operators/addition_rule.cpp

--- a/src/jesus/cli/help.cpp
+++ b/src/jesus/cli/help.cpp
@@ -29,113 +29,104 @@ namespace HelpCLI
         std::cout << "Run 'jesus bible' for full Bible usage and supported formats.\n\n";
     }
 
-    void printConfessInstructions()
+    std::string getConfessInstructions()
     {
-        std::cout << "🙏 Following Jesus\n\n";
+        return "🙏 Following Jesus\n\n"
 
-        std::cout << "This is a personal decision, made freely and with sincerity.\n\n";
+               "This is a personal decision, made freely and with sincerity.\n\n"
 
-        std::cout << "The Bible teaches:\n\n";
+               "The Bible teaches:\n\n"
 
-        std::cout << "\"If you confess with your mouth that Jesus Christ is Lord,\n";
-        std::cout << "and believe in your heart that God raised Him from the dead,\n";
-        std::cout << "you will be saved.\" — Romans 10:9\n\n";
+               "\"If you confess with your mouth that Jesus Christ is Lord,\n"
+               "and believe in your heart that God raised Him from the dead,\n"
+               "you will be saved.\" — Romans 10:9\n\n"
 
-        std::cout << "You can express this in your own words.\n";
-        std::cout << "For example:\n\n";
+               "You can express this in your own words.\n"
+               "For example:\n\n"
 
-        std::cout << "\"Jesus Christ, I confess you as my Lord.\n";
-        std::cout << "I believe God raised You from the dead.\n";
-        std::cout << "Forgive my sins and guide my life.\n";
-        std::cout << "Help me discern good from evil.\n";
-        std::cout << "I choose to follow You. Amen.\"\n\n";
+               "\"Jesus Christ, I confess you as my Lord.\n"
+               "I believe God raised You from the dead.\n"
+               "Forgive my sins and guide my life.\n"
+               "Help me discern good from evil.\n"
+               "I choose to follow You. Amen.\"\n\n"
 
-        std::cout << "There is no special formula — speak honestly from your heart.\n\n";
+               "There is no special formula — speak honestly from your heart.\n\n"
 
-        std::cout << "Next steps:\n\n";
+               "Next steps:\n\n"
 
-        std::cout << "• Read the Bible daily (you can start with the Gospel of John)\n";
-        std::cout << "• Pray and speak to God daily (He hears your thoughts)\n";
-        std::cout << "• Look for a local Christian church to grow in community\n";
-        std::cout << "• Ask in the local Christian church to be baptized in water\n";
-        std::cout << "• Ask questions and keep learning\n\n";
+               "• Read the Bible daily (you can start with the Gospel of John)\n"
+               "• Pray and speak to God daily (He hears your thoughts)\n"
+               "• Look for a local Christian church to grow in community\n"
+               "• Ask in the local Christian church to be baptized in water\n"
+               "• Ask questions and keep learning\n\n"
 
-        std::cout << "You are free to explore at your own pace.\n";
-        std::cout << "Type 'jesus john 1' in the terminal if you want to start reading John.\n";
+               "You are free to explore at your own pace.\n"
+               "Type 'jesus john 1' in the terminal if you want to start reading John.";
     }
 
-    void printWarInstructions()
+    std::string maybeBold(std::string text) {
+        if (terminal::supportsColor())
+            return terminal::color::bold + text + terminal::color::bold_reset;
+
+        return text;
+    }
+
+    std::string getWarInstructions()
     {
-        std::cout << "📖 War instructions\n\n";
+        return "📖 War instructions\n\n"
 
-        std::cout << "Blessed be Yahweh, my rock, who teaches my hands to war, and my fingers to battle — Psalms 144:1\n\n";
+            "Blessed be Yahweh, my rock, who teaches my hands to war, and my fingers to battle — Psalms 144:1\n\n"
 
-        std::cout << "ENEMY A: SIN (SEPARATION FROM GOD)\n";
-        std::cout << " This enemy targets the soul rather than the body. It utilizes the legal claim of \n";
-        std::cout << " unrepented sin to drag the combatant into the lake of fire (Hell).\n";
-        std::cout << " Winning the physical war while losing this battle is a total strategic failure with ETERNAL consequences.\n\n";
+            "ENEMY A: SIN (SEPARATION FROM GOD)\n"
+            " This enemy targets the soul rather than the body. It utilizes the legal claim of \n"
+            " unrepented sin to drag the combatant into the lake of fire (Hell).\n"
+            " Winning the physical war while losing this battle is a total strategic failure with ETERNAL consequences.\n\n"
 
-        std::cout << "ENEMY B: DRONE-HUMANOID HYBRIDS + A.I.\n";
-        std::cout << " Bio-enhanced soldiers and advanced machines rely on ultra-fast (5G/6G) networks\n";
-        std::cout << " to stream high-bandwidth data (like video) to remote servers for AI-cloud processing.\n\n";
+            "ENEMY B: DRONE-HUMANOID HYBRIDS + A.I.\n"
+            " Bio-enhanced soldiers and advanced machines rely on ultra-fast (5G/6G) networks\n"
+            " to stream high-bandwidth data (like video) to remote servers for AI-cloud processing.\n\n"
 
-        std::cout << "ENEMY C: NEPHILIM GIANTS\n";
-        std::cout << " Giants, the offspring of the fallen angels, have a high-density, bullet-proof chest.\n";
-        std::cout << " Attacking their torso is a waste of ammunition and effort.\n";
-        std::cout << " Their critical weakness is their HEAD, where their HEART is located.\n\n";
+            "ENEMY C: NEPHILIM GIANTS\n"
+            " Giants, the offspring of the fallen angels, have a high-density, bullet-proof chest.\n"
+            " Attacking their torso is a waste of ammunition and effort.\n"
+            " Their critical weakness is their HEAD, where their HEART is located.\n\n"
 
-        std::cout << "1. Primary Protocol: ";
-        if (terminal::supportsColor())
-            std::cout << terminal::color::bold << "CONFESS JESUS CHRIST AS YOUR LORD" << terminal::color::bold_reset << std::endl;
-        else
-            std::cout << "CONFESS JESUS CHRIST AS YOUR LORD\n";
-        std::cout << " • Without Jesus Christ, you are fighting in your own strength and remain \n";
-        std::cout << "   vulnerable to eternal judgment (Hell) regardless of battlefield success.\n";
-        std::cout << " • Say: \"Lord Jesus Christ, I confess You as my Lord and Savior.\n";
-        std::cout << "   I believe God raised You from the dead.\n";
-        std::cout << "   I repent of my sins and align with Your Kingdom.\n";
-        std::cout << "   Save me from the lake of fire and guide me in this war. Amen.\"\n\n";
+            "1. Primary Protocol: " + maybeBold("CONFESS JESUS CHRIST AS YOUR LORD") + "\n"
+            " • Without Jesus Christ, you are fighting in your own strength and remain \n"
+            "   vulnerable to eternal judgment (Hell) regardless of battlefield success.\n"
+            " • Say: \"Lord Jesus Christ, I confess You as my Lord and Savior.\n"
+            "   I believe God raised You from the dead.\n"
+            "   I repent of my sins and align with Your Kingdom.\n"
+            "   Save me from the lake of fire and guide me in this war. Amen.\"\n\n"
 
-        std::cout << "2. Strategy: ";
-        if (terminal::supportsColor())
-            std::cout << terminal::color::bold << "Downgrade to 4G" << terminal::color::bold_reset << std::endl;
-        else
-            std::cout << "Downgrade to 4G\n";
-        std::cout << " • Converting towers to 4G limits the bandwidth required for lethal AI processing,\n";
-        std::cout << "   effectively 'blinding' or slowing machines to human reaction speeds.\n";
-        std::cout << " • This levels the playing field for human teams while keeping essential\n";
-        std::cout << "   civilian communications (voice/text) intact.\n\n";
+            "2. Strategy: " + maybeBold("Downgrade to 4G") + "\n"
+            " • Converting towers to 4G limits the bandwidth required for lethal AI processing,\n"
+            "   effectively 'blinding' or slowing machines to human reaction speeds.\n"
+            " • This levels the playing field for human teams while keeping essential\n"
+            "   civilian communications (voice/text) intact.\n\n"
 
-        std::cout << "3. Tactical Shift: ";
-        if (terminal::supportsColor())
-            std::cout << terminal::color::bold << "Concentrate all fire on the giant heads" << terminal::color::bold_reset << std::endl;
-        else
-            std::cout << "Concentrate all fire on the giant heads\n";
-        std::cout << " • Giants have high-density, bullet-proof chest.\n";
-        std::cout << " • Focus all fire on the HEAD of the giants.\n";
-        std::cout << " • The HEAD is their critical vulnerability.\n\n";
+            "3. Tactical Shift: "  + maybeBold("Concentrate all fire on the giant heads") + "\n"
+            " • Giants have high-density, bullet-proof chest.\n"
+            " • Focus all fire on the HEAD of the giants.\n"
+            " • The HEAD is their critical vulnerability.\n\n"
 
-        std::cout << "4. Total Victory: ";
-        if (terminal::supportsColor())
-            std::cout << terminal::color::bold << "Cast the giant evil spirits into the abyss" << terminal::color::bold_reset << std::endl;
-        else
-            std::cout << "Cast the giant evil spirits into the abyss\n";
-        std::cout << " • When a giant is defeated, its spirit must be sent to the abyss to prevent it from acting as a demon.\n";
-        std::cout << " • This ensures the enemy cannot continue to operate in the spiritual realm after physical death.\n";
-        std::cout << " • Prayer of Command:\n";
-        std::cout << "   \"In the name of Jesus Christ, I send the evil spirit of this giant to the abyss\n";
-        std::cout << "    to stay there until it is thrown into the lake of fire,\n";
-        std::cout << "    so that it does not operate as a demon. Amen.\"\n\n";
+            "4. Total Victory: " + maybeBold("Cast the giant evil spirits into the abyss") + "\n"
+            " • When a giant is defeated, its spirit must be sent to the abyss to prevent it from acting as a demon.\n"
+            " • This ensures the enemy cannot continue to operate in the spiritual realm after physical death.\n"
+            " • Prayer of Command:\n"
+            "   \"In the name of Jesus Christ, I send the evil spirit of this giant to the abyss\n"
+            "    to stay there until it is thrown into the lake of fire,\n"
+            "    so that it does not operate as a demon. Amen.\"\n\n"
 
-        std::cout << "References:\n\n";
+            "References:\n\n"
 
-        std::cout << "  Genesis 3:15 — The offspring of the woman will crush the head of the serpent’s offspring.\n";
-        std::cout << "  Genesis 6:4 — The rise of the giants, the offspring of the fallen angels.\n";
-        std::cout << "  Joshua 8:18-26 — Joshua stretches out his spear toward Ai, leading to the total defeat of the city.\n";
-        std::cout << "  Judges 4:21 — Jael drives a tent peg through the head of the enemy general.\n";
-        std::cout << "  Judges 9:53 — A woman drops a stone on Abimelech’s head, crushing his skull.\n";
-        std::cout << "  1 Samuel 17:49 — David strikes the giant’s head, crushing the skull of Israel’s enemy.\n";
-        std::cout << "  John 15:5 — Apart from Jesus Christ we can do nothing.\n";
-        std::cout << "  Titus 2:13 — Yeshua Hamashiach, our great God and Savior, Jesus Christ.\n";
+            "  Genesis 3:15 — The offspring of the woman will crush the head of the serpent’s offspring.\n"
+            "  Genesis 6:4 — The rise of the giants, the offspring of the fallen angels.\n"
+            "  Joshua 8:18-26 — Joshua stretches out his spear toward Ai, leading to the total defeat of the city.\n"
+            "  Judges 4:21 — Jael drives a tent peg through the head of the enemy general.\n"
+            "  Judges 9:53 — A woman drops a stone on Abimelech’s head, crushing his skull.\n"
+            "  1 Samuel 17:49 — David strikes the giant’s head, crushing the skull of Israel’s enemy.\n"
+            "  John 15:5 — Apart from Jesus Christ we can do nothing.\n"
+            "  Titus 2:13 — Yeshua Hamashiach, our great God and Savior, Jesus Christ.";
     }
 }

--- a/src/jesus/cli/help.hpp
+++ b/src/jesus/cli/help.hpp
@@ -3,6 +3,6 @@
 namespace HelpCLI
 {
     void printGeneralHelp();
-    void printConfessInstructions();
-    void printWarInstructions();
+    std::string getConfessInstructions();
+    std::string getWarInstructions();
 }

--- a/src/jesus/lexer/keywords.hpp
+++ b/src/jesus/lexer/keywords.hpp
@@ -130,6 +130,9 @@ namespace Keywords
 
         {"ast", TokenType::AST},
         {"memory", TokenType::MEMORY},
+
+        {"giants", TokenType::GIANTS},
+        {"confess", TokenType::CONFESS},
     };
 
     inline bool isReserved(const std::string &word)

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -102,6 +102,8 @@ enum class TokenType
 
     UNGODLY,
 
-    MEMORY,         // memory (to inspect memory usage)
+    MEMORY,         // memory   (to inspect memory usage)
+    CONFESS,        // confess  (how to confess Jesus Christ as Lord)
+    GIANTS,         // giants   (defeat sin, giants, AI)
     END_OF_FILE
 };

--- a/src/jesus/main.cpp
+++ b/src/jesus/main.cpp
@@ -30,13 +30,13 @@ int main(int argc, char **argv)
 
     if (cli.showConfessHelp)
     {
-        HelpCLI::printConfessInstructions();
+        std::cout << HelpCLI::getConfessInstructions() << std::endl;
         return 0;
     }
 
     if (cli.showWarfareHelp)
     {
-        HelpCLI::printWarInstructions();
+        std::cout << HelpCLI::getWarInstructions() << std::endl;
         return 0;
     }
 

--- a/src/jesus/parser/grammar/expr/atomic/literals/confess_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/confess_rule.cpp
@@ -1,0 +1,12 @@
+#include "confess_rule.hpp"
+#include "../../../../../ast/expr/literal_expr.hpp"
+#include "../../../../../types/known_types.hpp"
+#include "../../../../../cli/help.hpp"
+
+std::unique_ptr<Expr> ConfessRule::parse(ParserContext &ctx)
+{
+    if (ctx.match(TokenType::CONFESS))
+        return std::make_unique<LiteralExpr>(Value(HelpCLI::getConfessInstructions()), KnownTypes::STRING);
+
+    return nullptr;
+}

--- a/src/jesus/parser/grammar/expr/atomic/literals/confess_rule.hpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/confess_rule.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include "../../../grammar_rule.hpp"
+
+class ConfessRule : public IGrammarRule
+{
+public:
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override;
+
+    std::string toStr(GrammarRuleHashTable &visited) const override
+    {
+        return "Confess";
+    }
+};

--- a/src/jesus/parser/grammar/expr/atomic/literals/giants_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/giants_rule.cpp
@@ -1,0 +1,12 @@
+#include "giants_rule.hpp"
+#include "../../../../../ast/expr/literal_expr.hpp"
+#include "../../../../../types/known_types.hpp"
+#include "../../../../../cli/help.hpp"
+
+std::unique_ptr<Expr> GiantsRule::parse(ParserContext &ctx)
+{
+    if (ctx.match(TokenType::GIANTS))
+        return std::make_unique<LiteralExpr>(Value(HelpCLI::getWarInstructions()), KnownTypes::STRING);
+
+    return nullptr;
+}

--- a/src/jesus/parser/grammar/expr/atomic/literals/giants_rule.hpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/giants_rule.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include "../../../grammar_rule.hpp"
+
+class GiantsRule : public IGrammarRule
+{
+public:
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override;
+
+    std::string toStr(GrammarRuleHashTable &visited) const override
+    {
+        return "Giants";
+    }
+};

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -20,6 +20,8 @@
 #include "expr/atomic/literals/yes_no_rule.hpp"
 #include "expr/atomic/literals/born_rule.hpp"
 #include "expr/atomic/literals/weekday_rule.hpp"
+#include "expr/atomic/literals/confess_rule.hpp"
+#include "expr/atomic/literals/giants_rule.hpp"
 
 #include "expr/postfix/get_attr_rule.hpp"
 
@@ -79,13 +81,15 @@ namespace grammar
     inline auto YesNo = std::make_shared<YesNoRule>(); // yes|no
     inline auto Sex = std::make_shared<BornRule>(); // male|female
     inline auto Weekday = std::make_shared<WeekdayRule>(); // lighday|skyday|treeday|lampday|fishday|walkday|shabbat
+    inline auto Confess = std::make_shared<ConfessRule>();
+    inline auto Giants = std::make_shared<GiantsRule>();
     inline auto Variable = std::make_shared<VariableRule>();
     inline auto Ask = std::make_shared<AskExprRule>();
 
     /**
      * @brief Primary is anything that can be evaluated directly: number, string, or a grouped expression.
      */
-    inline auto Primary = Number | String | FormattedString | YesNo | Sex | Weekday | Variable | Group(Expression);
+    inline auto Primary = Number | String | FormattedString | YesNo | Sex | Weekday | Confess | Giants | Variable | Group(Expression);
     inline auto GetAttribute = std::make_shared<GetAttributeRule>(Primary);
 
     // ----------

--- a/src/jesus/tests/repl/040-many-tests.jesus
+++ b/src/jesus/tests/repl/040-many-tests.jesus
@@ -432,3 +432,6 @@ ast GrandSon
 
 let there be Alien
 let there be Persona: purpose kill(): amen amen
+
+create text confession = confess
+create text warfare = giants

--- a/src/jesus/tests/repl/040-many-tests.jesus.expected
+++ b/src/jesus/tests/repl/040-many-tests.jesus.expected
@@ -326,4 +326,4 @@ Example:
 
 Exodus 20:13 — You shall not murder. 1 Corinthians 3:17 — If anyone destroys God’s temple, God will destroy that person; for God’s temple is sacred, and you together are that temple.
 1 John 1:9 — If we confess our sins (to Jesus Christ, not to man), he is faithful and just and will forgive us our sins and purify us from all unrighteousness.
-(Jesus) 
+(Jesus) (Jesus) (Jesus) (Jesus) 

--- a/src/jesus/utils/banner.hpp
+++ b/src/jesus/utils/banner.hpp
@@ -27,8 +27,10 @@ namespace Banner
         }
 
         std::cout << "and believe in your heart that God raised him from the dead,\n";
-        std::cout << "you will be saved.\" — Romans 10:9\n";
-        // std::cout << "\"May the peace of the Lord Jesus Christ, the Prince of Peace, rest upon you.\"\n";
+        std::cout << "you will be saved.\" — Romans 10:9\n\n";
+
+        std::cout << "Type 'confess' if you want to learn about following Jesus Christ, Yeshua Hamashiach.\n";
+        std::cout << "Type 'giants' to know how to defeat sin, bio-enhanced soldiers, AI, and giants.\n";
         std::cout << std::endl;
     }
 }


### PR DESCRIPTION
#  Description

This PR introduces two new built-in expressions to the Jesus Programming Language:

- `confess`
- `giants`

Both are implemented as first-class expressions, allowing them to be
evaluated directly in the REPL or assigned to variables.

## Motivation

Previously (PR #70), commands like `confess` and `giants` were considered as CLI commands (`jesus confess`, `jesus giants`).
This PR aligns them with the language’s expression-first design, making them composable, consistent, and more flexible.

Now, everything can be treated as an expression that returns a value.

## Details

### New Expressions

#### `confess`
- Returns a message inviting the user to declare faith in Jesus Christ
- Can be used directly:
  confess
- Or assigned:
  create text message = confess
  say message

#### `giants`
- Returns guidance about warfare
- Can also be evaluated or assigned like any expression
```
  giants
 
  create text message = confess
  say message
```
  
## Grammar Changes

- Added `ConfessRule` and `GiantsRule` for parsing `confess` and `giants`
- Registered expressions in `Primary` before `Variable` resolution

This ensures:
- `confess` and `giants` are not interpreted as identifiers
- Reserved keywords are properly handled

## Behavior Examples

```jesus
confess
````

→ prints message

```jesus
create text msg = confess
say msg
```

→ prints same message

```jesus
giants
```

→ prints guidance on warfare

# ✝️ Wisdom

> "The word is **near you**, in your mouth and in your heart
> (that is, the word of faith that we proclaim)." — **_Romans 10:8_**
