### PR TITLE
Step 76: feat(list): Added list creation and index access. Ref #8.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ set(JESUS_CPP_FILES
     src/jesus/ast/expr/grouping_expr.cpp
     src/jesus/ast/expr/conditional_expr.cpp
     src/jesus/ast/expr/list_expr.cpp
+    src/jesus/ast/expr/index_expr.cpp
 
     # --------------
     # AST Statements

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ set(JESUS_CPP_FILES
     src/jesus/ast/expr/formatted_string_expr.cpp
     src/jesus/ast/expr/grouping_expr.cpp
     src/jesus/ast/expr/conditional_expr.cpp
+    src/jesus/ast/expr/list_expr.cpp
 
     # --------------
     # AST Statements
@@ -162,6 +163,8 @@ set(JESUS_CPP_FILES
     src/jesus/parser/grammar/expr/keyword/giants_rule.cpp
 
     src/jesus/parser/grammar/expr/postfix/get_attr_rule.cpp
+
+    src/jesus/parser/grammar/expr/collection/list_rule.cpp
 
     # -----------------
     # Statement parsers

--- a/src/jesus/ast/expr/index_expr.cpp
+++ b/src/jesus/ast/expr/index_expr.cpp
@@ -1,0 +1,13 @@
+#include "index_expr.hpp"
+#include "interpreter/expr_visitor.hpp"
+#include "types/known_types.hpp"
+
+Value IndexExpr::accept(ExprVisitor &visitor) const
+{
+    return visitor.visitIndexExpr(*this);
+}
+
+std::shared_ptr<CreationType> IndexExpr::getReturnType(ParserContext &ctx) const
+{
+    return KnownTypes::CREATION;
+};

--- a/src/jesus/ast/expr/index_expr.hpp
+++ b/src/jesus/ast/expr/index_expr.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "expr.hpp"
+
+REGISTER_FOR_UML(
+    IndexExpr,
+    .packageName("ast.expr")
+        .parentsList({"Expr"})
+        .fieldsList({"list", "index"}));
+
+/**
+ * @brief Access list indexes. E.g.: list[7]
+ */
+class IndexExpr : public Expr
+{
+public:
+    std::unique_ptr<Expr> list;
+    std::unique_ptr<Expr> index;
+
+    IndexExpr(std::unique_ptr<Expr> list, std::unique_ptr<Expr> index)
+        : list(std::move(list)), index(std::move(index)) {}
+
+    Value evaluate(std::shared_ptr<Heart> heart) const override
+    {
+        return list->evaluate(heart);
+    }
+
+    Value accept(ExprVisitor &visitor) const override;
+
+    std::shared_ptr<CreationType> getReturnType(ParserContext &ctx) const override;
+
+    std::string toString() const override
+    {
+        return list->toString() + "[" + index->toString() + "]";
+    }
+};

--- a/src/jesus/ast/expr/list_expr.cpp
+++ b/src/jesus/ast/expr/list_expr.cpp
@@ -1,0 +1,13 @@
+#include "list_expr.hpp"
+#include "interpreter/expr_visitor.hpp"
+#include "types/known_types.hpp"
+
+Value ListExpr::accept(ExprVisitor &visitor) const
+{
+    return visitor.visitListExpr(*this);
+}
+
+std::shared_ptr<CreationType> ListExpr::getReturnType(ParserContext &ctx) const
+{
+    return KnownTypes::LIST;
+};

--- a/src/jesus/ast/expr/list_expr.hpp
+++ b/src/jesus/ast/expr/list_expr.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "expr.hpp"
+
+REGISTER_FOR_UML(
+    ListExpr,
+    .packageName("ast.expr")
+        .parentsList({"Expr"})
+        .fieldsList({"elements"}));
+
+/**
+ * @brief Represents a list. E.g.: [1, 2, 3]
+ */
+class ListExpr : public Expr
+{
+public:
+    std::vector<std::unique_ptr<Expr>> elements;
+
+    ListExpr(std::vector<std::unique_ptr<Expr>> elements)
+        : elements(std::move(elements)) {}
+
+    Value evaluate(std::shared_ptr<Heart> scope) const override
+    {
+        throw std::runtime_error("Should call Interpreter::evalListExpr through Interpreter::visitListEpxr");
+    }
+
+    Value accept(ExprVisitor &visitor) const override;
+
+    std::shared_ptr<CreationType> getReturnType(ParserContext &ctx) const override;
+};

--- a/src/jesus/interpreter/expr_visitor.hpp
+++ b/src/jesus/interpreter/expr_visitor.hpp
@@ -15,6 +15,7 @@
 #include "../ast/expr/formatted_string_expr.hpp"
 #include "../ast/expr/bible_expr.hpp"
 #include "../ast/expr/list_expr.hpp"
+#include "../ast/expr/index_expr.hpp"
 
 REGISTER_FOR_UML(
     ExprVisitor,
@@ -73,6 +74,7 @@ public:
     virtual Value visitParityCheckExpr(const ParityCheckExpr &expr) = 0;
     virtual Value visitBibleExpr(const BibleExpr &expr) = 0;
     virtual Value visitListExpr(const ListExpr &expr) = 0;
+    virtual Value visitIndexExpr(const IndexExpr &expr) = 0;
 
     virtual ~ExprVisitor() = default;
 };

--- a/src/jesus/interpreter/expr_visitor.hpp
+++ b/src/jesus/interpreter/expr_visitor.hpp
@@ -14,6 +14,7 @@
 #include "../ast/expr/method_call_expr.hpp"
 #include "../ast/expr/formatted_string_expr.hpp"
 #include "../ast/expr/bible_expr.hpp"
+#include "../ast/expr/list_expr.hpp"
 
 REGISTER_FOR_UML(
     ExprVisitor,
@@ -71,6 +72,7 @@ public:
     virtual Value visitFormattedStringExpr(const FormattedStringExpr &expr) = 0;
     virtual Value visitParityCheckExpr(const ParityCheckExpr &expr) = 0;
     virtual Value visitBibleExpr(const BibleExpr &expr) = 0;
+    virtual Value visitListExpr(const ListExpr &expr) = 0;
 
     virtual ~ExprVisitor() = default;
 };

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -299,6 +299,32 @@ Value Interpreter::visitListExpr(const ListExpr &expr)
     return evalListExpr(expr, *this);
 }
 
+Value Interpreter::visitIndexExpr(const IndexExpr &expr)
+{
+    Value listVal = expr.list->accept(*this);
+    Value indexVal = expr.index->accept(*this);
+
+    auto &items = listVal.asList();
+    int size = items.size();
+
+    int index = indexVal.toInt();
+    if (size == 0)
+    {
+        throw std::runtime_error("Cannot access index " + std::to_string(index) + ". This list is empty.");
+    }
+
+    if (index >= size || index < 0)
+    {
+        std::string msg = "It has 1 element (only index 0 is valid).";
+        if (size > 1)
+            msg = "It has " + std::to_string(size) + " elements (valid indexes: 0 to " + std::to_string(size - 1) + ").";
+
+        throw std::runtime_error("Index " + std::to_string(index) + " is not available in this list.\n" + msg);
+    }
+
+    return *items[index];
+}
+
 void Interpreter::visitPrintStmt(const PrintStmt &stmt)
 {
     Value value = evaluate(stmt.message);

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -281,6 +281,24 @@ Value Interpreter::visitBibleExpr(const BibleExpr &expr)
     return Value(verses);
 }
 
+Value Interpreter::evalListExpr(const ListExpr &expr, ExprVisitor &driver)
+{
+    std::vector<std::shared_ptr<Value>> result;
+    result.reserve(expr.elements.size());
+
+    for (const auto &el : expr.elements)
+    {
+        result.push_back(std::make_shared<Value>(el->accept(driver)));
+    }
+
+    return Value(result);
+}
+
+Value Interpreter::visitListExpr(const ListExpr &expr)
+{
+    return evalListExpr(expr, *this);
+}
+
 void Interpreter::visitPrintStmt(const PrintStmt &stmt)
 {
     Value value = evaluate(stmt.message);

--- a/src/jesus/interpreter/interpreter.hpp
+++ b/src/jesus/interpreter/interpreter.hpp
@@ -264,6 +264,7 @@ private:
 
     Value evalListExpr(const ListExpr &expr, ExprVisitor &driver);
     Value visitListExpr(const ListExpr &expr) override;
+    Value visitIndexExpr(const IndexExpr &expr) override;
 
     /**
      * @brief Converts a runtime value into a string representation.

--- a/src/jesus/interpreter/interpreter.hpp
+++ b/src/jesus/interpreter/interpreter.hpp
@@ -262,6 +262,9 @@ private:
 
     Value visitBibleExpr(const BibleExpr &expr) override;
 
+    Value evalListExpr(const ListExpr &expr, ExprVisitor &driver);
+    Value visitListExpr(const ListExpr &expr) override;
+
     /**
      * @brief Converts a runtime value into a string representation.
      *

--- a/src/jesus/lexer/lexer.cpp
+++ b/src/jesus/lexer/lexer.cpp
@@ -209,6 +209,19 @@ std::vector<Token> Lexer::tokenize(const std::string &raw_input)
             continue;
         }
 
+        if (c == "[")
+        {
+            tokens.emplace_back(TokenType::LEFT_BRACKET, "[", Value("["));
+            i++;
+            continue;
+        }
+        if (c == "]")
+        {
+            tokens.emplace_back(TokenType::RIGHT_BRACKET, "]", Value("]"));
+            i++;
+            continue;
+        }
+
         if (c == "+")
         {
             tokens.emplace_back(TokenType::PLUS, "+", Value("+"));

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -39,6 +39,8 @@ enum class TokenType
     IDENTIFIER,     // varname, attribute
     LEFT_PAREN,     // (
     RIGHT_PAREN,    // )
+    LEFT_BRACKET,   // [
+    RIGHT_BRACKET,  // ]
 
     PLUS,           // +
     MINUS,          // -

--- a/src/jesus/parser/grammar/expr/collection/list_rule.cpp
+++ b/src/jesus/parser/grammar/expr/collection/list_rule.cpp
@@ -1,0 +1,39 @@
+#include "list_rule.hpp"
+#include "ast/expr/list_expr.hpp"
+#include "ast/stmt/incomplete_block_stmt.hpp"
+
+std::unique_ptr<Expr> ListRule::parse(ParserContext &ctx)
+{
+    if (!ctx.match(TokenType::LEFT_BRACKET))
+        return nullptr;
+
+    std::vector<std::unique_ptr<Expr>> elements;
+
+    ctx.consumeAllNewLines();
+
+    if (!ctx.check(TokenType::RIGHT_BRACKET))
+    {
+        do
+        {
+            ctx.consumeAllNewLines();
+
+            auto value = expression->parse(ctx);
+            if (!value)
+            {
+                throw std::runtime_error("Expected value inside list.");
+            }
+
+            elements.push_back(std::move(value));
+
+            ctx.consumeAllNewLines();
+
+        } while (ctx.match(TokenType::COMMA));
+    }
+
+    if (!ctx.match(TokenType::RIGHT_BRACKET))
+    {
+        throw std::runtime_error("Expected ']' to close list.");
+    }
+
+    return std::make_unique<ListExpr>(std::move(elements));
+}

--- a/src/jesus/parser/grammar/expr/collection/list_rule.hpp
+++ b/src/jesus/parser/grammar/expr/collection/list_rule.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include "../../grammar_rule.hpp"
+
+/**
+ * @brief Grammar rule for parsing lists. E.g.: [70, 7]
+ *
+ * List → "[" ( Expression ( "," Expression )* )? "]"
+ */
+class ListRule : public IGrammarRule
+{
+private:
+    std::shared_ptr<IGrammarRule> expression;
+
+public:
+    ListRule(std::shared_ptr<IGrammarRule> expr)
+        : expression(expr) {}
+
+    std::unique_ptr<Expr> parse(ParserContext &ctx) override;
+
+    std::string toStr(GrammarRuleHashTable &visitedTable) const override
+    {
+        return "ListRule";
+    }
+};

--- a/src/jesus/parser/grammar/expr/postfix/get_attr_rule.cpp
+++ b/src/jesus/parser/grammar/expr/postfix/get_attr_rule.cpp
@@ -1,9 +1,12 @@
 #include "get_attr_rule.hpp"
-#include "../../../../ast/expr/get_attr_expr.hpp"
-#include "../../../../ast/expr/variable_expr.hpp"
-#include "../../../../ast/expr/method_call_expr.hpp"
-#include "../../../../types/creation_type.hpp"
-#include "../../../helpers/member.hpp"
+#include "ast/expr/get_attr_expr.hpp"
+#include "ast/expr/variable_expr.hpp"
+#include "ast/expr/method_call_expr.hpp"
+#include "ast/expr/index_expr.hpp"
+#include "types/creation_type.hpp"
+#include "types/known_types.hpp"
+#include "parser/helpers/member.hpp"
+#include "parser/grammar/jesus_grammar.hpp"
 #include <memory>
 
 std::unique_ptr<Expr> GetAttributeRule::parse(ParserContext &ctx)
@@ -13,52 +16,106 @@ std::unique_ptr<Expr> GetAttributeRule::parse(ParserContext &ctx)
     if (!expr)
         return nullptr;
 
-    // Parse more identifiers for attribute access: say person name
-    while (ctx.match(TokenType::IDENTIFIER))
+    // -------------------------------------------
+    // Parse postfix operations (chainable)
+    // Primary → Postfix → Postfix → Postfix → ...
+    // -------------------------------------------
+    while (true)
     {
-        if (auto varExpr = dynamic_cast<VariableExpr *>(expr.get()))
+        // =========================
+        // 1. LIST INDEX: expr[...]
+        // =========================
+        if (ctx.match(TokenType::LEFT_BRACKET))
         {
-            std::shared_ptr<CreationType> klass = ctx.getVarType(varExpr->name);
-            std::string name = ctx.previous().lexeme;
+            auto indexExpr = grammar::Expression->parse(ctx);
 
-            auto member = klass->findMember(name, klass);
-            if (!member)
-            {
-                throw std::runtime_error("Unknown member '" + name + "' in class " + klass->name);
-            }
+            if (!indexExpr)
+                throw std::runtime_error("Expected a value inside []. Example: list[0]");
 
-            if (member->isAttribute())
-            {
-                expr = std::make_unique<GetAttributeExpr>(std::move(expr), name);
-            }
-            else if (member->isMethod())
-            {
-                std::vector<std::unique_ptr<Expr>> args;
+            if (!ctx.match(TokenType::RIGHT_BRACKET))
+                throw std::runtime_error("Expected ']' after index.");
 
-                // If the next token(s) indicate arguments, parse them
-                if (!ctx.check(TokenType::NEWLINE) && !ctx.check(TokenType::END_OF_FILE))
+            auto type = expr->getReturnType(ctx);
+            if (!type->isA(KnownTypes::LIST))
+                throw std::runtime_error("Cannot access index on type '" + type->name + "'. Expected a list.");
+
+            type = indexExpr->getReturnType(ctx);
+            if (!(type->isA(KnownTypes::INT)))
+                throw std::runtime_error("Index must be an integer. Got '" + type->name + "' instead.");
+
+            expr = std::make_unique<IndexExpr>(std::move(expr), std::move(indexExpr));
+
+            continue;
+        }
+
+        // =============================
+        // 2. ATTRIBUTE / METHOD ACCESS
+        // =============================
+        if (ctx.match(TokenType::IDENTIFIER))
+        {
+            // ----------------------------
+            // Resolve attribute or method
+            // ----------------------------
+            if (auto varExpr = dynamic_cast<VariableExpr *>(expr.get()))
+            {
+                std::shared_ptr<CreationType> klass = ctx.getVarType(varExpr->name);
+                std::string name = ctx.previous().lexeme;
+
+                auto member = klass->findMember(name, klass);
+                if (!member)
                 {
-                    do
-                    {
-                        auto argExpr = primary->parse(ctx); // parse any expression
-                        if (!argExpr)
-                            throw std::runtime_error("Expected argument for method " + name);
-
-                        args.push_back(std::move(argExpr));
-                    } while (ctx.match(TokenType::COMMA));
+                    throw std::runtime_error("Unknown member '" + name + "' in class " + klass->name);
                 }
 
-                expr = std::make_unique<MethodCallExpr>(std::move(expr), member->method, std::move(args));
+                // -----------------
+                // ATTRIBUTE ACCESS
+                // -----------------
+                if (member->isAttribute())
+                {
+                    expr = std::make_unique<GetAttributeExpr>(std::move(expr), name);
+                }
+
+                // ------------
+                // METHOD CALL
+                // ------------
+                else if (member->isMethod())
+                {
+                    std::vector<std::unique_ptr<Expr>> args;
+
+                    // If the next token(s) indicate arguments, parse them
+                    if (!ctx.check(TokenType::NEWLINE) && !ctx.check(TokenType::END_OF_FILE))
+                    {
+                        do
+                        {
+                            auto argExpr = primary->parse(ctx); // parse any expression
+
+                            if (!argExpr)
+                                throw std::runtime_error("Expected argument for method " + name);
+
+                            args.push_back(std::move(argExpr));
+
+                        } while (ctx.match(TokenType::COMMA));
+                    }
+
+                    expr = std::make_unique<MethodCallExpr>(std::move(expr), member->method, std::move(args));
+                }
+                else
+                {
+                    throw std::runtime_error("Unknown member '" + name + "' in class " + klass->name);
+                }
             }
             else
             {
-                throw std::runtime_error("Unknown member '" + name + "' in class " + klass->name);
+                throw std::runtime_error("Cannot access member on this expression: '" + expr->toString() + "'");
             }
+
+            continue;
         }
-        else
-        {
-            throw std::runtime_error("Not prepared for this expression yet: '" + expr->toString() + "'");
-        }
+
+        // --------------------
+        // No more postfix ops
+        // --------------------
+        break;
     }
     return expr;
 }

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -27,6 +27,8 @@
 
 #include "expr/postfix/get_attr_rule.hpp"
 
+#include "expr/collection/list_rule.hpp"
+
 #include "expr/ask_expr_rule.hpp"
 #include "expr/conditional_expr_rule.hpp"
 #include "stmt/print_stmt_rule.hpp"
@@ -90,11 +92,15 @@ namespace grammar
     inline auto Variable = std::make_shared<VariableRule>();
     inline auto Ask = std::make_shared<AskExprRule>();
     inline auto BibleRef = std::make_shared<BibleExprRule>(Expression);
+    inline auto List = std::make_shared<ListRule>(Expression);
 
     /**
      * @brief Primary is anything that can be evaluated directly: number, string, or a grouped expression.
      */
-    inline auto Primary = Number | String | FormattedString | YesNo | Sex | Weekday | Confess | Giants | Variable | BibleRef | Group(Expression);
+    inline auto Primary =
+        Number | String | FormattedString | YesNo | Sex | Weekday |
+        Confess | Giants | Variable | BibleRef | List |
+        Group(Expression);
     inline auto GetAttribute = std::make_shared<GetAttributeRule>(Primary);
 
     // ----------

--- a/src/jesus/tests/repl/040-many-tests.jesus
+++ b/src/jesus/tests/repl/040-many-tests.jesus
@@ -457,3 +457,10 @@ on http '/plain' -> 'text/plain':
 amen
 
 serve on 123456
+
+create list l = ['Matt', 'Mark', 'Luke']
+4[0]
+l[-1]
+l[3]
+l[2]
+l['index']

--- a/src/jesus/tests/repl/040-many-tests.jesus.expected
+++ b/src/jesus/tests/repl/040-many-tests.jesus.expected
@@ -333,4 +333,11 @@ Exodus 20:13 — You shall not murder. 1 Corinthians 3:17 — If anyone destroys
 (Jesus) (Jesus) Remember Lot's wife!
 
 (Jesus) (Jesus) (Jesus) (Jesus) (Jesus) (Jesus) (Jesus) (Jesus) ❌ Error: Port must be between 1 and 65535
+(Jesus) (Jesus) (Jesus) ❌ Error: Cannot access index on type 'number'. Expected a list.
+(Jesus) ❌ Error: Index -1 is not available in this list.
+It has 3 elements (valid indexes: 0 to 2).
+(Jesus) ❌ Error: Index 3 is not available in this list.
+It has 3 elements (valid indexes: 0 to 2).
+(Jesus) Luke
+(Jesus) ❌ Error: Index must be an integer. Got 'text' instead.
 (Jesus) 

--- a/src/jesus/types/composite/list_type.hpp
+++ b/src/jesus/types/composite/list_type.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "../creation_type.hpp"
+
+/**
+ * @brief Runtime representation of list<T>.
+ */
+class ListType : public CreationType
+{
+public:
+    std::shared_ptr<CreationType> elementType;
+
+    ListType(std::shared_ptr<CreationType> elementType, std::shared_ptr<CreationType> parent)
+        : CreationType(PrimitiveType::Collection, "list", "core", parent),
+          elementType(elementType) {}
+
+    bool validate(const Value &value) const override
+    {
+        if (!value.IS_LIST)
+            return false;
+
+        for (const auto &v : value.asList())
+        {
+            if (!elementType->validate(*v))  // FIXME: Isn't this '*' slow?
+                return false;
+        }
+
+        return true;
+    }
+};

--- a/src/jesus/types/creation_type.hpp
+++ b/src/jesus/types/creation_type.hpp
@@ -17,6 +17,7 @@ enum class PrimitiveType
     Module,
     Class,
     Polymorphic,
+    Collection // list, dict
 };
 
 class CreationType

--- a/src/jesus/types/known_types.cpp
+++ b/src/jesus/types/known_types.cpp
@@ -14,6 +14,7 @@
 #include "atomic/strings/phrase_type.hpp"
 #include "composite/class_type.hpp"
 #include "composite/module_type.hpp"
+#include "composite/list_type.hpp"
 #include "composite/its_written_exception_type.hpp"
 #include <memory>
 #include <sstream>
@@ -35,6 +36,7 @@ void KnownTypes::registerBuiltInTypes()
     auto klass = std::make_shared<ClassType>(creation);
     auto module = std::make_shared<ModuleType>(creation);
     auto exception = std::make_shared<ItsWritten>(klass);
+    auto list = std::make_shared<ListType>(creation, creation);
 
     BOOLEAN = TRUTH = truth;
     VOID = NOTHING = nothing;
@@ -49,6 +51,7 @@ void KnownTypes::registerBuiltInTypes()
     MODULE = module;
     CLASS = klass;
     EXCEPTION = exception;
+    LIST = list;
 
     registerType(truth);
     registerType(creation);
@@ -69,6 +72,8 @@ void KnownTypes::registerBuiltInTypes()
     registerType(klass);
     registerType(module);
     registerType(exception);
+
+    registerType(list);
 }
 
 void KnownTypes::registerType(std::shared_ptr<CreationType> type)

--- a/src/jesus/types/known_types.cpp
+++ b/src/jesus/types/known_types.cpp
@@ -39,6 +39,7 @@ void KnownTypes::registerBuiltInTypes()
     auto list = std::make_shared<ListType>(creation, creation);
 
     BOOLEAN = TRUTH = truth;
+    CREATION = creation;
     VOID = NOTHING = nothing;
     BORN = SEX = sex;
     WEEKDAY = weekday;

--- a/src/jesus/types/known_types.hpp
+++ b/src/jesus/types/known_types.hpp
@@ -27,6 +27,7 @@ public:
     // -------------------------------------------------------------------
     inline static std::shared_ptr<CreationType> VOID;
     inline static std::shared_ptr<CreationType> NOTHING;
+    inline static std::shared_ptr<CreationType> CREATION;
 
     inline static std::shared_ptr<CreationType> SEX;
     inline static std::shared_ptr<CreationType> BORN;

--- a/src/jesus/types/known_types.hpp
+++ b/src/jesus/types/known_types.hpp
@@ -4,6 +4,8 @@
 #include "creation_type.hpp"
 #include "../spirit/value.hpp"
 
+class ListType;
+
 class KnownTypes
 {
 public:
@@ -44,6 +46,8 @@ public:
     inline static std::shared_ptr<CreationType> MODULE;
     inline static std::shared_ptr<CreationType> CLASS;
     inline static std::shared_ptr<CreationType> EXCEPTION;
+
+    inline static std::shared_ptr<CreationType> LIST;
     // -------------------------------------------------------------------
 
     static std::string toString();


### PR DESCRIPTION
# Description

This PR introduces support for lists in the Jesus language,
including list creation and element access by index, and it builds on top of PR #8.

### Features

- Added `list` type to the type system
- Support list literals: `[1, 2, 3]`
- Allow variable creation with lists:
  create list l = [1, 2, 3]

- Implement index access:
  l[0] -> returns first element

### Parser

- Introduce `ListRule` to parse list literals
- Extend postfix (`GetAttributeRule`) parsing to support index access (`expr[index]`)

### AST

- Added `ListExpr` for list literals
- Added `IndexExpr` for indexed access

### Interpreter

- Implemented evaluation for `ListExpr`
- Implemented `visitIndexExpr` for retrieving list elements
- Added runtime validation for:
  - non-list access
  - non-integer index
  - out-of-bounds access

### Type System

- Registered `list` in `KnownTypes`
- Default empty lists to `list<creation>`

### Notes

- Indexing is currently zero-based at runtime
- **Future** improvements may introduce position semantics where _**arrays start at 1**_

### Example

This code outputs '1':
```
create list numbers = [1, 2, 3]

numbers[0]
```

# ✝️ Wisdom

"Thus the heavens and the earth were completed in all their vast **_array_**." — Genesis 2:1