### PR TITLE
Step 80: feat(native-methods):  Laid foundation for built-in methods with NativeMethod, and added built-in list.add method. Ref #76, #77, #79.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ set(JESUS_CPP_FILES
     # ----------------------
     src/jesus/types/creation_type.cpp
     src/jesus/types/known_types.cpp
+    src/jesus/types/composite/list_type.cpp
 
     # ---------------
     # AST Expressions

--- a/src/jesus/ast/expr/expr.hpp
+++ b/src/jesus/ast/expr/expr.hpp
@@ -35,6 +35,12 @@ class Expr
 
 public:
     explicit Expr(ExprKind kind = ExprKind::Other) : kind(kind) {}
+
+    virtual void validate(ParserContext &ctx) const
+    {
+        throw std::runtime_error(utils::cleanTypeIdName(typeid(*this).name()) + ".validate() not implemented.");
+    };
+
     /**
      * @brief Evaluates the expression and returns a Value.
      *

--- a/src/jesus/ast/expr/method_call_expr.cpp
+++ b/src/jesus/ast/expr/method_call_expr.cpp
@@ -11,3 +11,60 @@ std::shared_ptr<CreationType> MethodCallExpr::getReturnType(ParserContext &ctx) 
 {
     return method->getReturnType(ctx);
 };
+
+bool MethodCallExpr::isArgumentAssignable(const std::shared_ptr<CreationType> &paramType, const std::shared_ptr<CreationType> &argType) const
+{
+    if (!paramType || !argType)
+        return false;
+
+    if (argType->isA(paramType) || paramType->isCompatibleWith(argType))
+        return true;
+
+    if (argType->isPolymorphic() && argType->parent_class->isA(paramType))
+        return true;
+
+    return false;
+}
+
+void MethodCallExpr::validate(ParserContext &ctx) const
+{
+    const auto &paramNames = method->params->getVariableNames();
+
+    if (args.size() != paramNames.size())
+    {
+        std::string message =
+            "Method '" + method->name +
+            "' expects " + std::to_string(paramNames.size()) +
+            " argument(s), but got " + std::to_string(args.size()) + ".";
+
+        if (args.size() < paramNames.size())
+        {
+            message += "\n\nMissing parameter(s):";
+
+            for (size_t i = args.size(); i < paramNames.size(); ++i)
+            {
+                auto paramType = method->params->getVarType(paramNames[i]);
+                message += "\n - " + paramNames[i] + ": " + paramType->name;
+            }
+        }
+
+        throw std::runtime_error(message);
+    }
+
+    for (size_t i = 0; i < args.size(); ++i)
+    {
+        auto argType = args[i]->getReturnType(ctx);
+
+        auto paramType =
+            method->params->getVarType(paramNames[i]);
+
+        if (!isArgumentAssignable(paramType, argType))
+        {
+            throw std::runtime_error(
+                "Argument '" + paramNames[i] +
+                "' for method '" + method->name +
+                "' expects type '" + paramType->name +
+                "', but got '" + argType->name + "'.");
+        }
+    }
+}

--- a/src/jesus/ast/expr/method_call_expr.hpp
+++ b/src/jesus/ast/expr/method_call_expr.hpp
@@ -2,7 +2,7 @@
 
 #include "expr.hpp"
 
-class Method; // Forward declaration
+class IMethod; // Forward declaration
 
 REGISTER_FOR_UML(
     MethodCallExpr,
@@ -14,12 +14,12 @@ class MethodCallExpr : public Expr
 {
 public:
     std::unique_ptr<Expr> object;
-    std::shared_ptr<Method> method;
+    std::shared_ptr<IMethod> method;
     std::vector<std::unique_ptr<Expr>> args;
 
     MethodCallExpr(
         std::unique_ptr<Expr> object,
-        std::shared_ptr<Method> method,
+        std::shared_ptr<IMethod> method,
         std::vector<std::unique_ptr<Expr>> args)
         : object(std::move(object)), method(std::move(method)), args(std::move(args))
     {
@@ -28,6 +28,8 @@ public:
             throw std::runtime_error("Method cannot be empty!");
         }
     }
+
+    void validate(ParserContext &ctx) const override;
 
     /**
      * @brief Return the 'object' that contains the 'method' to be called
@@ -46,4 +48,9 @@ public:
      * "Flesh gives birth to flesh, but the Spirit gives birth to spirit." — John 3:6
      */
     std::shared_ptr<CreationType> getReturnType(ParserContext &ctx) const override;
+
+private:
+    bool isArgumentAssignable(
+        const std::shared_ptr<CreationType> &paramType,
+        const std::shared_ptr<CreationType> &argType) const;
 };

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -95,14 +95,14 @@ Value Interpreter::visitMethodCallExpr(const MethodCallExpr &expr)
 {
     Value object = expr.object->accept(*this);
 
-    std::shared_ptr<Instance> instance = object.toInstance();
     std::vector<Value> args;
+    args.reserve(expr.args.size());
 
     // Evaluate all arguments
     for (auto &argExpr : expr.args)
         args.push_back(argExpr->accept(*this));
 
-    return expr.method->call(*this, instance, std::move(args));
+    return expr.method->call(*this, object, args);
 }
 
 Value Interpreter::visitFormattedStringExpr(const FormattedStringExpr &expr)

--- a/src/jesus/interpreter/runtime/method.cpp
+++ b/src/jesus/interpreter/runtime/method.cpp
@@ -2,8 +2,10 @@
 #include "method.hpp"
 #include "../interpreter.hpp"
 
-Value Method::call(Interpreter &interpreter, std::shared_ptr<Instance> instance, const std::vector<Value> args)
+Value Method::call(Interpreter &interpreter, Value &object, const std::vector<Value> &args)
 {
+    std::shared_ptr<Instance> instance = object.toInstance();
+
     // 1. Create the method 'params' scope for this call,
     // passing instance attributes as the parent attributes.
     auto paramsScope = params->clone("call-" + name, instance->attributes);
@@ -11,13 +13,7 @@ Value Method::call(Interpreter &interpreter, std::shared_ptr<Instance> instance,
     // Bind the actual 'arguments' to the 'param' names
     int index = 0;
     for (const auto &name : paramsScope->getVariableNames())
-    {
-        if (index < args.size())
-            paramsScope->updateVar(name, args[index++]);
-        else
-            // FIXME: speed it up: Validate params at parse time, not at rutime
-            throw std::runtime_error("Missing argument for parameter '" + name + "'");
-    }
+        paramsScope->updateVar(name, args[index++]);
 
     interpreter.addScope(paramsScope);
 

--- a/src/jesus/interpreter/runtime/method.hpp
+++ b/src/jesus/interpreter/runtime/method.hpp
@@ -5,45 +5,44 @@
 #include <memory>
 #include "../../ast/stmt/stmt.hpp"
 #include "../../spirit/return_signal.hpp"
+#include "../../spirit/heart.hpp"
 #include "../../types/creation_type.hpp"
 #include "instance.hpp"
 
 class Interpreter; // Forward declaration
+class ParserContext;
+
+REGISTER_FOR_UML(
+    IMethod,
+    .packageName("interpreter.runtime")
+        .fieldsList({"name", "params", "returnType"}));
 
 REGISTER_FOR_UML(
     Method,
     .packageName("interpreter.runtime")
-        .fieldsList({"name", "params", "body", "returnType"}));
+        .parentsList({"IMethod"})
+        .fieldsList({"body"}));
 
-class Method
+class IMethod
 {
 public:
     const std::string name;
     const std::shared_ptr<Heart> params;
-    const std::vector<std::shared_ptr<Stmt>> body;
     const std::shared_ptr<CreationType> returnType;
 
-    Method(std::string name,
-           std::shared_ptr<Heart> params,
-           std::vector<std::shared_ptr<Stmt>> body,
-           std::shared_ptr<CreationType> returnType)
-        : name(std::move(name)), params(std::move(params)),
-          body(std::move(body)), returnType(std::move(returnType)) {}
+    virtual ~IMethod() = default;
 
-    Value call(Interpreter &interp, std::shared_ptr<Instance> instance, std::vector<Value> args);
+    virtual Value call(
+        Interpreter &interp,
+        Value &object,
+        const std::vector<Value> &args) = 0;
 
-    /**
-     * @brief Get the return type, so that variable
-     *  creation and update can be enforced at parse time.
-     *
-     * "Flesh gives birth to flesh, but the Spirit gives birth to spirit." — John 3:6
-     */
-    std::shared_ptr<CreationType> getReturnType(ParserContext &ctx)
+    virtual std::shared_ptr<CreationType> getReturnType(ParserContext &ctx)
     {
         return returnType;
     }
 
-    std::string toString()
+    virtual std::string toString() const
     {
         std::string str = "{type: \"method\",\n params: {";
         if (!params->isEmpty())
@@ -53,4 +52,28 @@ public:
         str += " }\n}";
         return str;
     }
+
+protected:
+    IMethod(
+        std::string name,
+        std::shared_ptr<Heart> params,
+        std::shared_ptr<CreationType> returnType)
+        : name(std::move(name)),
+          params(std::move(params)),
+          returnType(std::move(returnType)) {}
+};
+
+class Method : public IMethod
+{
+public:
+    const std::vector<std::shared_ptr<Stmt>> body;
+
+    Method(std::string name,
+           std::shared_ptr<Heart> params,
+           std::vector<std::shared_ptr<Stmt>> body,
+           std::shared_ptr<CreationType> returnType)
+        : IMethod(std::move(name), std::move(params), std::move(returnType)),
+          body(std::move(body)) {}
+
+    Value call(Interpreter &interp, Value &object, const std::vector<Value> &args) override;
 };

--- a/src/jesus/interpreter/runtime/native_method.hpp
+++ b/src/jesus/interpreter/runtime/native_method.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "method.hpp"
+#include <functional>
+
+REGISTER_FOR_UML(
+    NativeMethod,
+    .packageName("interpreter.runtime")
+        .parentsList({"IMethod"})
+        .fieldsList({"fn: NativeFn"}));
+
+using NativeFn = std::function<Value(Interpreter &, Value &obj, const std::vector<Value> &args)>;
+
+class NativeMethod : public IMethod
+{
+private:
+    NativeFn fn;
+
+public:
+    NativeMethod(
+        std::string name,
+        std::shared_ptr<Heart> params,
+        std::shared_ptr<CreationType> returnType,
+        NativeFn fn)
+        : IMethod(std::move(name), std::move(params), std::move(returnType)),
+          fn(std::move(fn)) {}
+
+    Value call(Interpreter &interp, Value &object, const std::vector<Value> &args) override
+    {
+        return fn(interp, object, args);
+    }
+};

--- a/src/jesus/parser/grammar/expr/postfix/get_attr_rule.cpp
+++ b/src/jesus/parser/grammar/expr/postfix/get_attr_rule.cpp
@@ -95,6 +95,7 @@ std::unique_ptr<Expr> GetAttributeRule::parse(ParserContext &ctx)
                     }
 
                     expr = std::make_unique<MethodCallExpr>(std::move(expr), member->method, std::move(args));
+                    expr->validate(ctx);
                 }
                 else
                 {

--- a/src/jesus/parser/helpers/member.hpp
+++ b/src/jesus/parser/helpers/member.hpp
@@ -2,7 +2,7 @@
 
 #include <string>
 
-class Method;       // Forward declaration
+class IMethod;      // Forward declaration
 class CreationType; // Forward declaration
 
 /**
@@ -16,13 +16,13 @@ class Member
 {
 public:
     const std::string attr_name;                         // non-empty if it’s an attribute
-    const std::shared_ptr<Method> method;                // non-null if it’s a method
+    const std::shared_ptr<IMethod> method;               // non-null if it’s a method
     const std::shared_ptr<CreationType> declaring_class; // who declared it
 
     Member(std::string attr, std::shared_ptr<CreationType> klass)
         : attr_name(std::move(attr)), declaring_class(std::move(klass)) {}
 
-    Member(std::shared_ptr<Method> method, std::shared_ptr<CreationType> klass)
+    Member(std::shared_ptr<IMethod> method, std::shared_ptr<CreationType> klass)
         : method(std::move(method)), declaring_class(std::move(klass)) {}
 
     bool isAttribute() const { return !attr_name.empty(); }

--- a/src/jesus/tests/list/list_add_bad_arity.jesus
+++ b/src/jesus/tests/list/list_add_bad_arity.jesus
@@ -1,0 +1,2 @@
+create list nums = [1]
+nums add 2, 3

--- a/src/jesus/tests/list/list_add_bad_arity.jesus.expected
+++ b/src/jesus/tests/list/list_add_bad_arity.jesus.expected
@@ -1,0 +1,1 @@
+Method 'add' expects 1 argument(s), but got 2.

--- a/src/jesus/tests/list/list_add_bad_type.jesus
+++ b/src/jesus/tests/list/list_add_bad_type.jesus
@@ -1,0 +1,3 @@
+create list nums = [1, 2]
+nums add "nope"
+nums add 3

--- a/src/jesus/tests/list/list_add_bad_type.jesus.expected
+++ b/src/jesus/tests/list/list_add_bad_type.jesus.expected
@@ -1,0 +1,1 @@
+Argument 'item' for method 'add' expects type 'number', but got 'text'.

--- a/src/jesus/tests/modules/routes.jesus.expected
+++ b/src/jesus/tests/modules/routes.jesus.expected
@@ -1,3 +1,2 @@
-(Jesus) (Jesus) 👉 Inside routes.jesus
-(Jesus) (Jesus) (Jesus) (Jesus) 👉 At end of routes.jesus
-(Jesus) 
+👉 Inside routes.jesus
+👉 At end of routes.jesus

--- a/src/jesus/tests/repl/040-many-tests.jesus.expected
+++ b/src/jesus/tests/repl/040-many-tests.jesus.expected
@@ -199,7 +199,11 @@ What is your age again (curent: (int) 33)? (Jesus) (double) 2025.000000
 }
 (Jesus) I am inside functionWithoutParams
 null
-(Jesus) ❌ Error: Missing argument for parameter 'a_'
+(Jesus) ❌ Error: Method 'aToB' expects 2 argument(s), but got 0.
+
+Missing parameter(s):
+ - a_: number
+ - b: number
 (Jesus) The new name is: 
 (Jesus) Adam
 (Jesus) a before

--- a/src/jesus/types/composite/list_type.cpp
+++ b/src/jesus/types/composite/list_type.cpp
@@ -1,0 +1,19 @@
+#include "list_type.hpp"
+#include "interpreter/runtime/native_method.hpp"
+#include "types/known_types.hpp"
+
+Value ListType::addItem(Interpreter &, Value &obj, const std::vector<Value> &args)
+{
+    obj.asList().push_back(std::make_shared<Value>(args[0])); // FIXME: Shouldn't args be already smart pointers?
+
+    return Value::formless();
+}
+
+void ListType::registerMethods()
+{
+    auto params = std::make_shared<Heart>("list.add");
+
+    params->createVar(elementType, "item", Value::formless());
+
+    addMethod("add", std::make_shared<NativeMethod>("add", params, KnownTypes::VOID, ListType::addItem));
+}

--- a/src/jesus/types/composite/list_type.hpp
+++ b/src/jesus/types/composite/list_type.hpp
@@ -2,6 +2,8 @@
 
 #include "../creation_type.hpp"
 
+class Interpreter; // Forward declaration
+
 /**
  * @brief Runtime representation of list<T>.
  */
@@ -12,7 +14,10 @@ public:
 
     ListType(std::shared_ptr<CreationType> elementType, std::shared_ptr<CreationType> parent, std::string name = "list")
         : CreationType(PrimitiveType::Collection, name, "core", parent),
-          elementType(elementType) {}
+          elementType(elementType)
+    {
+        registerMethods();
+    }
 
     bool validate(const Value &value) const override
     {
@@ -27,4 +32,9 @@ public:
 
         return true;
     }
+
+private:
+    void registerMethods();
+
+    static Value addItem(Interpreter &interp, Value &obj, const std::vector<Value> &args);
 };

--- a/src/jesus/types/creation_type.hpp
+++ b/src/jesus/types/creation_type.hpp
@@ -4,7 +4,7 @@
 #include "../ast/expr/expr.hpp"
 #include "constraints/constraint.hpp"
 
-class Method; // Forward declaration
+class IMethod; // Forward declaration
 class Member; // Forward declaration
 
 enum class PrimitiveType
@@ -45,7 +45,7 @@ public:
     std::shared_ptr<CreationType> parent_class = nullptr;
 
     std::shared_ptr<Heart> class_attributes = nullptr;
-    std::unordered_map<std::string, std::shared_ptr<Method>> methods;
+    std::unordered_map<std::string, std::shared_ptr<IMethod>> methods;
 
     CreationType(PrimitiveType primitive_type, std::string name, std::string module = "core",
                  std::shared_ptr<CreationType> parent = nullptr,
@@ -137,10 +137,11 @@ public:
         return class_attributes->getVar(name);
     }
 
-    void addMethod(const std::string &name, std::shared_ptr<Method> method)
+    void addMethod(const std::string &name, std::shared_ptr<IMethod> method)
     {
-        if (primitive_type != PrimitiveType::Class)
-            throw std::runtime_error("Only class types can have methods.");
+        if (primitive_type != PrimitiveType::Class &&
+            primitive_type != PrimitiveType::Collection)
+            throw std::runtime_error("Only class and collection types can have methods.");
 
         methods[name] = std::move(method);
     }


### PR DESCRIPTION
# Description

This PR introduces NativeMethod and adds the first built-in runtime method: `list.add`.

### Changes

- Added `IMethod` 
- Added `NativeMethod` that implements IMethod
- Added first built-in method: `list.add(item)`


The changes also include:
- type validation
- arity validation
- runtime insertion into internal list storage

### Example:

The following code: 
```jesus
create list ages = [10]

ages add 20

say ages
````

outputs:

> [(int) 10, (int) 20]

# Motivation

This PR lays the foundation for future native runtime capabilities such as:

* list.remove
* list.contains
* text methods
* maps/dictionaries
* iterators
* etc

# ✝️ Wisdom

> “**_By the grace God has given me, I have laid the foundation_** as a wise builder, and someone else is building on it. But each one should build with care.”
> — **1 Corinthians 3:10**

