### PR TITLE
Step 90: feat(vm-control-flow): Added comparison operators and repeat-while loop support. Ref #5 and #44.

### DIFF
--- a/src/jesus/understanding/inspection/bytecode_inspector.cpp
+++ b/src/jesus/understanding/inspection/bytecode_inspector.cpp
@@ -1,7 +1,48 @@
+#include <iomanip>
 #include "bytecode_inspector.hpp"
 #include "ast/stmt/inspect_stmt.hpp"
 #include "interpreter/interpreter.hpp"
 #include "vm/compiler.hpp"
+#include "utils/terminal/color.hpp"
+#include "utils/terminal/terminal.hpp"
+
+std::string style(std::string text, const char *color, bool bold = false)
+{
+    std::string out;
+
+    if (bold)
+        out += terminal::color::bold;
+
+    out += color;
+    out += text;
+    out += terminal::color::reset;
+
+    return out;
+}
+
+std::string maybeBold(std::string text)
+{
+    if (terminal::supportsColor())
+        return style(text, "", true);
+
+    return text;
+}
+
+std::string maybeRed(std::string text)
+{
+    if (terminal::supportsColor())
+        return style(text, terminal::color::red, true);
+
+    return text;
+}
+
+std::string maybeGreen(std::string text)
+{
+    if (terminal::supportsColor())
+        return style(text, terminal::color::green, true);
+
+    return text;
+}
 
 void BytecodeInspector::inspect(Interpreter &jesus, const InspectStmt &)
 {
@@ -14,22 +55,59 @@ void BytecodeInspector::inspect(Interpreter &jesus, const InspectStmt &)
     {
         auto const &instr = chunk.instructions[i];
 
-        const auto &value = chunk.literals[instr.operand];
+        auto raw_opcode = opcodeToString(instr.opcode);
+        std::ostringstream oss;
+        oss << std::right << std::setw(14) << raw_opcode;
+        std::string padded_opcode = oss.str();
 
-        std::cout << i << ": ";
+        std::string opcode_str = padded_opcode;
+
+        switch (instr.opcode)
+        {
+        case OpCode::JUMP:
+            opcode_str = maybeGreen(padded_opcode);
+            break;
+        case OpCode::JUMP_IF_FALSE:
+            opcode_str = maybeRed(padded_opcode);
+            break;
+        case OpCode::RETURN:
+            opcode_str = maybeBold(padded_opcode);
+            break;
+
+        default:
+            break;
+        }
+
+        std::cout << std::setw(4) << i << ": " << opcode_str;
 
         switch (instr.opcode)
         {
         case OpCode::PUSH_LITERAL:
-        case OpCode::JUMP:
-        case OpCode::JUMP_IF_FALSE:
-
-            std::cout << opcodeToString(instr.opcode) << " [" << instr.operand << "] = " << value.toString() << "\n";
-            break;
-
-        default:
-            std::cout << opcodeToString(instr.opcode) << "\n";
+        {
+            const auto &value = chunk.literals[instr.operand];
+            std::cout << " const[" << instr.operand << "] = " << value.toString();
             break;
         }
+
+        case OpCode::READ_GLOBAL:
+        case OpCode::WRITE_GLOBAL:
+        case OpCode::CREATE_GLOBAL:
+        {
+            std::cout << " vars[" << instr.operand << "]";
+            break;
+        }
+
+        case OpCode::JUMP:
+        case OpCode::JUMP_IF_FALSE:
+        {
+            std::cout << " -> " << instr.operand;
+            break;
+        }
+
+        default:
+            break;
+        }
+
+        std::cout << "\n";
     }
 }

--- a/src/jesus/vm/compiler.cpp
+++ b/src/jesus/vm/compiler.cpp
@@ -35,6 +35,12 @@ void Compiler::compileStmt(const Stmt &stmt)
         return;
     }
 
+    if (auto repeat_while = dynamic_cast<const RepeatWhileStmt *>(&stmt))
+    {
+        compileRepeatWhileStmt(*repeat_while);
+        return;
+    }
+
     throw std::runtime_error("Statement not supported by VM yet: " + stmt.toString());
 }
 
@@ -194,4 +200,41 @@ void Compiler::compileUpdateVarStmt(const UpdateVarStmt &stmt)
     uint32_t index = getGlobalVar(stmt.name);
 
     emit(OpCode::WRITE_GLOBAL, index);
+}
+
+uint32_t Compiler::currentOffset() const
+{
+    return chunk.instructions.size();
+}
+
+uint32_t Compiler::emitPlaceholder(OpCode opcode)
+{
+    uint32_t index = chunk.instructions.size();
+
+    emit(opcode, 0);
+
+    return index;
+}
+
+void Compiler::patchJump(uint32_t instructionIndex)
+{
+    chunk.instructions[instructionIndex].operand = chunk.instructions.size();
+}
+
+void Compiler::compileRepeatWhileStmt(const RepeatWhileStmt &stmt)
+{
+    uint32_t loopStart = currentOffset();
+
+    compileExpr(*stmt.condition);
+
+    uint32_t jumpOut = emitPlaceholder(OpCode::JUMP_IF_FALSE);
+
+    for (const auto &bodyStmt : stmt.body)
+    {
+        compileStmt(*bodyStmt);
+    }
+
+    emit(OpCode::JUMP, loopStart);
+
+    patchJump(jumpOut);
 }

--- a/src/jesus/vm/compiler.cpp
+++ b/src/jesus/vm/compiler.cpp
@@ -87,6 +87,39 @@ void Compiler::compileBinaryExpr(const BinaryExpr &expr)
     case TokenType::SLASH:
         emit(OpCode::DIVIDE);
         break;
+    case TokenType::MOD:
+        emit(OpCode::MODULO);
+        break;
+
+    case TokenType::IS:
+        emit(OpCode::EQUAL);
+        break;
+    case TokenType::NOT_EQUAL:
+        emit(OpCode::NOT_EQUAL);
+        break;
+    case TokenType::LESS:
+        emit(OpCode::LESS);
+        break;
+    case TokenType::LESS_EQUAL:
+        emit(OpCode::LESS_EQUAL);
+        break;
+    case TokenType::GREATER:
+        emit(OpCode::GREATER);
+        break;
+    case TokenType::GREATER_EQUAL:
+        emit(OpCode::GREATER_EQUAL);
+        break;
+
+    case TokenType::OR:
+        emit(OpCode::OR);
+        break;
+    case TokenType::AND:
+        emit(OpCode::AND);
+        break;
+    case TokenType::VERSUS:
+        emit(OpCode::XOR);
+        break;
+
     default:
         throw std::runtime_error("Binary operator not supported by VM yet: " + expr.op.lexeme);
     }

--- a/src/jesus/vm/compiler.hpp
+++ b/src/jesus/vm/compiler.hpp
@@ -9,6 +9,7 @@
 #include "ast/stmt/create_var_stmt.hpp"
 #include "ast/stmt/update_var_stmt.hpp"
 #include "ast/stmt/print_stmt.hpp"
+#include "ast/stmt/repeat_while_stmt.hpp"
 
 /**
  * @brief Converts an Abstract Syntax Tree (AST) into bytecode.
@@ -111,6 +112,54 @@ private:
     void compileCreateVarStmt(const CreateVarStmt &stmt);
     uint32_t getGlobalVar(const std::string &name);
     void compileVariableExpr(const VariableExpr &expr);
-    void compileUpdateVarStmt(const UpdateVarStmt& stmt);
+    void compileUpdateVarStmt(const UpdateVarStmt &stmt);
 
+    /**
+     * Returns the current instruction index in the chunk.
+     *
+     * Used as a label for jumps and control flow targets.
+     *
+     * Meaning: Where am I in the bytecode stream?
+     */
+    uint32_t currentOffset() const;
+
+    /**
+     * @brief Emit an instruction whose operand will be patched later, like JUMP_IF_FALSE
+     *
+     * @param opcode the code to be emited
+     * @return uint32_t the instruction index
+     */
+    /**
+     * Emits a jump-like instruction with a temporary operand (0)
+     * that will be patched later once the target address is known.
+     *
+     * @param opcode the code to be emited, like JUMP_IF_FALSE
+     * @return uint32_t the instruction index so it can be patched.
+     */
+    uint32_t emitPlaceholder(OpCode opcode);
+
+    /**
+     * @brief Patches a previously emitted jump instruction with the current instruction position.
+     *
+     * @param instructionIndex the index of the instruction to be patched
+     */
+    void patchJump(uint32_t instructionIndex);
+
+    /**
+     * Compiles:
+     *
+     * repeat while condition:
+     *     body
+     * amen
+     *
+     * Control flow shape:
+     *
+     *  loopStart:
+     *     evaluate condition
+     *     if false → exit
+     *     body
+     *     jump loopStart
+     *  exit:
+     */
+    void compileRepeatWhileStmt(const RepeatWhileStmt &stmt);
 };

--- a/src/jesus/vm/opcode.cpp
+++ b/src/jesus/vm/opcode.cpp
@@ -28,6 +28,36 @@ std::string opcodeToString(OpCode opcode)
     case OpCode::DIVIDE:
         return "DIVIDE";
 
+    case OpCode::MODULO:
+        return "MODULO";
+
+    case OpCode::EQUAL:
+        return "EQUAL";
+
+    case OpCode::NOT_EQUAL:
+        return "NOT_EQUAL";
+
+    case OpCode::LESS:
+        return "LESS";
+
+    case OpCode::LESS_EQUAL:
+        return "LESS_EQUAL";
+
+    case OpCode::GREATER:
+        return "GREATER";
+
+    case OpCode::GREATER_EQUAL:
+        return "GREATER_EQUAL";
+
+    case OpCode::OR:
+        return "OR";
+
+    case OpCode::AND:
+        return "AND";
+
+    case OpCode::XOR:
+        return "XOR";
+
     case OpCode::PRINT:
         return "PRINT";
 

--- a/src/jesus/vm/opcode.hpp
+++ b/src/jesus/vm/opcode.hpp
@@ -30,6 +30,18 @@ enum class OpCode : uint8_t
     SUBTRACT,
     MULTIPLY,
     DIVIDE,
+    MODULO,
+
+    EQUAL,
+    NOT_EQUAL,
+    LESS,
+    LESS_EQUAL,
+    GREATER,
+    GREATER_EQUAL,
+
+    OR,
+    AND,
+    XOR,
 
     PRINT,
 

--- a/src/jesus/vm/vm.cpp
+++ b/src/jesus/vm/vm.cpp
@@ -33,6 +33,16 @@ void VM::run(const Chunk &chunk)
         case OpCode::SUBTRACT:
         case OpCode::MULTIPLY:
         case OpCode::DIVIDE:
+        case OpCode::MODULO:
+        case OpCode::EQUAL:
+        case OpCode::NOT_EQUAL:
+        case OpCode::LESS:
+        case OpCode::LESS_EQUAL:
+        case OpCode::GREATER:
+        case OpCode::GREATER_EQUAL:
+        case OpCode::OR:
+        case OpCode::AND:
+        case OpCode::XOR:
         {
             Value right = stack.back();
             stack.pop_back();
@@ -41,6 +51,9 @@ void VM::run(const Chunk &chunk)
 
             switch (ip->opcode)
             {
+            // ----------
+            // Arithmetic
+            // ----------
             case OpCode::ADD:
                 stack.push_back(left + right);
                 break;
@@ -53,6 +66,58 @@ void VM::run(const Chunk &chunk)
             case OpCode::DIVIDE:
                 stack.push_back(left / right);
                 break;
+            case OpCode::MODULO:
+                stack.push_back(left % right);
+                break;
+            // -----------------------
+            // Relational / Comparison
+            // -----------------------
+            case OpCode::EQUAL:
+                stack.push_back(Value(left == right));
+                break;
+            case OpCode::NOT_EQUAL:
+                stack.push_back(Value(left != right));
+                break;
+            case OpCode::LESS:
+                stack.push_back(Value(left < right));
+                break;
+            case OpCode::LESS_EQUAL:
+                stack.push_back(Value(left <= right));
+                break;
+            case OpCode::GREATER:
+                stack.push_back(Value(left > right));
+                break;
+            case OpCode::GREATER_EQUAL:
+                stack.push_back(Value(left >= right));
+                break;
+            // -----
+            // Logic
+            // -----
+            case OpCode::OR:
+                stack.push_back(left.AS_BOOLEAN ? left : right);
+                break;
+            case OpCode::AND:
+                stack.push_back(left.AS_BOOLEAN ? right : left);
+                break;
+
+            case OpCode::XOR:
+                if (left.IS_BOOLEAN && right.IS_BOOLEAN)
+                {
+                    // Logical XOR
+                    stack.push_back(Value(left.AS_BOOLEAN != right.AS_BOOLEAN));
+                    break;
+                }
+
+                if (left.IS_NUMBER && right.IS_NUMBER)
+                {
+                    // Bitwise XOR
+                    stack.push_back(Value(left.toInt() ^ right.toInt()));
+                    break;
+                }
+
+                stack.push_back(Value::formless()); // fallback if types mismatch
+                break;
+
             default:
                 break;
             }

--- a/src/jesus/vm/vm.cpp
+++ b/src/jesus/vm/vm.cpp
@@ -164,6 +164,32 @@ void VM::run(const Chunk &chunk)
             break;
         }
 
+        case OpCode::JUMP_IF_FALSE:
+        {
+            Value condition = stack.back();
+            stack.pop_back();
+
+            if (!condition.AS_BOOLEAN)
+            {
+                // false ? jump to end of the loop
+                ip = begin + ip->operand;
+            }
+            else
+            {
+                // true? execute the loop
+                ++ip;
+            }
+
+            break;
+        }
+
+        case OpCode::JUMP:
+        {
+            // Back to the beginning of the loop
+            ip = begin + ip->operand;
+            break;
+        }
+
         case OpCode::RETURN:
         {
             return;


### PR DESCRIPTION
# Description

This PR introduces foundational control-flow capabilities to the Jesus VM by enabling both **comparison/logical operations** and a **jump-based repeat-while loop execution model**.

This relates to PR #5 and PR #44.

##  What’s included

### Comparison & logical operations (VM + compiler)

Added support for:

* Equality / inequality
* Relational operators (`<`, `<=`, `>`, `>=`)
* Logical operators (`AND`, `OR`, `XOR`)
* Modulo operator

Example:

```jesus
say 10 < 20
say 5 mod 2
```

These operations are now evaluated directly in the VM using stack-based binary execution.

### Repeat-while loop (jump-based control flow)

Introduces bytecode-level loop execution using:

* `JUMP`
* `JUMP_IF_FALSE`

Example:

```jesus
create number age = 33

repeat while age > 3:
    age = age - 1
    say age
amen
```

The loop is compiled into a structured sequence of conditional jumps, enabling efficient repeated execution without AST interpretation at runtime.


# ✝️ Wisdom

> "For the Lord gives wisdom; from his mouth come knowledge and understanding." — **_Proverbs 2:6_**
> "Then Jesus told his disciples a parable to show them that they should **always pray** and not give up." — **_Luke 18:1_**

