### PR TITLE
Step 88: feat(vm): Added binary arithmetic expressions and global variable support. Ref #4.

### DIFF
--- a/src/jesus/understanding/inspection/bytecode_inspector.cpp
+++ b/src/jesus/understanding/inspection/bytecode_inspector.cpp
@@ -14,17 +14,17 @@ void BytecodeInspector::inspect(Interpreter &jesus, const InspectStmt &)
     {
         auto const &instr = chunk.instructions[i];
 
-        const auto &value = chunk.constants[instr.operand];
+        const auto &value = chunk.literals[instr.operand];
 
         std::cout << i << ": ";
 
         switch (instr.opcode)
         {
-        case OpCode::LOAD_CONST:
+        case OpCode::PUSH_LITERAL:
         case OpCode::JUMP:
         case OpCode::JUMP_IF_FALSE:
 
-            std::cout << opcodeToString(instr.opcode) << " const[" << instr.operand << "] -> " << value.toString() << "\n";
+            std::cout << opcodeToString(instr.opcode) << " [" << instr.operand << "] = " << value.toString() << "\n";
             break;
 
         default:

--- a/src/jesus/vm/chunk.hpp
+++ b/src/jesus/vm/chunk.hpp
@@ -18,25 +18,25 @@
  *
  *     say 10 + 20
  *
- * Constants table:
+ * Literals table:
  *
  *     0 -> 10
  *     1 -> 20
  *
  * Bytecode instructions:
  *
- *     LOAD_CONST 0
- *     LOAD_CONST 1
+ *     PUSH_LITERAL 0
+ *     PUSH_LITERAL 1
  *     ADD
  *     PRINT
  *     RETURN
  *
  * The VM executes instructions stored in `code`
- * and loads literal values from `constants`.
+ * and loads literal values from `literals`.
  */
 class Chunk
 {
 public:
     std::vector<Instruction> instructions;
-    std::vector<Value> constants;
+    std::vector<Value> literals;
 };

--- a/src/jesus/vm/compiler.cpp
+++ b/src/jesus/vm/compiler.cpp
@@ -3,7 +3,7 @@
 Chunk Compiler::compile(const std::vector<std::unique_ptr<Stmt>> &statements)
 {
     chunk.instructions.clear();
-    chunk.constants.clear();
+    chunk.literals.clear();
 
     for (const auto &stmt : statements)
     {
@@ -20,6 +20,12 @@ void Compiler::compileStmt(const Stmt &stmt)
     if (auto print = dynamic_cast<const PrintStmt *>(&stmt))
     {
         compilePrintStmt(*print);
+        return;
+    }
+
+    if (auto create_var = dynamic_cast<const CreateVarStmt *>(&stmt))
+    {
+        compileCreateVarStmt(*create_var);
         return;
     }
 
@@ -78,14 +84,14 @@ void Compiler::compileLiteralExpr(const LiteralExpr &expr)
 {
     uint32_t constantIndex = addConstant(expr.value);
 
-    emit(OpCode::LOAD_CONST, constantIndex);
+    emit(OpCode::PUSH_LITERAL, constantIndex);
 }
 
 uint32_t Compiler::addConstant(const Value &value)
 {
-    chunk.constants.push_back(value);
+    chunk.literals.push_back(value);
 
-    return static_cast<uint32_t>(chunk.constants.size() - 1);
+    return static_cast<uint32_t>(chunk.literals.size() - 1);
 }
 
 void Compiler::emit(OpCode opcode)
@@ -96,4 +102,25 @@ void Compiler::emit(OpCode opcode)
 void Compiler::emit(OpCode opcode, uint32_t operand)
 {
     chunk.instructions.push_back({opcode, operand});
+}
+
+uint32_t Compiler::registerGlobalVar(const std::string &name)
+{
+    auto it = globals.find(name);
+
+    if (it != globals.end())
+        return it->second;
+
+    uint32_t index = globals.size();
+    globals[name] = index;
+    return index;
+}
+
+void Compiler::compileCreateVarStmt(const CreateVarStmt &stmt)
+{
+    compileExpr(*stmt.value);
+
+    uint32_t index = registerGlobalVar(stmt.name);
+
+    emit(OpCode::CREATE_GLOBAL, index);
 }

--- a/src/jesus/vm/compiler.cpp
+++ b/src/jesus/vm/compiler.cpp
@@ -29,6 +29,12 @@ void Compiler::compileStmt(const Stmt &stmt)
         return;
     }
 
+    if (auto update_var = dynamic_cast<const UpdateVarStmt *>(&stmt))
+    {
+        compileUpdateVarStmt(*update_var);
+        return;
+    }
+
     throw std::runtime_error("Statement not supported by VM yet: " + stmt.toString());
 }
 
@@ -146,4 +152,13 @@ void Compiler::compileVariableExpr(const VariableExpr &expr)
     uint32_t index = getGlobalVar(expr.name);
 
     emit(OpCode::READ_GLOBAL, index);
+}
+
+void Compiler::compileUpdateVarStmt(const UpdateVarStmt &stmt)
+{
+    compileExpr(*stmt.value);
+
+    uint32_t index = getGlobalVar(stmt.name);
+
+    emit(OpCode::WRITE_GLOBAL, index);
 }

--- a/src/jesus/vm/compiler.cpp
+++ b/src/jesus/vm/compiler.cpp
@@ -53,6 +53,12 @@ void Compiler::compileExpr(const Expr &expr)
         return;
     }
 
+    if (auto var = dynamic_cast<const VariableExpr *>(&expr))
+    {
+        compileVariableExpr(*var);
+        return;
+    }
+
     throw std::runtime_error("Expression not supported by VM yet: " + expr.toString());
 }
 
@@ -123,4 +129,21 @@ void Compiler::compileCreateVarStmt(const CreateVarStmt &stmt)
     uint32_t index = registerGlobalVar(stmt.name);
 
     emit(OpCode::CREATE_GLOBAL, index);
+}
+
+uint32_t Compiler::getGlobalVar(const std::string &name)
+{
+    auto it = globals.find(name);
+
+    if (it == globals.end())
+        throw std::runtime_error("Unknown global variable: " + name);
+
+    return it->second;
+}
+
+void Compiler::compileVariableExpr(const VariableExpr &expr)
+{
+    uint32_t index = getGlobalVar(expr.name);
+
+    emit(OpCode::READ_GLOBAL, index);
 }

--- a/src/jesus/vm/compiler.cpp
+++ b/src/jesus/vm/compiler.cpp
@@ -41,7 +41,37 @@ void Compiler::compileExpr(const Expr &expr)
         return;
     }
 
+    if (auto binary = dynamic_cast<const BinaryExpr *>(&expr))
+    {
+        compileBinaryExpr(*binary);
+        return;
+    }
+
     throw std::runtime_error("Expression not supported by VM yet: " + expr.toString());
+}
+
+void Compiler::compileBinaryExpr(const BinaryExpr &expr)
+{
+    compileExpr(*expr.left);
+    compileExpr(*expr.right);
+
+    switch (expr.op.type)
+    {
+    case TokenType::PLUS:
+        emit(OpCode::ADD);
+        break;
+    case TokenType::MINUS:
+        emit(OpCode::SUBTRACT);
+        break;
+    case TokenType::STAR:
+        emit(OpCode::MULTIPLY);
+        break;
+    case TokenType::SLASH:
+        emit(OpCode::DIVIDE);
+        break;
+    default:
+        throw std::runtime_error("Binary operator not supported by VM yet: " + expr.op.lexeme);
+    }
 }
 
 void Compiler::compileLiteralExpr(const LiteralExpr &expr)

--- a/src/jesus/vm/compiler.hpp
+++ b/src/jesus/vm/compiler.hpp
@@ -5,6 +5,7 @@
 #include "ast/expr/binary_expr.hpp"
 #include "ast/expr/literal_expr.hpp"
 
+#include "ast/stmt/create_var_stmt.hpp"
 #include "ast/stmt/print_stmt.hpp"
 
 /**
@@ -52,8 +53,8 @@
  *
  *     Instructions:
  *
- *         LOAD_CONST 0
- *         LOAD_CONST 1
+ *         PUSH_LITERAL 0
+ *         PUSH_LITERAL 1
  *         ADD
  *         PRINT
  *         RETURN
@@ -76,6 +77,7 @@ public:
 
 private:
     Chunk chunk;
+    std::unordered_map<std::string, uint32_t> globals;
 
     void compileStmt(const Stmt &stmt);
 
@@ -102,4 +104,7 @@ private:
      *  Operand: 3
      */
     void emit(OpCode opcode, uint32_t operand);
+
+    uint32_t registerGlobalVar(const std::string &name);
+    void compileCreateVarStmt(const CreateVarStmt &stmt);
 };

--- a/src/jesus/vm/compiler.hpp
+++ b/src/jesus/vm/compiler.hpp
@@ -2,6 +2,7 @@
 
 #include "chunk.hpp"
 
+#include "ast/expr/binary_expr.hpp"
 #include "ast/expr/literal_expr.hpp"
 
 #include "ast/stmt/print_stmt.hpp"
@@ -81,6 +82,8 @@ private:
     void compileExpr(const Expr &expr);
 
     void compileLiteralExpr(const LiteralExpr &expr);
+
+    void compileBinaryExpr(const BinaryExpr &expr);
 
     void compilePrintStmt(const PrintStmt &stmt);
 

--- a/src/jesus/vm/compiler.hpp
+++ b/src/jesus/vm/compiler.hpp
@@ -4,6 +4,7 @@
 
 #include "ast/expr/binary_expr.hpp"
 #include "ast/expr/literal_expr.hpp"
+#include "ast/expr/variable_expr.hpp"
 
 #include "ast/stmt/create_var_stmt.hpp"
 #include "ast/stmt/print_stmt.hpp"
@@ -107,4 +108,7 @@ private:
 
     uint32_t registerGlobalVar(const std::string &name);
     void compileCreateVarStmt(const CreateVarStmt &stmt);
+
+    uint32_t getGlobalVar(const std::string &name);
+    void compileVariableExpr(const VariableExpr &expr);
 };

--- a/src/jesus/vm/compiler.hpp
+++ b/src/jesus/vm/compiler.hpp
@@ -7,6 +7,7 @@
 #include "ast/expr/variable_expr.hpp"
 
 #include "ast/stmt/create_var_stmt.hpp"
+#include "ast/stmt/update_var_stmt.hpp"
 #include "ast/stmt/print_stmt.hpp"
 
 /**
@@ -108,7 +109,8 @@ private:
 
     uint32_t registerGlobalVar(const std::string &name);
     void compileCreateVarStmt(const CreateVarStmt &stmt);
-
     uint32_t getGlobalVar(const std::string &name);
     void compileVariableExpr(const VariableExpr &expr);
+    void compileUpdateVarStmt(const UpdateVarStmt& stmt);
+
 };

--- a/src/jesus/vm/instruction.hpp
+++ b/src/jesus/vm/instruction.hpp
@@ -14,17 +14,17 @@
  *
  * Examples:
  *
- *     LOAD_CONST 3
- *     LOAD_CONST 7
+ *     PUSH_LITERAL 3
+ *     PUSH_LITERAL 7
  *     ADD
  *     PRINT
  *
  * In the examples above:
  *
- *     Opcode: LOAD_CONST
+ *     Opcode: PUSH_LITERAL
  *     Operand: 3
  *
- *     Opcode: LOAD_CONST
+ *     Opcode: PUSH_LITERAL
  *     Operand: 7
  *
  *     Opcode: ADD
@@ -36,7 +36,7 @@
  * Operands are interpreted according to the opcode.
  *
  * For example:
- *     LOAD_CONST 3
+ *     PUSH_LITERAL 3
  *
  * means:
  *     Load constants[3] onto the VM stack.
@@ -65,8 +65,8 @@ struct Instruction
      *
      * Examples:
      *
-     *     LOAD_CONST 5
-     *                ^
+     *     PUSH_LITERAL 5
+     *                  ^
      *                operand
      *
      *     JUMP 12

--- a/src/jesus/vm/opcode.cpp
+++ b/src/jesus/vm/opcode.cpp
@@ -16,14 +16,14 @@ std::string opcodeToString(OpCode opcode)
     case OpCode::ADD:
         return "ADD";
 
-    case OpCode::SUB:
-        return "SUB";
+    case OpCode::SUBTRACT:
+        return "SUBTRACT";
 
-    case OpCode::MUL:
-        return "MUL";
+    case OpCode::MULTIPLY:
+        return "MULTIPLY";
 
-    case OpCode::DIV:
-        return "DIV";
+    case OpCode::DIVIDE:
+        return "DIVIDE";
 
     case OpCode::PRINT:
         return "PRINT";

--- a/src/jesus/vm/opcode.cpp
+++ b/src/jesus/vm/opcode.cpp
@@ -4,14 +4,17 @@ std::string opcodeToString(OpCode opcode)
 {
     switch (opcode)
     {
-    case OpCode::LOAD_CONST:
-        return "LOAD_CONST";
+    case OpCode::PUSH_LITERAL:
+        return "PUSH_LITERAL";
 
-    case OpCode::LOAD_GLOBAL:
-        return "LOAD_GLOBAL";
+    case OpCode::CREATE_GLOBAL:
+        return "CREATE_GLOBAL";
 
-    case OpCode::STORE_GLOBAL:
-        return "STORE_GLOBAL";
+    case OpCode::READ_GLOBAL:
+        return "READ_GLOBAL";
+
+    case OpCode::WRITE_GLOBAL:
+        return "WRITE_GLOBAL";
 
     case OpCode::ADD:
         return "ADD";

--- a/src/jesus/vm/opcode.hpp
+++ b/src/jesus/vm/opcode.hpp
@@ -26,9 +26,9 @@ enum class OpCode : uint8_t
     STORE_GLOBAL,
 
     ADD,
-    SUB,
-    MUL,
-    DIV,
+    SUBTRACT,
+    MULTIPLY,
+    DIVIDE,
 
     PRINT,
 

--- a/src/jesus/vm/opcode.hpp
+++ b/src/jesus/vm/opcode.hpp
@@ -11,8 +11,8 @@
  *
  * Example:
  *
- *     LOAD_CONST
- *     LOAD_CONST
+ *     PUSH_LITERAL
+ *     PUSH_LITERAL
  *     ADD
  *     PRINT
  *
@@ -21,9 +21,10 @@
  */
 enum class OpCode : uint8_t
 {
-    LOAD_CONST,
-    LOAD_GLOBAL,
-    STORE_GLOBAL,
+    PUSH_LITERAL,
+    CREATE_GLOBAL,
+    READ_GLOBAL,
+    WRITE_GLOBAL,
 
     ADD,
     SUBTRACT,

--- a/src/jesus/vm/vm.cpp
+++ b/src/jesus/vm/vm.cpp
@@ -29,6 +29,38 @@ void VM::run(const Chunk &chunk)
             break;
         }
 
+        case OpCode::ADD:
+        case OpCode::SUBTRACT:
+        case OpCode::MULTIPLY:
+        case OpCode::DIVIDE:
+        {
+            Value right = stack.back();
+            stack.pop_back();
+            Value left = stack.back();
+            stack.pop_back();
+
+            switch (ip->opcode)
+            {
+            case OpCode::ADD:
+                stack.push_back(left + right);
+                break;
+            case OpCode::SUBTRACT:
+                stack.push_back(left - right);
+                break;
+            case OpCode::MULTIPLY:
+                stack.push_back(left * right);
+                break;
+            case OpCode::DIVIDE:
+                stack.push_back(left / right);
+                break;
+            default:
+                break;
+            }
+
+            ++ip;
+            break;
+        }
+
         case OpCode::RETURN:
         {
             return;

--- a/src/jesus/vm/vm.cpp
+++ b/src/jesus/vm/vm.cpp
@@ -87,6 +87,18 @@ void VM::run(const Chunk &chunk)
             break;
         }
 
+        case OpCode::WRITE_GLOBAL:
+        {
+            uint32_t index = ip->operand;
+            Value value = stack.back();
+
+            stack.pop_back();
+            globals[index] = value;
+
+            ++ip;
+            break;
+        }
+
         case OpCode::RETURN:
         {
             return;

--- a/src/jesus/vm/vm.cpp
+++ b/src/jesus/vm/vm.cpp
@@ -77,6 +77,16 @@ void VM::run(const Chunk &chunk)
             break;
         }
 
+        case OpCode::READ_GLOBAL:
+        {
+            uint32_t index = ip->operand;
+
+            stack.push_back(globals[index]);
+
+            ++ip;
+            break;
+        }
+
         case OpCode::RETURN:
         {
             return;

--- a/src/jesus/vm/vm.cpp
+++ b/src/jesus/vm/vm.cpp
@@ -12,9 +12,9 @@ void VM::run(const Chunk &chunk)
     {
         switch (ip->opcode)
         {
-        case OpCode::LOAD_CONST:
+        case OpCode::PUSH_LITERAL:
         {
-            stack.push_back(chunk.constants[ip->operand]);
+            stack.push_back(chunk.literals[ip->operand]);
 
             ++ip;
             break;
@@ -56,6 +56,22 @@ void VM::run(const Chunk &chunk)
             default:
                 break;
             }
+
+            ++ip;
+            break;
+        }
+
+        case OpCode::CREATE_GLOBAL:
+        {
+            Value value = stack.back();
+            stack.pop_back();
+
+            uint32_t index = ip->operand;
+
+            if (index >= globals.size())
+                globals.resize(index + 1);
+
+            globals[index] = value;
 
             ++ip;
             break;

--- a/src/jesus/vm/vm.hpp
+++ b/src/jesus/vm/vm.hpp
@@ -21,8 +21,8 @@
  *
  * Example:
  *
- *     LOAD_CONST 1
- *     LOAD_CONST 2
+ *     PUSH_LITERAL 1
+ *     PUSH_LITERAL 2
  *     ADD
  *
  * Execution:
@@ -55,6 +55,7 @@ private:
      * Instructions push and pop values from this stack.
      */
     std::vector<Value> stack;
+    std::vector<Value> globals;
 
 public:
     /**


### PR DESCRIPTION
# Description 

This PR expands the Jesus bytecode compiler and VM, adding support for binary arithmetic expressions.

### Added

#### Arithmetic Expressions

Added compilation and execution support for binary arithmetic expressions:

* Addition (`+`)
* Subtraction (`-`)
* Multiplication (`*`)
* Division (`/`)

Example:

```
say 7 + 8 * 2 - 4 / 3
```

#### Global Variable Creation

Added support for creating global variables:

```
create number age = 33
```

#### Global Variable Reads

Added support for loading previously defined variables:

```
create number age = 77
say age
```

#### Global Variable Updates

Added support for updating existing variables:

```
create number age = 1
age = 5
```

### Compiler

Added compilation support for:

* `BinaryExpr`
* `CreateVarStmt`
* `VariableExpr`
* `UpdateVarStmt`

### Result

The VM can now:

* Evaluate arithmetic expressions
* Create variables
* Read variables
* Update variables

### Example

```
create number age = 33
age = age + 7
say age
```

Output:

```
(int) 40
```

# ✝️ Wisdom

> "Do not be conformed to this world, but be transformed by the renewing of your mind." — **Romans 12:2**

