### PR TITLE
feat(attr-update): Update of object's attributes working. Ref #31.

### DIFF
--- a/src/jesus/ast/expr/assignable_expr.hpp
+++ b/src/jesus/ast/expr/assignable_expr.hpp
@@ -20,5 +20,7 @@ REGISTER_FOR_UML(
 class AssignableExpr : public Expr
 {
 public:
+    explicit AssignableExpr(ExprKind kind) : Expr(kind) {}
+
     virtual void assign(Interpreter &interpreter, const Value &value) const = 0;
 };

--- a/src/jesus/ast/expr/get_attr_expr.cpp
+++ b/src/jesus/ast/expr/get_attr_expr.cpp
@@ -2,6 +2,8 @@
 #include "../../interpreter/expr_visitor.hpp"
 #include "../../types/creation_type.hpp"
 #include "../../parser/parser_context.hpp"
+#include "interpreter/interpreter.hpp"
+#include "interpreter/runtime/instance.hpp"
 
 Value GetAttributeExpr::accept(ExprVisitor &visitor) const
 {
@@ -12,3 +14,19 @@ std::shared_ptr<CreationType> GetAttributeExpr::getReturnType(ParserContext &ctx
 {
     return ctx.getVarType(attribute);
 };
+
+void GetAttributeExpr::assign(Interpreter &interpreter, const Value &value) const
+{
+    Value objectVal = object->accept(interpreter);
+
+    std::shared_ptr<Instance> instance = objectVal.toInstance();
+
+    if (!instance)
+    {
+        throw std::runtime_error(
+            "Cannot access attribute '" + attribute + "' on '" + objectVal.toString() + "' value.\n" +
+            "Tip: ensure the value is a valid object before accessing its attributes.");
+    }
+
+    instance->setAttribute(attribute, value);
+}

--- a/src/jesus/ast/expr/get_attr_expr.hpp
+++ b/src/jesus/ast/expr/get_attr_expr.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "expr.hpp"
+#include "assignable_expr.hpp"
 
 REGISTER_FOR_UML(
     GetAttributeExpr,
@@ -8,14 +8,14 @@ REGISTER_FOR_UML(
         .parentsList({"Expr"})
         .fieldsList({"object", "attribute"}));
 
-class GetAttributeExpr : public Expr
+class GetAttributeExpr : public AssignableExpr
 {
 public:
     std::unique_ptr<Expr> object;
     std::string attribute;
 
     GetAttributeExpr(std::unique_ptr<Expr> object, std::string attribute)
-        : object(std::move(object)), attribute(std::move(attribute)), Expr(ExprKind::GetAttribute) {}
+        : object(std::move(object)), attribute(std::move(attribute)), AssignableExpr(ExprKind::GetAttribute) {}
 
     Value evaluate(std::shared_ptr<Heart> heart) const override
     {
@@ -23,6 +23,8 @@ public:
     }
 
     Value accept(ExprVisitor &visitor) const override;
+
+    void assign(Interpreter &interpreter, const Value &value) const override;
 
     /**
      * @brief Get the return type of the expression, so that variable

--- a/src/jesus/ast/expr/index_expr.hpp
+++ b/src/jesus/ast/expr/index_expr.hpp
@@ -18,7 +18,8 @@ public:
     std::unique_ptr<Expr> index;
 
     IndexExpr(std::unique_ptr<Expr> list, std::unique_ptr<Expr> index)
-        : list(std::move(list)), index(std::move(index)) {}
+        : AssignableExpr(ExprKind::Other),
+         list(std::move(list)), index(std::move(index)) {}
 
     Value evaluate(std::shared_ptr<Heart> heart) const override
     {

--- a/src/jesus/tests/repl/040-many-tests.jesus
+++ b/src/jesus/tests/repl/040-many-tests.jesus
@@ -267,6 +267,8 @@ say 'single-quote string'
 say 'Hi {adam} (single-quoted)'
 say "Hi, {adam} (double-quoted)"
 say "Your name is {adam name}"
+adam name = 'Adão'
+say adam name
 say "Forbidden:  {600 + 60 + 6}"
 let there be SonOfMan:
     purpose age() -> number:

--- a/src/jesus/tests/repl/040-many-tests.jesus.expected
+++ b/src/jesus/tests/repl/040-many-tests.jesus.expected
@@ -229,6 +229,7 @@ null
  }
 } (double-quoted)
 (Jesus) Your name is Adopted by Jesus Christ
+(Jesus) (Jesus) Adão
 (Jesus) ❌ Error: NasaRules: Only simple variables or attribute chains are allowed inside formatted strings. This restriction ensures code clarity and safety, following Object Calisthenics and the 10 NASA rules for maintainable software. Expression rejected: '600 + 60 + 6'.
 (Jesus) (Jesus) (Jesus) {type: "instance",
  class: "SonOfMan",


### PR DESCRIPTION
# Description

This PR adds support for assigning values to object attributes after
an instance has been created.

### Example:

Previously, attribute access worked only for reading values, not for assigning new values.

Before:

```
u attribute_name = 'value'
❌ unsupported assignment target
```

After:
```
let there be Person:
  create text name = 'Adam'
amen 

create Person man = 1

man name = 'Jesus Christ'
# ✅ attribute updated successfully

say man 
```
The code above outputs:
```
{type: "instance",
 class: "Person",
 attributes: {
  name: "Jesus Christ"
 }
}
```

# ✝️ Wisdom

> “Do not conform to the pattern of this world, but **be transformed**
> by the renewing of your mind.” — **_Romans 12:2_**