### PR TITLE
Step 73: Added event-driven HTTP routing with 'on', and HTTP Server runtime 'serve'. Ref #57.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,8 @@ set(JESUS_CPP_FILES
     src/jesus/ast/stmt/import_module_stmt.cpp
     src/jesus/ast/stmt/ast_inspect_stmt.cpp
     src/jesus/ast/stmt/memory_inspect_stmt.cpp
+    src/jesus/ast/stmt/on_stmt.cpp
+    src/jesus/ast/stmt/serve_stmt.cpp
 
     # --------------
     # Parser classes
@@ -175,12 +177,15 @@ set(JESUS_CPP_FILES
     src/jesus/parser/grammar/stmt/import_module_stmt_rule.cpp
     src/jesus/parser/grammar/stmt/ast_inspect_stmt_rule.cpp
     src/jesus/parser/grammar/stmt/memory_inspect_stmt_rule.cpp
+    src/jesus/parser/grammar/stmt/on_stmt_rule.cpp
+    src/jesus/parser/grammar/stmt/serve_stmt_rule.cpp
 
     # -----------
     # Interpreter
     # -----------
     src/jesus/interpreter/interpreter.cpp
     src/jesus/interpreter/runtime/method.cpp
+    src/jesus/interpreter/runtime/http/http_runtime.cpp
 
     # ---
     # CLI
@@ -193,6 +198,11 @@ set(JESUS_CPP_FILES
     src/jesus/cli/uml_exporter.cpp
     src/jesus/understanding/shared/uml_graph.cpp
     src/jesus/understanding/scripture/book_aliases.cpp
+
+    # --------
+    # Builtins
+    # --------
+    src/jesus/builtins/io/socket/tcpv4_socket.cpp
 )
 
 # --------------------------

--- a/src/jesus/ast/stmt/on_stmt.cpp
+++ b/src/jesus/ast/stmt/on_stmt.cpp
@@ -1,0 +1,7 @@
+#include "on_stmt.hpp"
+#include "../../interpreter/stmt_visitor.hpp"
+
+void OnStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visitOnStmt(*this);
+}

--- a/src/jesus/ast/stmt/on_stmt.hpp
+++ b/src/jesus/ast/stmt/on_stmt.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "stmt.hpp"
+#include <string>
+#include <vector>
+#include <memory>
+
+/**
+ * @brief Represents an event handler declaration in the Jesus language.
+ *
+ * Example:
+ * @code
+ * on http '/status':
+ *     return 1
+ * amen
+ * @endcode
+ *
+ * In this example, the program declares that whenever an HTTP request
+ * is received at the path `/status`, the http response is '1'.
+ *
+ * This abstraction is part of the event-driven model of the language,
+ * where all interactions (HTTP, TCP, WebSocket, etc.) are treated as
+ * events flowing through the system ("Mind"), and the program reacts
+ * accordingly.
+ *
+ * "My sheep hear my voice, and I know them, and they follow me."
+ * — John 10:27
+ */
+class OnStmt : public Stmt
+{
+public:
+    std::string protocol;                    // "http"
+    std::string path;                        // "/status"
+    std::vector<std::shared_ptr<Stmt>> body; // return {status: true}
+
+    OnStmt(std::string protocol,
+           std::string path,
+           std::vector<std::shared_ptr<Stmt>> body)
+        : protocol(std::move(protocol)),
+          path(std::move(path)),
+          body(std::move(body)) {}
+
+    void accept(StmtVisitor &visitor) const override;
+};

--- a/src/jesus/ast/stmt/serve_stmt.cpp
+++ b/src/jesus/ast/stmt/serve_stmt.cpp
@@ -1,0 +1,7 @@
+#include "serve_stmt.hpp"
+#include "../../interpreter/stmt_visitor.hpp"
+
+void ServeStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visitServeStmt(*this);
+}

--- a/src/jesus/ast/stmt/serve_stmt.hpp
+++ b/src/jesus/ast/stmt/serve_stmt.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include "stmt.hpp"
+
+/**
+ * @brief Start an HttpServer
+ */
+class ServeStmt : public Stmt
+{
+public:
+    void accept(StmtVisitor &visitor) const override;
+};

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -802,3 +802,18 @@ void Interpreter::visitMemoryInspectStmt(const MemoryInspectStmt &stmt)
     size_t kb = getPSS_KB();
     std::cout << "Memory Used: " << formatMemory(kb) << "\n";
 }
+
+void Interpreter::visitOnStmt(const OnStmt &stmt)
+{
+    HttpRoute route;
+    route.protocol = stmt.protocol;
+    route.path = stmt.path;
+    route.body = stmt.body;
+
+    httpRuntime.addRoute(route);
+}
+
+void Interpreter::visitServeStmt(const ServeStmt &stmt)
+{
+    httpRuntime.serve();
+}

--- a/src/jesus/interpreter/interpreter.hpp
+++ b/src/jesus/interpreter/interpreter.hpp
@@ -4,6 +4,7 @@
 #include "expr_visitor.hpp"
 #include "stmt_visitor.hpp"
 #include "runtime/module.hpp"
+#include "runtime/http/http_runtime.hpp"
 #include "../ast/expr/expr.hpp"
 #include "../ast/expr/binary_expr.hpp"
 #include "../ast/expr/conditional_expr.hpp"
@@ -51,7 +52,7 @@ REGISTER_FOR_UML(
 class Interpreter : public ExprVisitor, public StmtVisitor
 {
 public:
-    explicit Interpreter(std::shared_ptr<Module> module) : currentModule(module) {}
+    explicit Interpreter(std::shared_ptr<Module> module) : currentModule(module), httpRuntime(*this) {}
     /**
      * @brief Evaluates a given expression and returns its computed value.
      *
@@ -173,6 +174,7 @@ private:
      */
     std::shared_ptr<Module> currentModule;
     static std::unordered_map<std::string, std::shared_ptr<Module>> modules;
+    HttpRuntime httpRuntime;
 
     // 🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️
     // 🟢️ Visit expression methods 🟢️
@@ -371,4 +373,7 @@ private:
 
     void visitAstInspectStmt(const AstInspectStmt &stmt);
     void visitMemoryInspectStmt(const MemoryInspectStmt &stmt);
+
+    void visitOnStmt(const OnStmt &stmt);
+    void visitServeStmt(const ServeStmt &stmt);
 };

--- a/src/jesus/interpreter/runtime/http/http_route.hpp
+++ b/src/jesus/interpreter/runtime/http/http_route.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <memory>
+
+class Stmt;
+
+struct HttpRoute
+{
+    std::string protocol; // protocol: GET/POST
+    std::string path;
+    std::vector<std::shared_ptr<Stmt>> body;
+};

--- a/src/jesus/interpreter/runtime/http/http_runtime.cpp
+++ b/src/jesus/interpreter/runtime/http/http_runtime.cpp
@@ -1,0 +1,73 @@
+#include "http_runtime.hpp"
+#include "interpreter/interpreter.hpp"
+#include "builtins/net/protocols/http/http_server.hpp"
+#include "spirit/return_signal.hpp"
+
+void HttpRuntime::addRoute(const HttpRoute &route)
+{
+    routes.push_back(std::move(route));
+}
+
+void HttpRuntime::serve()
+{
+    auto server = std::make_shared<HttpServer>();
+
+    for (const auto &route : routes)
+    {
+        std::string key = "GET " + route.path;
+
+        server->route(key, [this](const HttpRequest &req)
+                      {
+            HttpResponse res;
+
+            res.body = handleRequest(req.path);
+
+            res.headers["Content-Type"] = "text/plain";
+            return res; });
+    }
+
+    int port = 7000;
+    server->listen("0.0.0.0", port);
+
+    std::cout << "🧠 HttpServer listening on " << port << "...\n";
+    server->run();
+}
+
+HttpRoute *HttpRuntime::findRoute(const std::string &path)
+{
+    for (auto &route : routes)
+    {
+        if (route.path == path)
+            return &route;
+    }
+
+    std::cerr << "ZERO routes registered.!!!\n";
+
+    return nullptr;
+}
+
+std::string HttpRuntime::handleRequest(const std::string &path)
+{
+    auto *route = findRoute(path);
+
+    if (!route)
+    {
+        std::cerr << "404 Not Found: " << path << std::endl;
+        return "404 - Not Found";
+    }
+
+    std::cout << "Handling route: " << path << std::endl;
+
+    try
+    {
+        for (auto stmt : route->body)
+        {
+            interpreter.execute(stmt);
+        }
+        return "";
+    }
+    catch (const ReturnSignal &ret)
+    {
+        return ret.value.toString();
+    }
+}

--- a/src/jesus/interpreter/runtime/http/http_runtime.hpp
+++ b/src/jesus/interpreter/runtime/http/http_runtime.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include <vector>
+#include "http_route.hpp"
+
+class Interpreter;
+
+class HttpRuntime
+{
+
+public:
+    explicit HttpRuntime(Interpreter &interpreter) : interpreter(interpreter) {}
+
+    void addRoute(const HttpRoute &route);
+    void serve();
+
+    HttpRoute *findRoute(const std::string &path);
+    std::string handleRequest(const std::string &path);
+
+private:
+    std::vector<HttpRoute> routes;
+    Interpreter &interpreter;
+};

--- a/src/jesus/interpreter/runtime/method.hpp
+++ b/src/jesus/interpreter/runtime/method.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <memory>
 #include "../../ast/stmt/stmt.hpp"
+#include "../../spirit/return_signal.hpp"
 #include "../../types/creation_type.hpp"
 #include "instance.hpp"
 
@@ -13,15 +14,6 @@ REGISTER_FOR_UML(
     Method,
     .packageName("interpreter.runtime")
         .fieldsList({"name", "params", "body", "returnType"}));
-
-class ReturnSignal
-{
-public:
-    Value value;
-
-public:
-    ReturnSignal(Value value) : value(std::move(value)) {}
-};
 
 class Method
 {

--- a/src/jesus/interpreter/stmt_visitor.hpp
+++ b/src/jesus/interpreter/stmt_visitor.hpp
@@ -20,6 +20,8 @@
 #include "../ast/stmt/import_module_stmt.hpp"
 #include "../ast/stmt/ast_inspect_stmt.hpp"
 #include "../ast/stmt/memory_inspect_stmt.hpp"
+#include "../ast/stmt/on_stmt.hpp"
+#include "../ast/stmt/serve_stmt.hpp"
 
 REGISTER_FOR_UML(
     StmtVisitor,
@@ -89,6 +91,8 @@ public:
     virtual void visitImportModuleStmt(const ImportModuleStmt &stmt) = 0;
     virtual void visitAstInspectStmt(const AstInspectStmt &stmt) = 0;
     virtual void visitMemoryInspectStmt(const MemoryInspectStmt &stmt) = 0;
+    virtual void visitOnStmt(const OnStmt &stmt) = 0;
+    virtual void visitServeStmt(const ServeStmt &stmt) = 0;
 
     virtual ~StmtVisitor() = default;
 };

--- a/src/jesus/lexer/keywords.hpp
+++ b/src/jesus/lexer/keywords.hpp
@@ -134,6 +134,9 @@ namespace Keywords
         {"giants", TokenType::GIANTS},
         {"confess", TokenType::CONFESS},
         {"bible", TokenType::BIBLE},
+
+        {"on", TokenType::ON},
+        {"serve", TokenType::SERVE},
     };
 
     inline bool isReserved(const std::string &word)

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -106,5 +106,9 @@ enum class TokenType
     CONFESS,        // confess  (how to confess Jesus Christ as Lord)
     GIANTS,         // giants   (defeat sin, giants, AI)
     BIBLE,          // bible 'john 3:16'
+
+    ON,             // on http '/status': ... amen
+    SERVE,          // serve    (builtin http server)
+
     END_OF_FILE
 };

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -41,6 +41,8 @@
 #include "stmt/import_module_stmt_rule.hpp"
 #include "stmt/ast_inspect_stmt_rule.hpp"
 #include "stmt/memory_inspect_stmt_rule.hpp"
+#include "stmt/on_stmt_rule.hpp"
+#include "stmt/serve_stmt_rule.hpp"
 #include "unary_rule.hpp"
 
 /**
@@ -111,6 +113,8 @@ namespace grammar
     inline auto ImportModuleStmt = std::make_shared<ImportModuleStmtRule>();
     inline auto AstInspectStmt = std::make_shared<AstInspectStmtRule>();
     inline auto MemoryInspectStmt = std::make_shared<MemoryInspectStmtRule>();
+    inline auto OnStmt = std::make_shared<OnStmtRule>();
+    inline auto ServeStmt = std::make_shared<ServeStmtRule>();
 
     /**
      * @brief Set the Expression rule to something (for now just Primary)

--- a/src/jesus/parser/grammar/stmt/on_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/on_stmt_rule.cpp
@@ -1,0 +1,59 @@
+#include "on_stmt_rule.hpp"
+
+#include "ast/stmt/on_stmt.hpp"
+#include "ast/stmt/return_stmt.hpp"
+#include "parser/grammar/jesus_grammar.hpp"
+#include "parser/parser_context.hpp"
+
+std::unique_ptr<Stmt> OnStmtRule::parse(ParserContext &ctx)
+{
+    // expect: on
+    if (!ctx.match(TokenType::ON))
+        return nullptr;
+
+    // protocol: http
+    if (!ctx.match(TokenType::IDENTIFIER))
+        throw std::runtime_error("Expected protocol after 'on'");
+    std::string protocol = ctx.previous().lexeme;
+
+    // path: '/status'
+    if (!ctx.match(TokenType::RAW_STRING))
+        throw std::runtime_error("Expected route path");
+    std::string path = ctx.previous().literal.toString();
+
+    if (!ctx.match(TokenType::COLON))
+        throw std::runtime_error("Expected ':' after route definition");
+
+    // body
+    std::vector<std::shared_ptr<Stmt>> body;
+
+    ctx.consumeAllNewLines();
+    while (!ctx.check(TokenType::AMEN) && !ctx.isAtEnd())
+    {
+        if (ctx.match(TokenType::RETURN))
+        {
+            std::unique_ptr<Expr> returnExpr = nullptr;
+
+            if (!ctx.check(TokenType::NEWLINE) && !ctx.check(TokenType::AMEN))
+            {
+                // Parse the expression after 'return'
+                returnExpr = grammar::Expression->parse(ctx);
+            }
+
+            body.push_back(std::make_shared<ReturnStmt>(std::move(returnExpr)));
+        }
+        else
+        {
+            throw std::runtime_error("Unexpected statement inside route body.");
+        }
+        ctx.consumeAllNewLines();
+    }
+
+    if (!ctx.match(TokenType::AMEN))
+        throw std::runtime_error("Expected 'amen' to close route body.");
+
+    return std::make_unique<OnStmt>(
+        protocol,
+        path,
+        std::move(body));
+}

--- a/src/jesus/parser/grammar/stmt/on_stmt_rule.hpp
+++ b/src/jesus/parser/grammar/stmt/on_stmt_rule.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include "../grammar_rule.hpp"
+#include "../../../ast/stmt/stmt.hpp"
+
+/**
+ * @brief Parser for 'on':
+
+    on http '/status':
+        return 1
+    amen
+ */
+class OnStmtRule
+{
+public:
+    std::unique_ptr<Stmt> parse(ParserContext &ctx);
+};

--- a/src/jesus/parser/grammar/stmt/serve_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/serve_stmt_rule.cpp
@@ -1,0 +1,11 @@
+#include "serve_stmt_rule.hpp"
+#include "../../../ast/stmt/serve_stmt.hpp"
+#include "../../parser_context.hpp"
+
+std::unique_ptr<Stmt> ServeStmtRule::parse(ParserContext &ctx)
+{
+    if (!ctx.match(TokenType::SERVE))
+        return nullptr;
+
+    return std::make_unique<ServeStmt>();
+}

--- a/src/jesus/parser/grammar/stmt/serve_stmt_rule.hpp
+++ b/src/jesus/parser/grammar/stmt/serve_stmt_rule.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include "../grammar_rule.hpp"
+#include "../../parser_context.hpp"
+#include "../../../ast/stmt/stmt.hpp"
+
+/**
+ * @brief Parser for 'serve', that runs an Http Server.
+ */
+class ServeStmtRule
+{
+public:
+    std::unique_ptr<Stmt> parse(ParserContext &ctx);
+};

--- a/src/jesus/parser/parser.cpp
+++ b/src/jesus/parser/parser.cpp
@@ -76,6 +76,16 @@ std::unique_ptr<Stmt> parse(const std::vector<Token> &tokens, ParserContext &con
     if (memoryInspectStmt)
         return memoryInspectStmt;
 
+    context.restore(snapshot);
+    auto onStmt = grammar::OnStmt->parse(context);
+    if (onStmt)
+        return onStmt;
+
+    context.restore(snapshot);
+    auto serveStmt = grammar::ServeStmt->parse(context);
+    if (serveStmt)
+        return serveStmt;
+
     // If no match, fall back to expression parsing
     context.restore(snapshot);
     auto expr = grammar::Expression->parse(context);

--- a/src/jesus/spirit/return_signal.hpp
+++ b/src/jesus/spirit/return_signal.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include "value.hpp"
+
+/**
+ * @brief Returned when we have 'return' inside a function.
+ */
+class ReturnSignal
+{
+public:
+    Value value;
+
+public:
+    ReturnSignal(Value value) : value(std::move(value)) {}
+};


### PR DESCRIPTION
# Description

This PR introduces the HTTP Server runtime, built on top of PR #57.

Users can now declare HTTP handlers using the `on` statement and activate them using `serve`, which starts the underlying HTTP runtime and listens for incoming requests.

This establishes a clear separation between:

- **Declaration phase** → defining behavior (`on`)
- **Execution phase** → activating the runtime (`serve`)

## New Syntax and Behavior

Imagine a file named `urls.jesus` with the following content:

```jesus
on http '/status':
    return 1
amen

serve
````

When parsing:

* `on http '/path'` registers a route handler
* The handler body is stored and executed when a request matches the route
* `serve` initializes the HTTP server and starts listening (blocking loop)
* When a request is received:

  * The matching handler is executed
  * `return` inside the handler is captured and converted into the HTTP response

Example:

```bash
$ curl localhost:7000/status

# or using httpie

$ http localhost:7000/status
HTTP/1.1 200 OK
Content-Type: text/plain

(int) 1
```

---

## 📁 Changes

* AST:

  * `OnStmt`
  * `ServeStmt`
* Parser:

  * `OnStmtRule`
  * `ServeStmtRule`
 
* Interpreter:
  * Added runtime integration
  * New visit methods for event declaration and serving
 
* Runtime:
  * Introduced `HttpRuntime` and `HttpRoute`
 
* Builtins:
  * Reused existing `HttpServer`

## Motivation

This is the first step toward a unified event-driven model, where different protocols (HTTP, TCP, WebSocket, etc.) can be expressed through the same `on` abstraction.

# ✝️ Wisdom

> "The Word became flesh and made his dwelling among us." — **_John 1:14_**

The declared logic (`on`) is now made active through `serve`, becoming a living system that responds to the world.

