### PR TITLE
Step 75: feat(http): Introduced dynamic port binding and unified HTTP error handling (serve on 8080). Ref #74.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,7 @@ set(JESUS_CPP_FILES
     # Builtins
     # --------
     src/jesus/builtins/io/socket/tcpv4_socket.cpp
+    src/jesus/builtins/net/protocols/http/http_server.cpp
 )
 
 # --------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ set(JESUS_CPP_FILES
 
     src/jesus/lexer/lexer.cpp
     src/jesus/utils/terminal/terminal.cpp
+    src/jesus/utils/string_utils.cpp
     src/jesus/spirit/value.cpp
     src/jesus/spirit/heart.cpp
     src/jesus/spirit/spirit_of_understanding.cpp  # Semantics Analyzer

--- a/src/jesus/ast/stmt/serve_stmt.hpp
+++ b/src/jesus/ast/stmt/serve_stmt.hpp
@@ -1,11 +1,26 @@
 #pragma once
 #include "stmt.hpp"
 
+class Expr;
+
 /**
  * @brief Start an HttpServer
+ *
+ * Usage:
+ *  serve
+ *
+ *  serve on 80
+ *
+ *  create number port = 8080
+ *  serve on port
  */
 class ServeStmt : public Stmt
 {
 public:
+    std::unique_ptr<Expr> portExpr; // default: 7000
+
+    ServeStmt(std::unique_ptr<Expr> portExpr)
+        : portExpr(std::move(portExpr)) {}
+
     void accept(StmtVisitor &visitor) const override;
 };

--- a/src/jesus/builtins/net/protocols/http/http_message.hpp
+++ b/src/jesus/builtins/net/protocols/http/http_message.hpp
@@ -36,3 +36,13 @@ struct HttpResponse
         return oss.str();
     }
 };
+
+struct HttpError
+{
+    int code;
+    std::string title;
+    std::string message;
+    std::string hint;
+    std::string actionText;
+    std::string actionLink;
+};

--- a/src/jesus/builtins/net/protocols/http/http_server.cpp
+++ b/src/jesus/builtins/net/protocols/http/http_server.cpp
@@ -1,0 +1,149 @@
+#include <format>
+#include "http_server.hpp"
+
+bool HttpServer::wantsJson(const HttpRequest& req)
+{
+    auto it = req.headers.find("Accept");
+    if (it == req.headers.end()) return false;
+
+    return it->second.find("application/json") != std::string::npos;
+}
+
+std::string HttpServer::renderJsonError(const HttpError& err)
+{
+    std::ostringstream oss;
+
+    oss << "{"
+        << "\"code\":" << err.code << ","
+        << "\"title\":\"" << err.title << "\","
+        << "\"message\":\"" << err.message << "\","
+        << "\"hint\":\"" << err.hint << "\","
+        << "\"actionText\":\"" << err.actionText << "\","
+        << "\"actionLink\":\"" << err.actionLink << "\""
+        << "}";
+
+    return oss.str();
+}
+
+void HttpServer::renderErrorPage(int code, const HttpRequest& req, HttpResponse &res)
+{
+
+    HttpError httpError = getHttpError(code);
+    res.status = httpError.code;
+    res.reason = httpError.title;
+
+    if (wantsJson(req))
+    {
+        res.headers["Content-Type"] = "application/json; charset=utf-8";
+        res.body = renderJsonError(httpError);
+    }
+    else
+    {
+        res.headers["Content-Type"] = "text/html; charset=utf-8";
+        res.body = renderErrorTemplate(httpError);
+    }
+
+}
+
+inline HttpError HttpServer::getHttpError(int code)
+{
+    switch (code)
+    {
+    case 400:
+        return {400, "Bad Request",
+                "The request could not be understood.",
+                "Check the request format or parameters.",
+                "Go back home", "/"};
+
+    case 403:
+        return {403, "Forbidden",
+                "You do not have permission to access this resource.",
+                "This resource may require authentication.",
+                "Go to homepage", "/"};
+
+    case 404:
+        return {404, "Not Found",
+                "The page does not exist.",
+                "It may have been moved or deleted.",
+                "Go to homepage", "/"};
+
+    case 405:
+        return {405, "Method Not Allowed",
+                "This HTTP method is not supported here.",
+                "Try using GET or POST instead.",
+                "Go to homepage", "/"};
+
+    case 408:
+        return {408, "Request Timeout",
+                "The server took too long to respond.",
+                "Try again later.",
+                "Go to homepage", "/"};
+
+    case 413:
+        return {413, "Payload Too Large",
+                "The request is too large to process.",
+                "Reduce the size of your request body.",
+                "Go to homepage", "/"};
+
+    case 429:
+        return {429, "Too Many Requests",
+                "You are sending requests too quickly.",
+                "Please slow down.",
+                "Go to homepage", "/"};
+
+    case 500:
+    default:
+        return {500, "Internal Server Error",
+                "Something went wrong while processing your request.",
+                "The server encountered an unexpected condition.",
+                "Go to homepage", "/"};
+    }
+}
+
+std::string HttpServer::renderErrorTemplate(HttpError &error)
+{
+    return std::format(R"(
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{0} - SonOfMan</title>
+  <style>
+    body {{
+      font-family: system-ui;
+      background: #0f172a;
+      color: #e2e8f0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      margin: 0;
+    }}
+    .box {{
+      text-align: center;
+      max-width: 600px;
+    }}
+    h1 {{
+      font-size: 3rem;
+      margin-bottom: 0;
+    }}
+    p {{
+      opacity: 0.85;
+    }}
+    a {{
+      color: #38bdf8;
+      text-decoration: none;
+    }}
+  </style>
+</head>
+<body>
+  <div class="box">
+    <h1>{0}</h1>
+    <p><strong>{1}</strong></p>
+    <p>{2}</p>
+    <p style="margin-top:1rem; opacity:0.7">{3}</p>
+    <p><a href="{5}">{4}</a></p>
+  </div>
+</body>
+</html>
+)", error.code, error.title, error.message, error.hint, error.actionText, error.actionLink);
+}

--- a/src/jesus/builtins/net/protocols/http/http_server.hpp
+++ b/src/jesus/builtins/net/protocols/http/http_server.hpp
@@ -173,9 +173,8 @@ protected:
             res = routes[key](req);
         else
         {
-            res.status = 404;
-            res.reason = "Not Found";
-            res.body = "404 - Not Found";
+            int code = 404;
+            renderErrorPage(code, req, res);
         }
 
         auto end = std::chrono::high_resolution_clock::now();
@@ -195,6 +194,12 @@ protected:
         unregister_fd(fd);
         ::close(fd);
     }
+
+    inline HttpError getHttpError(int code);
+    bool wantsJson(const HttpRequest& req);
+    std::string renderJsonError(const HttpError& err);
+    std::string renderErrorTemplate(HttpError &);
+    void renderErrorPage(int code, const HttpRequest& req, HttpResponse &res);
 
 private:
     std::string receive_from_fd(int fd)

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -821,5 +821,21 @@ void Interpreter::visitOnStmt(const OnStmt &stmt)
 
 void Interpreter::visitServeStmt(const ServeStmt &stmt)
 {
-    httpRuntime.serve();
+    int port = 7000;
+
+    if (stmt.portExpr)
+    {
+        Value value = evaluate(stmt.portExpr);
+        port = value.toInt();
+
+        // ----------------
+        // RANGE VALIDATION
+        // ----------------
+        if (port < 1 || port > 65535)
+        {
+            throw std::runtime_error("Port must be between 1 and 65535");
+        }
+    }
+
+    httpRuntime.serve(port);
 }

--- a/src/jesus/interpreter/runtime/http/http_runtime.cpp
+++ b/src/jesus/interpreter/runtime/http/http_runtime.cpp
@@ -8,7 +8,7 @@ void HttpRuntime::addRoute(const HttpRoute &route)
     routes.push_back(std::move(route));
 }
 
-void HttpRuntime::serve()
+void HttpRuntime::serve(int port)
 {
     auto server = std::make_shared<HttpServer>();
     bool hasRoot = false;
@@ -49,17 +49,25 @@ void HttpRuntime::serve()
         });
     }
 
-    int port = 7000;
     server->listen("0.0.0.0", port);
 
-    std::cout << "🧠 HttpServer listening on " << port << "...\n";
+    std::cout << "🧠 SonOfMan HTTP Server\n\n";
+    std::cout << "Local:\n";
+    std::cout << "  → http://127.0.0.1:" << port << "/\n";
+    std::cout << "  → http://localhost:" << port << "/\n\n";
+    std::cout << "Network:\n";
+    std::cout << "  → http://<your-ip>:" << port << "/\n\n";
+    std::cout << "Try:\n";
+    std::cout << "  curl http://localhost:"<< port << "/\n\n";
+
+    std::cout << "Press CTRL+C to stop.\n";
+
     server->run();
 }
 
 std::string HttpRuntime::defaultHomepage()
 {
-    std::string home = R"(
-<!DOCTYPE html>
+    std::string home = R"(<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">

--- a/src/jesus/interpreter/runtime/http/http_runtime.hpp
+++ b/src/jesus/interpreter/runtime/http/http_runtime.hpp
@@ -11,7 +11,7 @@ public:
     explicit HttpRuntime(Interpreter &interpreter) : interpreter(interpreter) {}
 
     void addRoute(const HttpRoute &route);
-    void serve();
+    void serve(int port);
 
 private:
     std::vector<HttpRoute> routes;

--- a/src/jesus/parser/grammar/stmt/serve_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/serve_stmt_rule.cpp
@@ -1,11 +1,30 @@
 #include "serve_stmt_rule.hpp"
-#include "../../../ast/stmt/serve_stmt.hpp"
-#include "../../parser_context.hpp"
+#include "ast/stmt/serve_stmt.hpp"
+#include "parser/parser_context.hpp"
+#include "parser/grammar/jesus_grammar.hpp"
+#include "types/known_types.hpp"
 
 std::unique_ptr<Stmt> ServeStmtRule::parse(ParserContext &ctx)
 {
     if (!ctx.match(TokenType::SERVE))
         return nullptr;
 
-    return std::make_unique<ServeStmt>();
+    std::unique_ptr<Expr> portExpr = nullptr;
+    if (ctx.match(TokenType::ON))
+    {
+        portExpr = grammar::Expression->parse(ctx);
+        if (!portExpr)
+            throw std::runtime_error("Expected port number after 'serve on'");
+
+        // -------------
+        // Type checking
+        // -------------
+        auto varType = portExpr->getReturnType(ctx);
+        if (!varType->isA(KnownTypes::INT))
+        {
+            throw std::runtime_error("Invalid port after 'serve on': expected number, got " + varType->name);
+        }
+    }
+
+    return std::make_unique<ServeStmt>(std::move(portExpr));
 }

--- a/src/jesus/tests/repl/040-many-tests.jesus
+++ b/src/jesus/tests/repl/040-many-tests.jesus
@@ -455,3 +455,5 @@ amen
 on http '/plain' -> 'text/plain':
     return 'Jesus Christ is the only way to heavens'
 amen
+
+serve on 123456

--- a/src/jesus/tests/repl/040-many-tests.jesus.expected
+++ b/src/jesus/tests/repl/040-many-tests.jesus.expected
@@ -332,4 +332,5 @@ Exodus 20:13 — You shall not murder. 1 Corinthians 3:17 — If anyone destroys
 
 (Jesus) (Jesus) Remember Lot's wife!
 
-(Jesus) (Jesus) (Jesus) (Jesus) (Jesus) (Jesus) (Jesus) 
+(Jesus) (Jesus) (Jesus) (Jesus) (Jesus) (Jesus) (Jesus) (Jesus) ❌ Error: Port must be between 1 and 65535
+(Jesus) 

--- a/src/jesus/utils/string_utils.cpp
+++ b/src/jesus/utils/string_utils.cpp
@@ -1,0 +1,17 @@
+#include "string_utils.hpp"
+
+namespace utils
+{
+    void replaceAll(std::string &text, const std::string &search, const std::string &replacement)
+    {
+        if (search.empty())
+            return;
+
+        size_t start = 0;
+        while ((start = text.find(search, start)) != std::string::npos)
+        {
+            text.replace(start, search.length(), replacement);
+            start += replacement.length();
+        }
+    }
+}

--- a/src/jesus/utils/string_utils.hpp
+++ b/src/jesus/utils/string_utils.hpp
@@ -100,4 +100,5 @@ namespace utils
         return (c.size() == 1 && c[0] >= '0' && c[0] <= '9');
     }
 
+    void replaceAll(std::string &text, const std::string &search, const std::string &replacement);
 }


### PR DESCRIPTION
# Description

This pull request enhances the HTTP runtime with two foundational improvements:

## 1. Flexible port binding in `serve`

The `serve` statement now supports multiple ways of defining the listening port:

- `serve` (default port: 7000)
- `serve on 8080` (explicit numeric port)
- `serve on portVar` (variable-based port)
- `serve on (basePort + 100)` (expression-based port resolution)

This enables dynamic deployment configurations and runtime flexibility without
modifying server internals.

## 2. Unified HTTP error handling system

Introduces a centralized error model (`HttpError`) with structured fields:

- code
- title
- message
- hint
- actionText
- actionLink

Errors are now rendered consistently using a single template system and support
content negotiation:

- HTML responses for browsers
- JSON responses for API clients (via Accept header)

Standard HTTP error codes are now covered:
400, 403, 404, 405, 408, 413, 429, 500

## Design impact

- Enables future customization of error pages

# ✝️ Wisdom

"I am the door; if anyone enters through Me, he will be saved…"
— **John 10:9**

"Do not despise these small beginnings, for the Lord rejoices to see the work begin."
— **Zechariah 4:10**

# Preview

<img width="436" height="391" alt="error-page" src="https://github.com/user-attachments/assets/34f5f4e3-421a-4cce-859d-23bad6e03af7" />
