### PR TITLE
Step 77: feat(index-update): Assignment to list indexes working (l-values: list[1] = 40). Ref #76.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ set(JESUS_CPP_FILES
     src/jesus/ast/stmt/repeat_while_stmt.cpp
     src/jesus/ast/stmt/repeat_forever_stmt.cpp
     src/jesus/ast/stmt/update_var_stmt.cpp
+    src/jesus/ast/stmt/assign_stmt.cpp
     src/jesus/ast/stmt/return_stmt.cpp
     src/jesus/ast/stmt/if_stmt.cpp
     src/jesus/ast/stmt/try_stmt.cpp
@@ -174,6 +175,7 @@ set(JESUS_CPP_FILES
     src/jesus/parser/grammar/stmt/create_var_type_stmt_rule.cpp
     src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
     src/jesus/parser/grammar/stmt/update_var_stmt_rule.cpp
+    src/jesus/parser/grammar/stmt/assign_stmt_rule.cpp
     src/jesus/parser/grammar/stmt/create_method_stmt_rule.cpp
     src/jesus/parser/grammar/stmt/repeat_stmt_rule.cpp
     src/jesus/parser/grammar/stmt/if_stmt_rule.cpp

--- a/src/jesus/ast/expr/assignable_expr.hpp
+++ b/src/jesus/ast/expr/assignable_expr.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "expr.hpp"
+
+class Interpreter;
+
+REGISTER_FOR_UML(
+    AssignableExpr,
+    .packageName("ast.expr")
+        .parentsList({"Expr"}));
+
+/**
+ * @brief Represents variable updates: (target) = expression
+ *
+ * Where target can be:
+ *  variable        → x = 10
+ *  indexed access  → list[0] = 10
+ *  attribute       → person.name = "Adam"
+ */
+class AssignableExpr : public Expr
+{
+public:
+    virtual void assign(Interpreter &interpreter, const Value &value) const = 0;
+};

--- a/src/jesus/ast/expr/index_expr.cpp
+++ b/src/jesus/ast/expr/index_expr.cpp
@@ -1,6 +1,7 @@
 #include "index_expr.hpp"
 #include "interpreter/expr_visitor.hpp"
 #include "types/known_types.hpp"
+#include "interpreter/interpreter.hpp"
 
 Value IndexExpr::accept(ExprVisitor &visitor) const
 {
@@ -11,3 +12,23 @@ std::shared_ptr<CreationType> IndexExpr::getReturnType(ParserContext &ctx) const
 {
     return KnownTypes::CREATION;
 };
+
+void IndexExpr::assign(Interpreter &interpreter, const Value &value) const
+{
+    Value listVal = list->accept(interpreter);
+    Value indexVal = index->accept(interpreter);
+
+    if (!listVal.IS_LIST)
+        throw std::runtime_error("Cannot assign to index of non-list.");
+
+    if (!indexVal.IS_NUMBER)
+        throw std::runtime_error("Index must be an integer.");
+
+    auto &items = listVal.asList();
+    int idx = indexVal.toInt();
+
+    if (idx < 0 || idx >= items.size())
+        throw std::runtime_error("Index " + std::to_string(idx) + " is not available.");
+
+    items[idx] = std::make_shared<Value>(value);
+}

--- a/src/jesus/ast/expr/index_expr.hpp
+++ b/src/jesus/ast/expr/index_expr.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
-#include "expr.hpp"
+#include "assignable_expr.hpp"
 
 REGISTER_FOR_UML(
     IndexExpr,
     .packageName("ast.expr")
-        .parentsList({"Expr"})
+        .parentsList({"AssignableExpr"})
         .fieldsList({"list", "index"}));
 
 /**
  * @brief Access list indexes. E.g.: list[7]
  */
-class IndexExpr : public Expr
+class IndexExpr : public AssignableExpr
 {
 public:
     std::unique_ptr<Expr> list;
@@ -26,6 +26,8 @@ public:
     }
 
     Value accept(ExprVisitor &visitor) const override;
+
+    void assign(Interpreter &interpreter, const Value &value) const override;
 
     std::shared_ptr<CreationType> getReturnType(ParserContext &ctx) const override;
 

--- a/src/jesus/ast/stmt/assign_stmt.cpp
+++ b/src/jesus/ast/stmt/assign_stmt.cpp
@@ -1,0 +1,7 @@
+#include "assign_stmt.hpp"
+#include "../../interpreter/stmt_visitor.hpp"
+
+void AssignStmt::accept(StmtVisitor &visitor) const
+{
+    visitor.visitAssignStmt(*this);
+}

--- a/src/jesus/ast/stmt/assign_stmt.hpp
+++ b/src/jesus/ast/stmt/assign_stmt.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include "stmt.hpp"
+#include "ast/expr/assignable_expr.hpp"
+
+REGISTER_FOR_UML(
+    AssignStmt,
+    .packageName("ast.stmt")
+        .parentsList({"Stmt"})
+        .fieldsList({"target", "value"}));
+
+class AssignStmt : public Stmt
+{
+public:
+  std::unique_ptr<AssignableExpr> target;
+  std::unique_ptr<Expr> value;
+
+  AssignStmt(std::unique_ptr<AssignableExpr> target, std::unique_ptr<Expr> value)
+      : target(std::move(target)), value(std::move(value)) {}
+
+  std::string toString() const override
+  {
+    return "AssignStmt(target: " + target->toString() + ", value: " + value->toString() + ")";
+  }
+
+  void accept(StmtVisitor &visitor) const override;
+};

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -248,6 +248,13 @@ void Interpreter::visitUpdateVar(const UpdateVarStmt &stmt)
     updateVariable(stmt.name, val);
 }
 
+void Interpreter::visitAssignStmt(const AssignStmt &stmt)
+{
+    Value value = stmt.value->accept(*this);
+
+    stmt.target->assign(*this, value);
+}
+
 Value Interpreter::visitConditional(const ConditionalExpr &expr)
 {
     Value conditionValue = evaluate(expr.condition);
@@ -283,12 +290,12 @@ Value Interpreter::visitBibleExpr(const BibleExpr &expr)
 
 Value Interpreter::evalListExpr(const ListExpr &expr, ExprVisitor &driver)
 {
-    std::vector<std::shared_ptr<Value>> result;
-    result.reserve(expr.elements.size());
+    auto result = std::make_shared<std::vector<std::shared_ptr<Value>>>();
+    result->reserve(expr.elements.size());
 
     for (const auto &el : expr.elements)
     {
-        result.push_back(std::make_shared<Value>(el->accept(driver)));
+        result->push_back(std::make_shared<Value>(/* val = */ el->accept(driver)));
     }
 
     return Value(result);

--- a/src/jesus/interpreter/interpreter.hpp
+++ b/src/jesus/interpreter/interpreter.hpp
@@ -314,6 +314,14 @@ private:
      */
     void visitUpdateVarWithAsk(const UpdateVarWithAskStmt &stmt) override;
 
+    /**
+     * @brief Handle var updates.
+     *  x = 10
+     *  list[0] = 10
+     *  user.age = 33
+     */
+    void visitAssignStmt(const AssignStmt &stmt) override;
+
     void visitPrintStmt(const PrintStmt &stmt) override;
 
     /**

--- a/src/jesus/interpreter/stmt_visitor.hpp
+++ b/src/jesus/interpreter/stmt_visitor.hpp
@@ -4,6 +4,7 @@
 #include "../ast/stmt/create_var_type_stmt.hpp"
 #include "../ast/stmt/create_var_stmt.hpp"
 #include "../ast/stmt/update_var_stmt.hpp"
+#include "../ast/stmt/assign_stmt.hpp"
 #include "../ast/stmt/create_var_with_ask_stmt.hpp"
 #include "../ast/stmt/update_var_with_ask_stmt.hpp"
 #include "../ast/stmt/print_stmt.hpp"
@@ -93,6 +94,7 @@ public:
     virtual void visitMemoryInspectStmt(const MemoryInspectStmt &stmt) = 0;
     virtual void visitOnStmt(const OnStmt &stmt) = 0;
     virtual void visitServeStmt(const ServeStmt &stmt) = 0;
+    virtual void visitAssignStmt(const AssignStmt &stmt) = 0;
 
     virtual ~StmtVisitor() = default;
 };

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -36,6 +36,7 @@
 #include "stmt/create_var_type_stmt_rule.hpp"
 #include "stmt/create_var_stmt_rule.hpp"
 #include "stmt/update_var_stmt_rule.hpp"
+#include "stmt/assign_stmt_rule.hpp"
 #include "stmt/repeat_stmt_rule.hpp"
 #include "stmt/if_stmt_rule.hpp"
 #include "stmt/try_stmt_rule.hpp"
@@ -110,6 +111,7 @@ namespace grammar
     inline auto CreateVarType = std::make_shared<CreateVarTypeStmtRule>();
     inline auto CreateVar = std::make_shared<CreateVarStmtRule>(Expression, Ask);
     inline auto UpdateVar = std::make_shared<UpdateVarStmtRule>(Expression, Ask);
+    inline auto UpdateItem = std::make_shared<AssignStmtRule>(Expression);
     inline auto CreateMethod = std::make_shared<CreateMethodStmtRule>(CreateVar, UpdateVar, Print);
     inline auto CreateClass = std::make_shared<CreateClassStmtRule>(CreateVar, CreateMethod);
     inline auto RepeatWhile = std::make_shared<RepeatStmtRule>();

--- a/src/jesus/parser/grammar/stmt/assign_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/assign_stmt_rule.cpp
@@ -1,0 +1,31 @@
+#include "assign_stmt_rule.hpp"
+#include "ast/stmt/assign_stmt.hpp"
+#include "ast/expr/assignable_expr.hpp"
+#include <stdexcept>
+
+std::unique_ptr<Stmt> AssignStmtRule::parse(ParserContext &ctx)
+{
+    int start = ctx.snapshot();
+    auto target = expression->parse(ctx);
+    if (!target)
+        return nullptr;
+
+    if (!ctx.match(TokenType::EQUAL))
+    {
+        ctx.restore(start);
+        return nullptr;
+    }
+
+    auto value = expression->parse(ctx);
+    if (!value)
+        throw std::runtime_error("Expected value after '='.");
+
+    auto assignable = dynamic_cast<AssignableExpr *>(target.get());
+    if (!assignable)
+    {
+        throw std::runtime_error("This value cannot be changed.");
+    }
+
+    std::unique_ptr<AssignableExpr> assignablePtr(static_cast<AssignableExpr *>(target.release()));
+    return std::make_unique<AssignStmt>(std::move(assignablePtr), std::move(value));
+}

--- a/src/jesus/parser/grammar/stmt/assign_stmt_rule.hpp
+++ b/src/jesus/parser/grammar/stmt/assign_stmt_rule.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "../grammar_rule.hpp"
+#include "../../../ast/stmt/stmt.hpp"
+#include "../expr/ask_expr_rule.hpp"
+
+class AssignStmtRule
+{
+    std::shared_ptr<IGrammarRule> expression;
+
+public:
+    explicit AssignStmtRule(std::shared_ptr<IGrammarRule> expression)
+        : expression(std::move(expression)) {}
+
+    std::unique_ptr<Stmt> parse(ParserContext &ctx);
+};

--- a/src/jesus/parser/grammar/stmt/update_var_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/update_var_stmt_rule.cpp
@@ -6,13 +6,18 @@
 
 std::unique_ptr<Stmt> UpdateVarStmtRule::parse(ParserContext &ctx)
 {
+    int start = ctx.snapshot();
+
     if (!ctx.match(TokenType::IDENTIFIER))
         return nullptr;
 
     const std::string varName = ctx.previous().lexeme;
 
     if (!ctx.match(TokenType::EQUAL))
+    {
+        ctx.restore(start);
         return nullptr;
+    }
 
     auto varType = ctx.getVarType(varName);
     if (!varType)

--- a/src/jesus/parser/parser.cpp
+++ b/src/jesus/parser/parser.cpp
@@ -42,6 +42,11 @@ std::unique_ptr<Stmt> parse(const std::vector<Token> &tokens, ParserContext &con
     if (updateVarStmt)
         return updateVarStmt;
 
+    context.restore(snapshot);
+    auto updateItem = grammar::UpdateItem->parse(context);
+    if (updateItem)
+        return updateItem;
+
     auto repeatWhileStmt = grammar::RepeatWhile->parse(context);
     if (repeatWhileStmt)
         return repeatWhileStmt;

--- a/src/jesus/spirit/value.cpp
+++ b/src/jesus/spirit/value.cpp
@@ -13,12 +13,15 @@ struct make_string_functor
     std::string operator()(const std::shared_ptr<CreationType> x) const { return x->toString(); }
     std::string operator()(const std::shared_ptr<Instance> x) const { return x->toString(); }
 
-    std::string operator()(const std::vector<std::shared_ptr<Value>> &list) const
+    std::string operator()(const std::shared_ptr<std::vector<std::shared_ptr<Value>>> &list) const
     {
+        if (!list)
+            return "[]";
+
         std::string result = "[";
         bool first = true;
 
-        for (const auto &item : list)
+        for (const auto &item : *list)
         {
             if (!first)
                 result += ", ";

--- a/src/jesus/spirit/value.hpp
+++ b/src/jesus/spirit/value.hpp
@@ -21,7 +21,16 @@ struct Instance;            // Forward declaration
  * "then the Lord God formed the man of dust from the ground and breathed into his nostrils the breath of life, and the man became a living creature."
  * — Genesis 2:7
  */
-using Dust = std::variant<std::vector<std::shared_ptr<Value>>, std::string, double, int, bool, std::monostate, std::shared_ptr<Module>, std::shared_ptr<CreationType>, std::shared_ptr<Instance>>; // or std::unique_ptr<Value>, etc.
+using Dust = std::variant<
+    bool,
+    int,
+    double,
+    std::string,
+    std::monostate,
+    std::shared_ptr<Module>,
+    std::shared_ptr<Instance>,
+    std::shared_ptr<CreationType>,
+    std::shared_ptr<std::vector<std::shared_ptr<Value>>>>;
 
 class Value
 {
@@ -46,7 +55,7 @@ public:
     explicit Value(bool v) : value(v), IS_BOOLEAN(true), AS_BOOLEAN(v) {}
     explicit Value(const std::string &v) : value(v), IS_STRING(true), AS_BOOLEAN(v != "") {}
     explicit Value(const char *v) : value(std::string(v)), IS_STRING(true), AS_BOOLEAN(std::string(v) != "") {}
-    explicit Value(const std::vector<std::shared_ptr<Value>> &v) : value(v), IS_LIST(true), AS_BOOLEAN(!v.empty()) {}
+    explicit Value(const std::shared_ptr<std::vector<std::shared_ptr<Value>>> &v) : value(std::move(v)), IS_LIST(true), AS_BOOLEAN(!v->empty()) {}
     explicit Value(const std::shared_ptr<Module> &v) : value(v), IS_MODULE(true), AS_BOOLEAN(true) {}
     explicit Value(const std::shared_ptr<CreationType> &v): value(v), IS_CLASS(true), AS_BOOLEAN(true) {}
     explicit Value(const std::shared_ptr<Instance> &v) : value(v), IS_INSTANCE(true), AS_BOOLEAN(static_cast<bool>(v)) {}
@@ -88,12 +97,20 @@ public:
 
     std::string toString() const;
 
+    std::vector<std::shared_ptr<Value>> &asList()
+    {
+        if (!IS_LIST)
+            throw std::runtime_error("This value is not a list.");
+
+        return *std::get<std::shared_ptr<std::vector<std::shared_ptr<Value>>>>(value);
+    }
+
     const std::vector<std::shared_ptr<Value>> &asList() const
     {
         if (!IS_LIST)
             throw std::runtime_error("This value is not a list.");
 
-        return std::get<std::vector<std::shared_ptr<Value>>>(value);
+        return *std::get<std::shared_ptr<std::vector<std::shared_ptr<Value>>>>(value);
     }
 
     /**

--- a/src/jesus/tests/repl/040-many-tests.jesus
+++ b/src/jesus/tests/repl/040-many-tests.jesus
@@ -464,3 +464,5 @@ l[-1]
 l[3]
 l[2]
 l['index']
+l[1] = 'Marcos'
+l

--- a/src/jesus/tests/repl/040-many-tests.jesus.expected
+++ b/src/jesus/tests/repl/040-many-tests.jesus.expected
@@ -340,4 +340,5 @@ It has 3 elements (valid indexes: 0 to 2).
 It has 3 elements (valid indexes: 0 to 2).
 (Jesus) Luke
 (Jesus) ❌ Error: Index must be an integer. Got 'text' instead.
+(Jesus) (Jesus) [Matt, Marcos, Luke]
 (Jesus) 


### PR DESCRIPTION
# Description

This PR introduces the concept of assignable expressions (l-values) into the AST
by adding a new base class: `AssignableExpr`.

With this abstraction in place, `IndexExpr` is refactored to inherit from
`AssignableExpr`, enabling assignment to list elements:

    create list l = [3, 5, 7]
    l[2] = 590

This change allows list indices to act as valid assignment targets, not just
value-producing expressions.

### Motivation

Previously (PR #76), assignment was limited to variables. This prevented constructs like:

    myList[2] = 10

By introducing `AssignableExpr`, we establish an extensible mechanism
for supporting assignment targets beyond variables, such as:

- List indexing (`l[0] = ...`) ✅ (implemented in this PR)
- Attribute access (`obj.field = ...`) # SOON
- Nested/chained assignments (`matrix[1][2] = ...`)  # SOON

### Example

The following code is now possible:

```jesus
create list members = ['tail', 'heart of stone']
members[0] = 'Head'
members[1] = 'Heart of Flesh'
say members
````

Expected output:

```text
[Head, Heart of Flesh]
```

# ✝️ Wisdom


> “I will give you a new heart and put a new spirit in you; 
> I will remove from you your heart of stone and give you a **_heart of flesh_**.”
> — **Ezekiel 36:26**