### PR TITLE
Step 85: feat(benchmarking): Added tests/benchmark/zoo.jesus for interpreter performance tracking.

### DIFF
--- a/src/jesus/ast/expr/method_call_expr.cpp
+++ b/src/jesus/ast/expr/method_call_expr.cpp
@@ -1,10 +1,16 @@
 #include "method_call_expr.hpp"
-#include "../../interpreter/expr_visitor.hpp"
-#include "../../interpreter/runtime/method.hpp"
+#include "interpreter/expr_visitor.hpp"
+#include "interpreter/interpreter.hpp"
+#include "interpreter/runtime/method.hpp"
 
 Value MethodCallExpr::accept(ExprVisitor &visitor) const
 {
     return visitor.visitMethodCallExpr(*this);
+}
+
+Value MethodCallExpr::evaluate(std::shared_ptr<Heart> heart) const
+{
+    return interpreter->visitMethodCallExpr(*this);
 }
 
 std::shared_ptr<CreationType> MethodCallExpr::getReturnType(ParserContext &ctx) const

--- a/src/jesus/ast/expr/method_call_expr.hpp
+++ b/src/jesus/ast/expr/method_call_expr.hpp
@@ -3,6 +3,7 @@
 #include "expr.hpp"
 
 class IMethod; // Forward declaration
+class Interpreter; // Forward declaration
 
 REGISTER_FOR_UML(
     MethodCallExpr,
@@ -16,12 +17,13 @@ public:
     std::unique_ptr<Expr> object;
     std::shared_ptr<IMethod> method;
     std::vector<std::unique_ptr<Expr>> args;
+    Interpreter *interpreter = nullptr;
 
     MethodCallExpr(
         std::unique_ptr<Expr> object,
         std::shared_ptr<IMethod> method,
-        std::vector<std::unique_ptr<Expr>> args)
-        : object(std::move(object)), method(std::move(method)), args(std::move(args))
+        std::vector<std::unique_ptr<Expr>> args, Interpreter *interpreter_)
+        : object(std::move(object)), method(std::move(method)), args(std::move(args)), interpreter(interpreter_)
     {
         if (this->method == nullptr)
         {
@@ -32,12 +34,9 @@ public:
     void validate(ParserContext &ctx) const override;
 
     /**
-     * @brief Return the 'object' that contains the 'method' to be called
+     * @brief Calls the method and returns its value: return object.method(args)
      */
-    Value evaluate(std::shared_ptr<Heart> heart) const override
-    {
-        return object->evaluate(heart);
-    }
+    Value evaluate(std::shared_ptr<Heart> heart) const override;
 
     Value accept(ExprVisitor &visitor) const override;
 

--- a/src/jesus/interpreter/interpreter.hpp
+++ b/src/jesus/interpreter/interpreter.hpp
@@ -226,7 +226,9 @@ private:
 
     Value visitParityCheckExpr(const ParityCheckExpr &expr) override;
 
+    public:
     Value visitMethodCallExpr(const MethodCallExpr &expr) override;
+    private:
 
     Value visitFormattedStringExpr(const FormattedStringExpr &expr) override;
 

--- a/src/jesus/parser/grammar/expr/postfix/get_attr_rule.cpp
+++ b/src/jesus/parser/grammar/expr/postfix/get_attr_rule.cpp
@@ -110,7 +110,7 @@ std::unique_ptr<Expr> GetAttributeRule::parse(ParserContext &ctx)
                         } while (ctx.match(TokenType::COMMA));
                     }
 
-                    expr = std::make_unique<MethodCallExpr>(std::move(expr), member->method, std::move(args));
+                    expr = std::make_unique<MethodCallExpr>(std::move(expr), member->method, std::move(args), ctx.interpreter);
                     expr->validate(ctx);
                 }
                 else

--- a/src/jesus/tests/benchmark/zoo.jesus
+++ b/src/jesus/tests/benchmark/zoo.jesus
@@ -1,0 +1,61 @@
+# Benchmark: zoo.jesus
+# Workload: sum < 10000000
+# Adapted from: https://github.com/munificent/craftinginterpreters/blob/master/test/benchmark/zoo.lox
+
+# C++:              0.014823 s
+# PHP 8.3:          0.168236 s
+# Clox:             0.249795 s
+# Python 3.12.3:    0.444851 s
+#
+# Jesus
+#   AST [2a29564]:  64.455000 s
+#   VM:
+#   JIT:
+#
+# Machine:
+#   CPU: AMD Ryzen 7 5825U with Radeon Graphics
+#   Cores: 8 physical / 16 logical
+#   RAM: 32 GB
+#   OS: Ubuntu 24.04.4 LTS
+
+let there be Zoo:
+    create number aarvark = 1
+    create number baboon = 1
+    create number cat = 1
+    create number donkey = 1
+    create number elephant = 1
+    create number fox = 1
+
+    purpose ant() -> number:
+        return aarvark
+    amen
+
+    purpose banana() -> number:
+        return baboon
+    amen
+
+    purpose tuna() -> number:
+        return cat
+    amen
+
+    purpose hay() -> number:
+        return donkey
+    amen
+
+    purpose grass() -> number:
+        return elephant
+    amen
+
+    purpose mouse() -> number:
+        return fox
+    amen
+amen
+
+create Zoo zoo = 1
+create number sum = 0
+
+repeat while sum < 10000000:
+    sum = sum + zoo ant + zoo banana  + zoo tuna  + zoo hay  + zoo grass  + zoo mouse
+amen
+
+say sum


### PR DESCRIPTION
# Description

This PR introduces the first interpreter benchmark for the Jesus language and fixes an issue where method calls inside expressions were not evaluated correctly.

## Changes

### Fixed method calls in expressions

Method calls now evaluate correctly in arithmetic expressions like the one below:

```jesus
sum = zoo ant + zoo banana + zoo tuna
```

Previously, method call evaluation could return the object instance instead of the method result, causing incorrect behavior when expressions combined multiple method calls.

### Added zoo.jesus benchmark

Added `tests/benchmark/zoo.jesus`, adapted from the `zoo.lox` benchmark used in **Crafting Interpreters** book (https://github.com/munificent/craftinginterpreters/).

The benchmark exercises:

* Object instantiation
* Method dispatch
* Integer arithmetic
* Variable assignment
* Loop execution

This benchmark establishes a performance baseline for future VM and JIT implementations.

## Motivation

Before introducing bytecode and JIT compilation, it is important to have a reproducible benchmark that can be used to measure progress over time.

Current measurements are recorded together with machine specifications and commit hashes, allowing performance regressions and improvements to be tracked across interpreter, VM, and JIT milestones.

## Benchmark Source

Adapted from:

- https://github.com/munificent/craftinginterpreters/blob/master/test/benchmark/zoo.lox

Original benchmark from Crafting Interpreters by Robert Nystrom.

# ✝️ Widsom

> "Test everything; hold fast what is good." — **1 Thessalonians 5:21**
"For which of you, desiring to build a tower, does not first sit down and count the cost?" — **Luke 14:28**
