### PR TITLE
Step 84: feat(foreach): Added foreach loops for lists and dict pairs. Ref #8, #76, #82.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,7 @@ set(JESUS_CPP_FILES
     src/jesus/parser/grammar/stmt/assign_stmt_rule.cpp
     src/jesus/parser/grammar/stmt/create_method_stmt_rule.cpp
     src/jesus/parser/grammar/stmt/repeat_stmt_rule.cpp
+    src/jesus/parser/grammar/stmt/foreach_stmt_rule.cpp
     src/jesus/parser/grammar/stmt/if_stmt_rule.cpp
     src/jesus/parser/grammar/stmt/resist_stmt_rule.cpp
     src/jesus/parser/grammar/stmt/try_stmt_rule.cpp

--- a/src/jesus/ast/stmt/for_each_stmt.hpp
+++ b/src/jesus/ast/stmt/for_each_stmt.hpp
@@ -19,14 +19,15 @@ REGISTER_FOR_UML(
 class ForEachStmt : public Stmt
 {
 public:
-    std::string varName;
+    std::vector<std::string> varNames;
     std::unique_ptr<Expr> iterable;
     std::vector<std::unique_ptr<Stmt>> body;
 
-    ForEachStmt(std::string varName,
-                std::unique_ptr<Expr> iterable,
-                std::vector<std::unique_ptr<Stmt>> body)
-        : varName(std::move(varName)),
+    ForEachStmt(
+        std::vector<std::string> varNames,
+        std::unique_ptr<Expr> iterable,
+        std::vector<std::unique_ptr<Stmt>> body)
+        : varNames(std::move(varNames)),
           iterable(std::move(iterable)),
           body(std::move(body)) {}
 

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -512,11 +512,38 @@ void Interpreter::visitForEach(const ForEachStmt &stmt)
 
     auto &items = listValue.asList();
 
+    currentModule->symbol_table->addScope(std::make_shared<Heart>("foreach"));
     for (const std::shared_ptr<Value> &value : items)
     {
+        // ----------------------
+        // foreach key in list...
+        // ----------------------
+        if (stmt.varNames.size() == 1)
+        {
+            updateVariable(stmt.varNames[0], *value);
+        }
+        // --------------------------------
+        // foreach key, value in dict.pairs
+        // --------------------------------
+        else if (stmt.varNames.size() == 2)
+        {
+            if (!value->IS_LIST)
+            {
+                // FIXME: Validate this at PARSE time, not runtime.
+                throw std::runtime_error("foreach key,value expects a list of pairs.");
+            }
 
-        // FIXME: Remove the line below.
-        // heart.createVar(stmt.varName, *value); // like "let name = item" // TODO: Use a pointer instead of *value
+            auto &pair = value->asList();
+
+            if (pair.size() != 2)
+            {
+                // FIXME: Validate this at PARSE time, not runtime.
+                throw std::runtime_error("foreach key,value expects pairs with exactly 2 values. Got '" +std::to_string(pair.size()) + "' values.");
+            }
+
+            updateVariable(stmt.varNames[0], *pair[0]);
+            updateVariable(stmt.varNames[1], *pair[1]);
+        }
 
         try
         {
@@ -534,6 +561,7 @@ void Interpreter::visitForEach(const ForEachStmt &stmt)
             break;
         }
     }
+    currentModule->symbol_table->popScope();
 }
 
 void Interpreter::visitBreak(const BreakStmt &)

--- a/src/jesus/lexer/keywords.hpp
+++ b/src/jesus/lexer/keywords.hpp
@@ -117,6 +117,9 @@ namespace Keywords
         {"forever", TokenType::FOREVER},
         {"sempre", TokenType::FOREVER},
 
+        {"foreach", TokenType::FOREACH},
+        {"in", TokenType::IN},
+
         {"otherwise", TokenType::OTHERWISE},
         {"senão", TokenType::OTHERWISE},
 

--- a/src/jesus/lexer/token_type.hpp
+++ b/src/jesus/lexer/token_type.hpp
@@ -87,6 +87,8 @@ enum class TokenType
     WHILE,          // repeat while count < 100: ... amen
     TIMES,          // repeat 3 `times`
     FOREVER,        // repeat forever: ... amen
+    FOREACH,        // foreach key in items: ... amen
+    IN,             // foreach key in items: ... amen
     SKIP,           // 'continue' in other languages.
     BREAK,          // loop break
 

--- a/src/jesus/parser/grammar/expr/postfix/get_attr_rule.cpp
+++ b/src/jesus/parser/grammar/expr/postfix/get_attr_rule.cpp
@@ -7,6 +7,7 @@
 #include "types/composite/dict_type.hpp"
 #include "parser/helpers/member.hpp"
 #include "parser/grammar/jesus_grammar.hpp"
+#include "interpreter/runtime/method.hpp"
 #include <memory>
 
 std::unique_ptr<Expr> GetAttributeRule::parse(ParserContext &ctx)
@@ -95,6 +96,8 @@ std::unique_ptr<Expr> GetAttributeRule::parse(ParserContext &ctx)
                     // If the next token(s) indicate arguments, parse them
                     if (!ctx.check(TokenType::NEWLINE) && !ctx.check(TokenType::END_OF_FILE))
                     {
+                        auto expectedParams = member->method->params->size();
+                        if (expectedParams > 0)
                         do
                         {
                             auto argExpr = primary->parse(ctx); // parse any expression

--- a/src/jesus/parser/grammar/jesus_grammar.hpp
+++ b/src/jesus/parser/grammar/jesus_grammar.hpp
@@ -39,6 +39,7 @@
 #include "stmt/update_var_stmt_rule.hpp"
 #include "stmt/assign_stmt_rule.hpp"
 #include "stmt/repeat_stmt_rule.hpp"
+#include "stmt/foreach_stmt_rule.hpp"
 #include "stmt/if_stmt_rule.hpp"
 #include "stmt/try_stmt_rule.hpp"
 #include "stmt/resist_stmt_rule.hpp"
@@ -117,6 +118,7 @@ namespace grammar
     inline auto CreateMethod = std::make_shared<CreateMethodStmtRule>(CreateVar, UpdateVar, Print);
     inline auto CreateClass = std::make_shared<CreateClassStmtRule>(CreateVar, CreateMethod);
     inline auto RepeatWhile = std::make_shared<RepeatStmtRule>();
+    inline auto Foreach = std::make_shared<ForEachStmtRule>();
     inline auto IfStmt = std::make_shared<IfStmtRule>();
     inline auto TryStmt = std::make_shared<TryStmtRule>();
     inline auto ResistStmt = std::make_shared<ResistStmtRule>();

--- a/src/jesus/parser/grammar/stmt/foreach_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/foreach_stmt_rule.cpp
@@ -1,0 +1,146 @@
+#include "foreach_stmt_rule.hpp"
+#include "update_var_stmt_rule.hpp"
+#include "ast/stmt/update_var_stmt.hpp"
+#include "ast/stmt/update_var_with_ask_stmt.hpp"
+#include "ast/stmt/for_each_stmt.hpp"
+#include "ast/stmt/skip_stmt.hpp"
+#include "ast/stmt/break_stmt.hpp"
+#include "ast/stmt/incomplete_block_stmt.hpp"
+#include "parser/grammar/jesus_grammar.hpp"
+#include "types/known_types.hpp"
+#include "types/composite/list_type.hpp"
+#include <stdexcept>
+
+class IncompleteBlockStmtSignal : public std::exception
+{
+public:
+    const char *what() const noexcept override
+    {
+        return "Incomplete block detected (waiting for more input)";
+    }
+};
+
+std::unique_ptr<Stmt> ForEachStmtRule::parse(ParserContext &ctx)
+{
+    // --------------------------------
+    // Step 1: Must start with 'foreach'
+    // --------------------------------
+    if (!ctx.match(TokenType::FOREACH))
+        return nullptr;
+
+    if (!ctx.match(TokenType::IDENTIFIER))
+        throw std::runtime_error("Expected variable name after 'foreach'. ");
+
+    std::vector<std::string> varNames;
+    varNames.push_back(ctx.previous().lexeme);
+
+    while (ctx.match(TokenType::COMMA))
+    {
+        if (!ctx.match(TokenType::IDENTIFIER))
+        {
+            throw std::runtime_error("Expected variable name after ','.");
+        }
+
+        varNames.push_back(ctx.previous().lexeme);
+    }
+
+    if (varNames.size() > 2)
+        throw std::runtime_error("foreach supports at most two variables.");
+
+    if (!ctx.match(TokenType::IN))
+        throw std::runtime_error("Expected 'in' after variable name.");
+
+    auto iterable = grammar::Expression->parse(ctx);
+    if (!iterable)
+    {
+        throw std::runtime_error("Expected iterable expression after 'in'.");
+    }
+
+    if (!ctx.match(TokenType::COLON))
+        throw std::runtime_error("Expected ':' after foreach statement.");
+
+    auto iterableType = iterable->getReturnType(ctx);
+    if (!iterableType->isA(KnownTypes::LIST))
+        throw std::runtime_error("Expected a list after 'foreach key in'. Got '" + iterableType->name + "' instead.");
+
+    auto listType = std::dynamic_pointer_cast<ListType>(iterableType);
+
+    auto elementType = listType->elementType;
+
+    auto foreachScope = std::make_shared<Heart>("foreach." + varNames[0]);
+    if (varNames.size() == 1)
+    {
+        foreachScope->createVar(elementType, varNames[0], Value::formless());
+    }
+    else
+    {
+        auto innerListType = std::dynamic_pointer_cast<ListType>(listType->elementType);
+
+        if (!innerListType)
+        {
+            throw std::runtime_error(
+                "foreach key,value requires a list of pairs. "
+                "The iterable element type is '" +
+                listType->elementType->name + "'.");
+        }
+
+        foreachScope->createVar(innerListType->elementType, varNames[0], Value::formless());
+        foreachScope->createVar(innerListType->elementType, varNames[1], Value::formless());
+    }
+
+    // ----------
+    // Parse body
+    // ----------
+    ctx.addScope(foreachScope); // <🟢️>
+    std::vector<std::unique_ptr<Stmt>> body;
+    try
+    {
+        body = parseBody(ctx);
+    }
+    catch (const IncompleteBlockStmtSignal &)
+    {
+        return std::make_unique<IncompleteBlockStmt>();
+    }
+    ctx.popScope(); // </🟢️>
+
+    return std::make_unique<ForEachStmt>(std::move(varNames), std::move(iterable), std::move(body));
+}
+
+std::vector<std::unique_ptr<Stmt>> ForEachStmtRule::parseBody(ParserContext &ctx)
+{
+    // FIXME: This code is repeated inside RepeatStmtRule
+    std::vector<std::unique_ptr<Stmt>> body;
+    ctx.consumeAllNewLines();
+
+    while (!ctx.check(TokenType::AMEN) && !ctx.isAtEnd())
+    {
+        if (auto stmt = grammar::Print->parse(ctx))
+            body.push_back(std::move(stmt));
+        else if (auto stmt = grammar::CreateVar->parse(ctx))
+            body.push_back(std::move(stmt));
+        else if (auto stmt = grammar::UpdateVar->parse(ctx))
+            body.push_back(std::move(stmt));
+        else if (auto stmt = grammar::IfStmt->parse(ctx))
+            body.push_back(std::move(stmt));
+        else if (ctx.match(TokenType::SKIP))
+            body.push_back(std::make_unique<SkipStmt>());
+        else if (ctx.match(TokenType::BREAK))
+            body.push_back(std::make_unique<BreakStmt>());
+        else
+            throw std::runtime_error("Unexpected statement inside foreach block.");
+
+        ctx.consumeAllNewLines();
+    }
+
+    if (ctx.isAtEnd())
+    {
+        // FIXME: Each time an IncompleteBlockStmt is returned, all code is parsed again. Too expensive.
+        // Why not just keep from where it stopped, remembering what was already in the `body` vector?
+        throw IncompleteBlockStmtSignal{};
+    }
+
+    if (!ctx.match(TokenType::AMEN))
+        throw std::runtime_error("Expected 'amen' to close foreach block.");
+
+    return body;
+}

--- a/src/jesus/parser/grammar/stmt/foreach_stmt_rule.hpp
+++ b/src/jesus/parser/grammar/stmt/foreach_stmt_rule.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "ast/stmt/stmt.hpp"
+#include "parser/parser_context.hpp"
+
+/**
+ * @brief Parser for 'foreach' statements
+ *
+ * foreach key in items_list: amen
+ * foreach key, value in dict_items.pairs(): amen
+ */
+
+class ForEachStmtRule
+{
+public:
+    std::unique_ptr<Stmt> parse(ParserContext &ctx);
+
+private:
+    void consumeColon(ParserContext &ctx);
+
+    std::vector<std::unique_ptr<Stmt>> parseBody(ParserContext &ctx);
+};

--- a/src/jesus/parser/grammar/stmt/if_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/if_stmt_rule.cpp
@@ -1,13 +1,13 @@
 #include "if_stmt_rule.hpp"
-#include "../../../ast/stmt/if_stmt.hpp"
-#include "../../../ast/stmt/update_var_stmt.hpp"
-#include "../../../ast/stmt/update_var_with_ask_stmt.hpp"
-#include "../../../ast/stmt/repeat_while_stmt.hpp"
-#include "../../../ast/stmt/repeat_times_stmt.hpp"
-#include "../../../ast/stmt/repeat_forever_stmt.hpp"
-#include "../../../ast/stmt/skip_stmt.hpp"
-#include "../../../ast/stmt/break_stmt.hpp"
-#include "../../../ast/stmt/incomplete_block_stmt.hpp"
+#include "ast/stmt/if_stmt.hpp"
+#include "ast/stmt/update_var_stmt.hpp"
+#include "ast/stmt/update_var_with_ask_stmt.hpp"
+#include "ast/stmt/repeat_while_stmt.hpp"
+#include "ast/stmt/repeat_times_stmt.hpp"
+#include "ast/stmt/repeat_forever_stmt.hpp"
+#include "ast/stmt/skip_stmt.hpp"
+#include "ast/stmt/break_stmt.hpp"
+#include "ast/stmt/incomplete_block_stmt.hpp"
 #include "../jesus_grammar.hpp"
 #include <stdexcept>
 
@@ -56,6 +56,8 @@ std::unique_ptr<Stmt> IfStmtRule::parse(ParserContext &ctx)
             thenBranch.push_back(std::move(stmt));
         else if (auto stmt = grammar::RepeatWhile->parse(ctx))
             thenBranch.push_back(std::move(stmt));
+        else if (auto stmt = grammar::Foreach->parse(ctx))
+            thenBranch.push_back(std::move(stmt));
         else if (auto stmt = grammar::ResistStmt->parse(ctx))
             thenBranch.push_back(std::move(stmt));
         else if (ctx.match(TokenType::SKIP))
@@ -88,6 +90,8 @@ std::unique_ptr<Stmt> IfStmtRule::parse(ParserContext &ctx)
                 otherwiseBranch.push_back(std::move(stmt));
             else if (auto stmt = grammar::RepeatWhile->parse(ctx))
                 otherwiseBranch.push_back(std::move(stmt));
+            else if (auto stmt = grammar::Foreach->parse(ctx))
+                thenBranch.push_back(std::move(stmt));
             else if (auto stmt = grammar::ResistStmt->parse(ctx))
                 otherwiseBranch.push_back(std::move(stmt));
             else if (ctx.match(TokenType::SKIP))

--- a/src/jesus/parser/parser.cpp
+++ b/src/jesus/parser/parser.cpp
@@ -51,6 +51,9 @@ std::unique_ptr<Stmt> parse(const std::vector<Token> &tokens, ParserContext &con
     if (repeatWhileStmt)
         return repeatWhileStmt;
 
+    if (auto stmt = grammar::Foreach->parse(context))
+        return stmt;
+
     context.restore(snapshot);
     auto ifStmt = grammar::IfStmt->parse(context);
     if (ifStmt)

--- a/src/jesus/spirit/heart.hpp
+++ b/src/jesus/spirit/heart.hpp
@@ -133,6 +133,11 @@ public:
         return variables.empty();
     }
 
+    bool size() const
+    {
+        return variables.size();
+    }
+
     void registerVarType(const VarType &type, const std::string &name)
     {
         semantics_analyzer->registerVarType(type, name);

--- a/src/jesus/tests/dict/dict_remove_bad_arity.jesus
+++ b/src/jesus/tests/dict/dict_remove_bad_arity.jesus
@@ -1,0 +1,3 @@
+create dict d = {"name": "Paul"}
+
+d remove

--- a/src/jesus/tests/dict/dict_remove_bad_arity.jesus.expected
+++ b/src/jesus/tests/dict/dict_remove_bad_arity.jesus.expected
@@ -1,0 +1,4 @@
+Method 'remove' expects 1 argument(s), but got 0.
+
+Missing parameter(s):
+ - key: creation

--- a/src/jesus/tests/dict/dict_remove_twice.jesus
+++ b/src/jesus/tests/dict/dict_remove_twice.jesus
@@ -1,0 +1,4 @@
+create dict d = {"name": "Paul"}
+
+say d remove "name"
+say d remove "name"

--- a/src/jesus/tests/dict/dict_remove_twice.jesus.expected
+++ b/src/jesus/tests/dict/dict_remove_twice.jesus.expected
@@ -1,0 +1,2 @@
+(logic) 1
+(logic) 0

--- a/src/jesus/tests/repl/040-many-tests.jesus
+++ b/src/jesus/tests/repl/040-many-tests.jesus
@@ -472,3 +472,14 @@ l
 create list deep = [[isaac]]
 deep[0][0] surname = 'Hijo'
 say deep
+
+foreach disciple in l:
+    say "Apostle {disciple}"
+amen
+say disciple # FIXME: should fail, since disciple is inside 'foreach' only.
+
+create dict d = {"name": "Jesus", 'surname': 'Christ', "role": "Savior"}
+foreach key, value in d pairs:
+  say "{key} -> {value}"
+amen
+say value # FIXME: should fail, since 'value' is inside 'foreach' only.

--- a/src/jesus/tests/repl/040-many-tests.jesus.expected
+++ b/src/jesus/tests/repl/040-many-tests.jesus.expected
@@ -355,4 +355,12 @@ It has 3 elements (valid indexes: 0 to 2).
   surname: "Hijo"
  }
 }]]
+(Jesus) (Jesus) Apostle Matt
+Apostle Marcos
+Apostle Luke
+(Jesus) Luke
+(Jesus) (Jesus) (Jesus) name -> Jesus
+surname -> Christ
+role -> Savior
+(Jesus) Savior
 (Jesus) 

--- a/src/jesus/types/composite/dict_type.cpp
+++ b/src/jesus/types/composite/dict_type.cpp
@@ -68,7 +68,9 @@ void DictType::registerMethods()
     // --------
     {
         auto params = std::make_shared<Heart>("dict.pairs");
-        addMethod("pairs", std::make_shared<NativeMethod>("pairs", params, KnownTypes::LIST, DictType::pairs));
+        auto keysReturnType = KnownTypes::makeListType(keyType); // FIXME: Assuming key and value has the same type. Using dict<str, int> would fail. Introduce PairType.
+        auto pairsReturnType = KnownTypes::makeListType(keysReturnType);
+        addMethod("pairs", std::make_shared<NativeMethod>("pairs", params, pairsReturnType, DictType::pairs));
     }
 
     // ------

--- a/src/jesus/types/known_types.cpp
+++ b/src/jesus/types/known_types.cpp
@@ -38,7 +38,6 @@ void KnownTypes::registerBuiltInTypes()
     auto module = std::make_shared<ModuleType>(creation);
     auto exception = std::make_shared<ItsWritten>(klass);
     auto list = std::make_shared<ListType>(creation, creation);
-    auto dict = std::make_shared<DictType>(creation, creation, creation);
 
     BOOLEAN = TRUTH = truth;
     CREATION = creation;
@@ -55,6 +54,9 @@ void KnownTypes::registerBuiltInTypes()
     CLASS = klass;
     EXCEPTION = exception;
     LIST = list;
+
+    // dict refers to LIST, so, it comes AFTER 'LIST = list'
+    auto dict = std::make_shared<DictType>(creation, creation, creation);
     DICT = dict;
 
     registerType(truth);


### PR DESCRIPTION
# Description

This PR introduces support for _`foreach`_ loops in the Jesus language.

Users can now iterate over **lists** and **dictionary pairs** using a simple and expressive syntax.

## Examples

### List iteration

```
create list disciples = ["Peter", "James", "John"]

foreach disciple in disciples:
    say disciple
amen
```

Output:

> Peter
> James
> John

### Dictionary pair iteration

```jesus

create dict d = {
    "name": "Jesus",
    "surname": "Christ",
    "role": "Savior"
}

foreach key, value in d pairs:
    say "{key} -> {value}"
amen
```

Output:

> name -> Jesus
> surname -> Christ
> role -> Savior

# ✝️ Widsom

> "The unfolding of your words gives light;
> it gives understanding to the simple." — **_Psalm 119:130_**
