### PR TITLE
Step 79: feat(list-type): List element types inferred at parse time. Ref #31, #76, #77, #78.

### DIFF
--- a/src/jesus/ast/ast_node.hpp
+++ b/src/jesus/ast/ast_node.hpp
@@ -53,7 +53,7 @@ public:
      * "For nothing is hidden that will not be made manifest, nor is anything
      * secret that will not be known and come to light." — Luke 8:17
      */
-    virtual std::string toString() const { return typeid(*this).name(); }
+    virtual std::string toString() const { return utils::cleanTypeIdName(typeid(*this).name()); }
 };
 
 /**

--- a/src/jesus/ast/expr/expr.hpp
+++ b/src/jesus/ast/expr/expr.hpp
@@ -88,5 +88,5 @@ public:
      * "For nothing is hidden that will not be made manifest, nor is anything
      * secret that will not be known and come to light." — Luke 8:17
      */
-    virtual std::string toString() const { return "Expr"; }
+    virtual std::string toString() const { return utils::cleanTypeIdName(typeid(*this).name()); }
 };

--- a/src/jesus/ast/expr/index_expr.cpp
+++ b/src/jesus/ast/expr/index_expr.cpp
@@ -2,6 +2,7 @@
 #include "interpreter/expr_visitor.hpp"
 #include "types/known_types.hpp"
 #include "interpreter/interpreter.hpp"
+#include "types/composite/list_type.hpp"
 
 Value IndexExpr::accept(ExprVisitor &visitor) const
 {
@@ -10,6 +11,11 @@ Value IndexExpr::accept(ExprVisitor &visitor) const
 
 std::shared_ptr<CreationType> IndexExpr::getReturnType(ParserContext &ctx) const
 {
+    auto type = list->getReturnType(ctx);
+
+    if (auto listType = std::dynamic_pointer_cast<ListType>(type))
+        return listType->elementType;
+
     return KnownTypes::CREATION;
 };
 

--- a/src/jesus/ast/expr/list_expr.cpp
+++ b/src/jesus/ast/expr/list_expr.cpp
@@ -1,6 +1,5 @@
 #include "list_expr.hpp"
 #include "interpreter/expr_visitor.hpp"
-#include "types/known_types.hpp"
 
 Value ListExpr::accept(ExprVisitor &visitor) const
 {
@@ -9,5 +8,5 @@ Value ListExpr::accept(ExprVisitor &visitor) const
 
 std::shared_ptr<CreationType> ListExpr::getReturnType(ParserContext &ctx) const
 {
-    return KnownTypes::LIST;
+    return listType;
 };

--- a/src/jesus/ast/expr/list_expr.hpp
+++ b/src/jesus/ast/expr/list_expr.hpp
@@ -15,9 +15,10 @@ class ListExpr : public Expr
 {
 public:
     std::vector<std::unique_ptr<Expr>> elements;
+    std::shared_ptr<CreationType> listType;
 
-    ListExpr(std::vector<std::unique_ptr<Expr>> elements)
-        : elements(std::move(elements)) {}
+    ListExpr(std::vector<std::unique_ptr<Expr>> elements, std::shared_ptr<CreationType> listType)
+        : elements(std::move(elements)), listType(listType) {}
 
     Value evaluate(std::shared_ptr<Heart> scope) const override
     {

--- a/src/jesus/parser/grammar/expr/collection/list_rule.cpp
+++ b/src/jesus/parser/grammar/expr/collection/list_rule.cpp
@@ -1,6 +1,7 @@
 #include "list_rule.hpp"
 #include "ast/expr/list_expr.hpp"
 #include "ast/stmt/incomplete_block_stmt.hpp"
+#include "types/known_types.hpp"
 
 std::unique_ptr<Expr> ListRule::parse(ParserContext &ctx)
 {
@@ -8,6 +9,7 @@ std::unique_ptr<Expr> ListRule::parse(ParserContext &ctx)
         return nullptr;
 
     std::vector<std::unique_ptr<Expr>> elements;
+    std::shared_ptr<CreationType> elementType = nullptr;
 
     ctx.consumeAllNewLines();
 
@@ -23,9 +25,46 @@ std::unique_ptr<Expr> ListRule::parse(ParserContext &ctx)
                 throw std::runtime_error("Expected value inside list.");
             }
 
+            auto currentType = value->getReturnType(ctx);
             elements.push_back(std::move(value));
 
             ctx.consumeAllNewLines();
+
+            /*
+             * ------------------------------------------------------------
+             * List type inference
+             * ------------------------------------------------------------
+             *
+             * Lists infer their element type automatically during parsing.
+             *
+             * Rules:
+             *
+             *   []                  -> list<creation>
+             *   [1, 2, 3]           -> list<int>
+             *   ['a', 'b']          -> list<text>
+             *   [user1, user2]      -> list<User>
+             *   [1, 'abc']          -> list<creation>
+             *
+             * Inference strategy:
+             *
+             * - The first element defines the initial list type.
+             * - If all elements share the same type, the list keeps that type.
+             * - If a different type appears, the list falls back to `creation`.
+             *
+             * This allows Python/JavaScript-like list syntax while preserving
+             * strong typing whenever possible.
+             * ------------------------------------------------------------
+             */
+            if (!elementType)
+            {
+                elementType = currentType;
+            }
+            else if (
+                elementType != KnownTypes::CREATION &&
+                currentType != elementType)
+            {
+                elementType = KnownTypes::CREATION;
+            }
 
         } while (ctx.match(TokenType::COMMA));
     }
@@ -35,5 +74,11 @@ std::unique_ptr<Expr> ListRule::parse(ParserContext &ctx)
         throw std::runtime_error("Expected ']' to close list.");
     }
 
-    return std::make_unique<ListExpr>(std::move(elements));
+    // Empty list defaults to creation
+    if (!elementType)
+        elementType = KnownTypes::CREATION;
+
+    auto listType = KnownTypes::makeListType(elementType);
+
+    return std::make_unique<ListExpr>(std::move(elements), listType);
 }

--- a/src/jesus/parser/grammar/expr/postfix/get_attr_rule.cpp
+++ b/src/jesus/parser/grammar/expr/postfix/get_attr_rule.cpp
@@ -1,6 +1,5 @@
 #include "get_attr_rule.hpp"
 #include "ast/expr/get_attr_expr.hpp"
-#include "ast/expr/variable_expr.hpp"
 #include "ast/expr/method_call_expr.hpp"
 #include "ast/expr/index_expr.hpp"
 #include "types/creation_type.hpp"
@@ -56,9 +55,7 @@ std::unique_ptr<Expr> GetAttributeRule::parse(ParserContext &ctx)
             // ----------------------------
             // Resolve attribute or method
             // ----------------------------
-            if (auto varExpr = dynamic_cast<VariableExpr *>(expr.get()))
-            {
-                std::shared_ptr<CreationType> klass = ctx.getVarType(varExpr->name);
+                std::shared_ptr<CreationType> klass = expr->getReturnType(ctx);
                 std::string name = ctx.previous().lexeme;
 
                 auto member = klass->findMember(name, klass);
@@ -103,11 +100,6 @@ std::unique_ptr<Expr> GetAttributeRule::parse(ParserContext &ctx)
                 {
                     throw std::runtime_error("Unknown member '" + name + "' in class " + klass->name);
                 }
-            }
-            else
-            {
-                throw std::runtime_error("Cannot access member on this expression: '" + expr->toString() + "'");
-            }
 
             continue;
         }

--- a/src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
@@ -127,6 +127,11 @@ std::unique_ptr<Stmt> CreateVarStmtRule::parse(ParserContext &ctx)
             throw std::runtime_error("Invalid value " + value_str + " for variable '" + varName + "' declared as type " + varType->name);
         }
 
+        if (varType->isA(KnownTypes::LIST))
+        {
+            varType = valueType;
+        }
+
         ctx.registerVarType(varType, varName);
     }
 

--- a/src/jesus/tests/repl/040-many-tests.jesus
+++ b/src/jesus/tests/repl/040-many-tests.jesus
@@ -468,3 +468,7 @@ l[2]
 l['index']
 l[1] = 'Marcos'
 l
+
+create list deep = [[isaac]]
+deep[0][0] surname = 'Hijo'
+say deep

--- a/src/jesus/tests/repl/040-many-tests.jesus.expected
+++ b/src/jesus/tests/repl/040-many-tests.jesus.expected
@@ -307,7 +307,7 @@ null
 (Jesus) (Jesus) Inside try-repent.
 Pleas forgive my sins, Oh God Almighty.
 God always wins.
-(Jesus) (Jesus) 15CreateClassStmt
+(Jesus) (Jesus) CreateClassStmt
 AST Memory: 8 bytes
 (Jesus) (Jesus) Class name 'Alien' does not appear to reflect God's standards.
 To hide this warning, declare the class explicitly as 'ungodly'.
@@ -342,4 +342,13 @@ It has 3 elements (valid indexes: 0 to 2).
 (Jesus) Luke
 (Jesus) ❌ Error: Index must be an integer. Got 'text' instead.
 (Jesus) (Jesus) [Matt, Marcos, Luke]
+(Jesus) (Jesus) (Jesus) (Jesus) [[{type: "instance",
+ class: "Son",
+ attributes: {
+  surname: "Terahson",
+  name: "Jacob"
+
+  surname: "Hijo"
+ }
+}]]
 (Jesus) 

--- a/src/jesus/types/composite/list_type.hpp
+++ b/src/jesus/types/composite/list_type.hpp
@@ -10,8 +10,8 @@ class ListType : public CreationType
 public:
     std::shared_ptr<CreationType> elementType;
 
-    ListType(std::shared_ptr<CreationType> elementType, std::shared_ptr<CreationType> parent)
-        : CreationType(PrimitiveType::Collection, "list", "core", parent),
+    ListType(std::shared_ptr<CreationType> elementType, std::shared_ptr<CreationType> parent, std::string name = "list")
+        : CreationType(PrimitiveType::Collection, name, "core", parent),
           elementType(elementType) {}
 
     bool validate(const Value &value) const override

--- a/src/jesus/types/known_types.cpp
+++ b/src/jesus/types/known_types.cpp
@@ -147,6 +147,21 @@ std::string KnownTypes::makeKey(const std::string &module_name, const std::strin
     return module_name + "." + name;
 }
 
+std::shared_ptr<CreationType> KnownTypes::makeListType(const std::shared_ptr<CreationType> &elementType)
+{
+    auto name = "list<" + elementType->name + ">";
+    auto listType = std::make_shared<ListType>(elementType, KnownTypes::LIST, name);
+
+    auto registeredType = KnownTypes::resolve(listType->name, listType->module_name);
+    if (!registeredType) {
+        registeredType = listType;
+        KnownTypes::registerType(listType);
+
+    }
+
+    return registeredType;
+}
+
 std::string KnownTypes::toString()
 {
     std::ostringstream out;

--- a/src/jesus/types/known_types.hpp
+++ b/src/jesus/types/known_types.hpp
@@ -51,6 +51,8 @@ public:
     inline static std::shared_ptr<CreationType> LIST;
     // -------------------------------------------------------------------
 
+    static std::shared_ptr<CreationType> makeListType(const std::shared_ptr<CreationType>& elementType);
+
     static std::string toString();
 
 private:

--- a/src/jesus/utils/string_utils.hpp
+++ b/src/jesus/utils/string_utils.hpp
@@ -101,4 +101,24 @@ namespace utils
     }
 
     void replaceAll(std::string &text, const std::string &search, const std::string &replacement);
+
+    /**
+     * @brief Cleans compiler RTTI names returned by `typeid(...).name()`.
+     *
+     * Example:
+     *   "8ListExpr" -> "ListExpr"
+     *   "13Route53Expr" -> "Route53Expr"
+     *
+     * "For God is not a God of confusion but of peace."
+     * — 1 Corinthians 14:33
+     */
+    inline std::string cleanTypeIdName(const std::string &name)
+    {
+        size_t pos = 0;
+
+        while (pos < name.size() && std::isdigit(static_cast<unsigned char>(name[pos])))
+            ++pos;
+
+        return name.substr(pos);
+    }
 }


### PR DESCRIPTION
# Description

This PR adds parse-time list element type inference.

`ListExpr` now stores its inferred list type:

    std::shared_ptr<CreationType> listType;

Instead of resolving element types repeatedly during lookup/index access,
the parser determines the most specific list type when the list is created.

This improves type propagation for nested indexing while keeping lookup
operations simpler and cheaper at runtime.

### Inference Rules

    []              -> list<creation>
    [1, 2, 3]       -> list<int>
    ['a', 'b']      -> list<text>
    [user1, user2]  -> list<User>
    [1, 'abc']      -> list<creation>

If all elements share the same type, the list adopts that type.

If mixed element types are detected, the list falls back to `list<creation>`.

### Nested Indexing

This PR also enables proper nested type propagation through chained
`IndexExpr` access.

Example:

    create list users = [[user1]]

    users[0][0] name = 'Noah'

Nested indexing now preserves the underlying creation type instead of
falling back to generic `creation`.

### Internal Changes

- Added `listType` to `ListExpr`
- Added `KnownTypes::makeListType(...)`
- Added parse-time element type inference in `ListRule`
- Updated `IndexExpr::getReturnType(...)` to propagate nested types

## Motivation

Lookup/index operations happen far more frequently than list creation.

By inferring the list type once during parsing, runtime access becomes
simpler and avoids repeated type inspection during every indexed lookup.

# ✝️ Wisdom

> “That which is born of the flesh is flesh. That which is born of the Spirit is spirit."  — **_John 3:6_**

