### PR TITLE
Step 74: feat(http): Added default homepage, content-type parsing, and standard response headers for 'serve' command. Ref #73.

### DIFF
--- a/src/jesus/ast/stmt/on_stmt.hpp
+++ b/src/jesus/ast/stmt/on_stmt.hpp
@@ -5,6 +5,8 @@
 #include <vector>
 #include <memory>
 
+class Expr;
+
 /**
  * @brief Represents an event handler declaration in the Jesus language.
  *
@@ -31,13 +33,16 @@ class OnStmt : public Stmt
 public:
     std::string protocol;                    // "http"
     std::string path;                        // "/status"
+    std::unique_ptr<Expr> returnTypeExpr;    // 'text/html', json, varname
     std::vector<std::shared_ptr<Stmt>> body; // return {status: true}
 
     OnStmt(std::string protocol,
            std::string path,
+           std::unique_ptr<Expr> returnTypeExpr,
            std::vector<std::shared_ptr<Stmt>> body)
         : protocol(std::move(protocol)),
           path(std::move(path)),
+          returnTypeExpr(std::move(returnTypeExpr)),
           body(std::move(body)) {}
 
     void accept(StmtVisitor &visitor) const override;

--- a/src/jesus/builtins/net/protocols/http/http_message.hpp
+++ b/src/jesus/builtins/net/protocols/http/http_message.hpp
@@ -19,7 +19,7 @@ struct HttpResponse
     std::unordered_map<std::string, std::string> headers{
         // Default headers
         {"Server", "SonOfMan (Jesus)"},
-        {"Content-Type", "text/html"},
+        {"Content-Type", "text/html; charset=utf-8"},
     };
     std::string body;
 

--- a/src/jesus/builtins/net/protocols/http/http_message.hpp
+++ b/src/jesus/builtins/net/protocols/http/http_message.hpp
@@ -16,7 +16,11 @@ struct HttpResponse
 {
     int status = 200;
     std::string reason = "OK";
-    std::unordered_map<std::string, std::string> headers;
+    std::unordered_map<std::string, std::string> headers{
+        // Default headers
+        {"Server", "SonOfMan (Jesus)"},
+        {"Content-Type", "text/html"},
+    };
     std::string body;
 
     std::string to_string() const

--- a/src/jesus/builtins/net/protocols/http/http_server.hpp
+++ b/src/jesus/builtins/net/protocols/http/http_server.hpp
@@ -5,6 +5,7 @@
 #include <functional>
 #include <unordered_map>
 #include <iostream>
+#include <chrono>
 #include <memory>
 
 /**
@@ -90,6 +91,49 @@ public:
         routes[method_path] = handler;
     }
 
+    /**
+     * @brief Generate RFC 9110 compliant Date header
+     * @return std::ostringstream
+     */
+    inline std::string format_rfc_9110(std::chrono::system_clock::time_point &response_end_time)
+    {
+        std::time_t t = std::chrono::system_clock::to_time_t(response_end_time);
+
+        std::tm gmt{};
+        #ifdef _WIN32
+            gmtime_s(&gmt, &t); // Windows
+        #else
+            gmtime_r(&t, &gmt); // POSIX
+        #endif
+
+        std::ostringstream date_stream;
+        date_stream << std::put_time(&gmt, "%a, %d %b %Y %H:%M:%S GMT");
+        return date_stream.str();
+    }
+
+    inline std::string responseTime(int64_t &duration)
+    {
+        int64_t us = duration;
+        std::string responseTime;
+
+        if (us < 1000)
+        {
+            responseTime = std::to_string(us) + "us";
+        }
+        else if (us < 1'000'000)
+        {
+            responseTime = std::to_string(us / 1000) + "ms";
+        }
+        else
+        {
+            double s = us / 1'000'000.0;
+            std::ostringstream oss;
+            oss << std::fixed << std::setprecision(2) << s << "s";
+            responseTime = oss.str();
+        }
+        return responseTime;
+    }
+
 protected:
     void handle_event(int fd) override
     {
@@ -118,6 +162,7 @@ protected:
         // Parse HTTP request
         // ------------------
         HttpRequest req = parse_request(data);
+        auto start = std::chrono::high_resolution_clock::now();
 
         // ------------
         // Find handler
@@ -132,6 +177,11 @@ protected:
             res.reason = "Not Found";
             res.body = "404 - Not Found";
         }
+
+        auto end = std::chrono::high_resolution_clock::now();
+        auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+        res.headers["X-Response-Time"] = responseTime(duration);
+        res.headers["Date"] = format_rfc_9110(end);
 
         // -------------
         // Send response

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -810,6 +810,12 @@ void Interpreter::visitOnStmt(const OnStmt &stmt)
     route.path = stmt.path;
     route.body = stmt.body;
 
+    if (stmt.returnTypeExpr)
+    {
+        auto value = evaluate(stmt.returnTypeExpr);
+        route.contentType = value.toString();
+    }
+
     httpRuntime.addRoute(route);
 }
 

--- a/src/jesus/interpreter/runtime/http/http_route.hpp
+++ b/src/jesus/interpreter/runtime/http/http_route.hpp
@@ -10,6 +10,6 @@ struct HttpRoute
 {
     std::string protocol; // protocol: GET/POST
     std::string path;
-    std::string contentType = "text/html";
+    std::string contentType = "text/html; charset=utf-8";
     std::vector<std::shared_ptr<Stmt>> body;
 };

--- a/src/jesus/interpreter/runtime/http/http_route.hpp
+++ b/src/jesus/interpreter/runtime/http/http_route.hpp
@@ -10,5 +10,6 @@ struct HttpRoute
 {
     std::string protocol; // protocol: GET/POST
     std::string path;
+    std::string contentType = "text/html";
     std::vector<std::shared_ptr<Stmt>> body;
 };

--- a/src/jesus/interpreter/runtime/http/http_runtime.cpp
+++ b/src/jesus/interpreter/runtime/http/http_runtime.cpp
@@ -11,10 +11,12 @@ void HttpRuntime::addRoute(const HttpRoute &route)
 void HttpRuntime::serve()
 {
     auto server = std::make_shared<HttpServer>();
+    bool hasRoot = false;
 
     for (const auto &route : routes)
     {
         std::string key = "GET " + route.path;
+        hasRoot = hasRoot || route.path == "/";
 
         server->route(key, [this, route](const HttpRequest &req) {
             HttpResponse res;
@@ -37,9 +39,223 @@ void HttpRuntime::serve()
         });
     }
 
+    if (!hasRoot)
+    {
+        server->route("GET /", [this](const HttpRequest &req)
+        {
+            HttpResponse res;
+            res.body = defaultHomepage();
+            return res;
+        });
+    }
+
     int port = 7000;
     server->listen("0.0.0.0", port);
 
     std::cout << "🧠 HttpServer listening on " << port << "...\n";
     server->run();
+}
+
+std::string HttpRuntime::defaultHomepage()
+{
+    std::string home = R"(
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>SonOfMan - Jesus Programming Language</title>
+
+<style>
+  body {
+    margin: 0;
+    font-family: system-ui, sans-serif;
+    background: #0f172a;
+    color: #e2e8f0;
+  }
+  .container {
+    max-width: 1200px;
+    margin: auto;
+    padding: 1.5rem;
+  }
+  header {
+    margin-bottom: 2rem;
+  }
+  h1 {
+    margin: 0;
+  }
+  .muted {
+    opacity: 0.8;
+    font-style: italic;
+    padding-left: 12px;
+  }
+  /* GRID */
+  .grid {
+    display: grid;
+    gap: 1.5rem;
+  }
+  /* Mobile first: 1 column */
+  .grid {
+    grid-template-columns: 1fr;
+  }
+  /* Desktop: 2 columns */
+  @media (min-width: 768px) {
+    .grid {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+  .card {
+    background: #111827;
+    padding: 1.2rem;
+    border-radius: 12px;
+    box-shadow: 0 5px 20px rgba(0,0,0,0.4);
+  }
+  .code-block {
+    position: relative;
+  }
+  .copy-btn {
+        position: absolute;
+        top: 8px;
+        right: 8px;
+        background: #1f2937;
+        color: #e2e8f0;
+        border: none;
+        padding: 0.3rem 0.6rem;
+        font-size: 0.75rem;
+        border-radius: 6px;
+        cursor: pointer;
+        opacity: 0.7;
+        transition: 0.2s;
+  }
+  .copy-btn:hover {
+    opacity: 1;
+    background: #374151;
+  }
+  .copy-btn.copied {
+    background: #16a34a;
+    color: white;
+  }
+  .copy-btn {
+    opacity: 0;
+  }
+  .code-block:hover .copy-btn {
+    opacity: 1;
+  }
+  code {
+    display: block;
+    background: #020617;
+    padding: 0.8rem;
+    border-radius: 8px;
+    margin-top: 0.5rem;
+    color: #38bdf8;
+    white-space: pre;
+    overflow-x: auto;
+  }
+
+  .full {
+    grid-column: 1 / -1;
+  }
+</style>
+</head>
+<body>
+<div class="container">
+  <!-- HEADER -->
+  <header>
+    <h1>🧠 Jesus Programming Language</h1>
+    <p><strong>SonOfMan HTTP Server</strong></p>
+
+    <p class="muted">
+      "For even the Son of Man did not come to be served, but to serve..." <b>— Mark 10:45</b>
+    </p>
+</header>
+<h3>Define routes in different ways:</h3>
+  <!-- GRID CONTENT -->
+  <div class="grid">
+
+    <!-- DEFAULT -->
+    <div class="card">
+      <h3>Default (HTML)</h3>
+      <div class="code-block">
+        <button class="copy-btn">Copy</button>
+        <code>on http '/savior':
+    return '&lt;h1&gt;Jesus&lt;/h1&gt;&lt;p&gt;Christ&lt;/p&gt;'
+amen
+</code>
+      </div>
+    </div>
+
+    <!-- JSON -->
+    <div class="card">
+      <h3>JSON</h3>
+       <div class="code-block">
+        <button class="copy-btn">Copy</button>
+      <code>on http '/api' -> json:
+    return '{"name": "Jesus"}'
+amen
+</code>
+      </div>
+    </div>
+
+    <!-- VARIABLE -->
+    <div class="card">
+      <h3>Custom (Variable)</h3>
+       <div class="code-block">
+        <button class="copy-btn">Copy</button>
+      <code>create text pdf = 'application/pdf'
+
+on http '/file' -> pdf:
+    return 'A PDF file'
+amen
+</code>
+       </div>
+    </div>
+
+    <!-- RAW -->
+    <div class="card">
+      <h3>Explicit MIME</h3>
+       <div class="code-block">
+        <button class="copy-btn">Copy</button>
+      <code>on http '/plain' -> 'text/plain':
+    return 'Jesus Christ is the only way'
+amen
+</code>
+       </div>
+    </div>
+
+    <!-- FOOTER -->
+    <div class="card full">
+      <p>
+        To override this page, define a route for  '<i>/</i>'
+      </p>
+       <div class="code-block">
+        <button class="copy-btn">Copy</button>
+       <code>on http '/':
+    return '&lt;h1&gt;Hello, Jesus&lt;/h1&gt;'
+amen
+</code>
+       </div>
+    </div>
+  </div>
+</div>
+<script>
+  document.querySelectorAll('.copy-btn').forEach(button => {
+    button.addEventListener('click', () => {
+      const code = button.nextElementSibling.innerText;
+
+      navigator.clipboard.writeText(code).then(() => {
+        button.textContent = "Copied!";
+        button.classList.add("copied");
+
+        setTimeout(() => {
+          button.textContent = "Copy";
+          button.classList.remove("copied");
+        }, 1500);
+      });
+    });
+  });
+</script>
+</body>
+</html>
+)";
+
+    return home;
 }

--- a/src/jesus/interpreter/runtime/http/http_runtime.cpp
+++ b/src/jesus/interpreter/runtime/http/http_runtime.cpp
@@ -16,14 +16,25 @@ void HttpRuntime::serve()
     {
         std::string key = "GET " + route.path;
 
-        server->route(key, [this](const HttpRequest &req)
-                      {
+        server->route(key, [this, route](const HttpRequest &req) {
             HttpResponse res;
 
-            res.body = handleRequest(req.path);
+            try
+            {
+                for (auto stmt : route.body)
+                    interpreter.execute(stmt);
 
-            res.headers["Content-Type"] = "text/plain";
-            return res; });
+                res.body = "";
+            }
+            catch (const ReturnSignal &ret)
+            {
+                res.body = ret.value.toString();
+            }
+
+            res.headers["Content-Type"] = route.contentType;
+
+            return res;
+        });
     }
 
     int port = 7000;
@@ -31,43 +42,4 @@ void HttpRuntime::serve()
 
     std::cout << "🧠 HttpServer listening on " << port << "...\n";
     server->run();
-}
-
-HttpRoute *HttpRuntime::findRoute(const std::string &path)
-{
-    for (auto &route : routes)
-    {
-        if (route.path == path)
-            return &route;
-    }
-
-    std::cerr << "ZERO routes registered.!!!\n";
-
-    return nullptr;
-}
-
-std::string HttpRuntime::handleRequest(const std::string &path)
-{
-    auto *route = findRoute(path);
-
-    if (!route)
-    {
-        std::cerr << "404 Not Found: " << path << std::endl;
-        return "404 - Not Found";
-    }
-
-    std::cout << "Handling route: " << path << std::endl;
-
-    try
-    {
-        for (auto stmt : route->body)
-        {
-            interpreter.execute(stmt);
-        }
-        return "";
-    }
-    catch (const ReturnSignal &ret)
-    {
-        return ret.value.toString();
-    }
 }

--- a/src/jesus/interpreter/runtime/http/http_runtime.hpp
+++ b/src/jesus/interpreter/runtime/http/http_runtime.hpp
@@ -13,9 +13,6 @@ public:
     void addRoute(const HttpRoute &route);
     void serve();
 
-    HttpRoute *findRoute(const std::string &path);
-    std::string handleRequest(const std::string &path);
-
 private:
     std::vector<HttpRoute> routes;
     Interpreter &interpreter;

--- a/src/jesus/interpreter/runtime/http/http_runtime.hpp
+++ b/src/jesus/interpreter/runtime/http/http_runtime.hpp
@@ -16,4 +16,6 @@ public:
 private:
     std::vector<HttpRoute> routes;
     Interpreter &interpreter;
+
+    std::string defaultHomepage();
 };

--- a/src/jesus/lexer/keywords.hpp
+++ b/src/jesus/lexer/keywords.hpp
@@ -137,6 +137,7 @@ namespace Keywords
 
         {"on", TokenType::ON},
         {"serve", TokenType::SERVE},
+        {"json", TokenType::JSON},
     };
 
     inline bool isReserved(const std::string &word)

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -109,6 +109,7 @@ enum class TokenType
 
     ON,             // on http '/status': ... amen
     SERVE,          // serve    (builtin http server)
+    JSON,           // on http '/api' -> json: amen
 
     END_OF_FILE
 };

--- a/src/jesus/parser/grammar/stmt/on_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/on_stmt_rule.cpp
@@ -1,9 +1,12 @@
 #include "on_stmt_rule.hpp"
 
+#include "ast/expr/literal_expr.hpp"
 #include "ast/stmt/on_stmt.hpp"
 #include "ast/stmt/return_stmt.hpp"
+#include "ast/stmt/incomplete_block_stmt.hpp"
 #include "parser/grammar/jesus_grammar.hpp"
 #include "parser/parser_context.hpp"
+#include "types/known_types.hpp"
 
 std::unique_ptr<Stmt> OnStmtRule::parse(ParserContext &ctx)
 {
@@ -20,6 +23,21 @@ std::unique_ptr<Stmt> OnStmtRule::parse(ParserContext &ctx)
     if (!ctx.match(TokenType::RAW_STRING))
         throw std::runtime_error("Expected route path");
     std::string path = ctx.previous().literal.toString();
+    std::unique_ptr<Expr> returnTypeExpr = nullptr;
+
+    if (ctx.match(TokenType::ARROW))
+    {
+        if (ctx.match(TokenType::JSON))
+        {
+            returnTypeExpr = std::make_unique<LiteralExpr>(Value("application/json; charset=utf-8"), KnownTypes::STRING);
+        }
+        else
+        {
+            returnTypeExpr = grammar::Expression->parse(ctx);
+            if (!returnTypeExpr)
+                throw std::runtime_error("Expected content type after '->'");
+        }
+    }
 
     if (!ctx.match(TokenType::COLON))
         throw std::runtime_error("Expected ':' after route definition");
@@ -49,11 +67,15 @@ std::unique_ptr<Stmt> OnStmtRule::parse(ParserContext &ctx)
         ctx.consumeAllNewLines();
     }
 
+    if (ctx.isAtEnd())
+        return std::make_unique<IncompleteBlockStmt>();
+
     if (!ctx.match(TokenType::AMEN))
         throw std::runtime_error("Expected 'amen' to close route body.");
 
     return std::make_unique<OnStmt>(
         protocol,
         path,
+        std::move(returnTypeExpr),
         std::move(body));
 }

--- a/src/jesus/tests/repl/040-many-tests.jesus
+++ b/src/jesus/tests/repl/040-many-tests.jesus
@@ -441,3 +441,17 @@ create text verse = bible '1thessalonians 5:16'
 say "In Christ we must: {verse}"
 create text luke1732 = "luke 17:32"
 bible luke1732
+
+on http '/savior':
+    return '<h1>Jesus</h1><p>Christ</p>'
+amen
+on http '/api' -> json :
+    return '{"nome": "Jesus", "surname": "Christ"}'
+amen
+create text pdf = 'application/pdf'
+on http '/pdf' -> pdf:
+    return 'A PDF file'
+amen
+on http '/plain' -> 'text/plain':
+    return 'Jesus Christ is the only way to heavens'
+amen

--- a/src/jesus/tests/repl/040-many-tests.jesus.expected
+++ b/src/jesus/tests/repl/040-many-tests.jesus.expected
@@ -332,4 +332,4 @@ Exodus 20:13 — You shall not murder. 1 Corinthians 3:17 — If anyone destroys
 
 (Jesus) (Jesus) Remember Lot's wife!
 
-(Jesus) 
+(Jesus) (Jesus) (Jesus) (Jesus) (Jesus) (Jesus) (Jesus) 


### PR DESCRIPTION
# Description

This PR improves the HTTP experience of the Jesus Programming Language by introducing:

- A default homepage for the `serve` statement
- Content-type declaration for routes
- Standard HTTP response headers

Together, these changes make the server more expressive, user-friendly, and aligned with real-world web frameworks.

## Features

### 1. Default Homepage (**_SonOfMan Server_**)

When:
- no routes are defined, or
- no route matches `/`

The server now responds with a built-in HTML page that:

- Confirms the server is running
- Introduces the SonOfMan server
- Shows practical route examples
- Guides users to define their first route

Users can override this by defining:

```jesus
on http '/':
    return '<h1>Hello</h1>'
amen
````

<img width="810" height="783" alt="default-home" src="https://github.com/user-attachments/assets/77b2e9e3-6e17-4bdb-ab51-34859f6c6d67" />

### 2. Content-Type Declaration in Routes

Routes now support multiple ways to define response types:

#### Default (HTML)

```jesus
on http '/home':
    return '<h1>Jesus</h1><p>Christ</p>'
amen
```

#### JSON shortcut

```jesus
on http '/api' -> json:
    return '{"name": "Jesus"}'
amen
```

The `-> json` sets the `content-type` header to `application/json; charset=utf-8`

#### Custom via variable

```jesus
create text pdf = 'application/pdf'

on http '/file' -> pdf:
    return 'A PDF file'
amen
```

#### Explicit MIME type

```jesus
on http '/plain' -> 'text/plain':
    return 'Jesus Christ is the only way to heaven.'
amen
```

### 3. Default HTTP Response Headers

All responses now include:

* `Server`
* `Date`
* `Content-Type`
* `X-Response-Time`

This provides better observability and aligns responses with HTTP standards.

## Impact

* Improves first-time user experience (no more empty 404 on startup)
* Makes routes more expressive and flexible
* Brings the runtime closer to production-grade HTTP behavior
* Establishes a foundation for future features (e.g. middleware, proxies)

# ✝️ Wisdom

> "For even the **Son of Man** came not to be served, but to serve..."  — **Mark 10:45**
