### PR TITLE
Step 90: feat(vm-classes): Added instance creation support in the VM. Ref #31, #32.

### DIFF
--- a/src/jesus/ast/expr/create_instance_expr.hpp
+++ b/src/jesus/ast/expr/create_instance_expr.hpp
@@ -6,17 +6,18 @@ REGISTER_FOR_UML(
     CreateInstanceExpr,
     .packageName("ast.expr")
         .parentsList({"Expr"})
-        .fieldsList({"klass", "constructorArgs"}));
+        .fieldsList({"name", "klass", "constructorArgs"}));
 
 class CreateInstanceExpr : public Expr
 {
 public:
+    const std::string name;
     const std::shared_ptr<CreationType> klass;
     std::unique_ptr<Expr> constructorArgs;
 
 public:
-    explicit CreateInstanceExpr(std::shared_ptr<CreationType> klass, std::unique_ptr<Expr> constructorArgs = nullptr)
-        : klass(std::move(klass)), constructorArgs(std::move(constructorArgs)) {}
+    explicit CreateInstanceExpr(const std::string name, std::shared_ptr<CreationType> klass, std::unique_ptr<Expr> constructorArgs = nullptr)
+        : name(std::move(name)), klass(std::move(klass)), constructorArgs(std::move(constructorArgs)) {}
 
     Value evaluate(std::shared_ptr<Heart> scope) const override
     {

--- a/src/jesus/interpreter/interpreter.hpp
+++ b/src/jesus/interpreter/interpreter.hpp
@@ -24,6 +24,8 @@
 #include "../ast/stmt/skip_stmt.hpp"
 #include "../spirit/heart.hpp"
 #include "../spirit/symbol_table.hpp"
+#include "types/known_types.hpp"
+#include "types/type_registry.hpp"
 
 REGISTER_FOR_UML(
     Interpreter,
@@ -52,7 +54,9 @@ REGISTER_FOR_UML(
 class Interpreter : public ExprVisitor, public StmtVisitor
 {
 public:
-    explicit Interpreter(std::shared_ptr<Module> module, bool useVm) : currentModule(module), httpRuntime(*this), useVm(useVm) {}
+    explicit Interpreter(std::shared_ptr<Module> module, bool useVm)
+        : currentModule(module), httpRuntime(*this), useVm(useVm),
+          typeRegistry(std::make_shared<TypeRegistry>()) {}
     /**
      * @brief Evaluates a given expression and returns its computed value.
      *
@@ -118,6 +122,26 @@ public:
         currentModule->symbol_table->registerClassName(className);
     }
 
+    void registerParseTimeType(const std::shared_ptr<CreationType> &type)
+    {
+        typeRegistry->registerType(type);
+    }
+
+    bool isClassKnown(const std::string &className) const
+    {
+        return typeRegistry->exists(className) ||
+               currentModule->symbol_table->isClassKnown(className);
+    }
+
+    std::shared_ptr<CreationType> resolveType(const std::string &name)
+    {
+        auto type = KnownTypes::resolve(name, currentModule->name);
+        if (type)
+            return type;
+
+        return typeRegistry->resolve(name);
+    }
+
     void addScope(std::shared_ptr<Heart> scope)
     {
         currentModule->symbol_table->addScope(scope);
@@ -176,6 +200,7 @@ private:
     static std::unordered_map<std::string, std::shared_ptr<Module>> modules;
     HttpRuntime httpRuntime;
     bool useVm;
+    std::shared_ptr<TypeRegistry> typeRegistry;
 
     // 🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️🟢️
     // 🟢️ Visit expression methods 🟢️

--- a/src/jesus/parser/grammar/stmt/create_class_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_class_stmt_rule.cpp
@@ -5,6 +5,18 @@
 #include "../../../understanding/doctrine/law/ungodly_naming.hpp"
 #include <stdexcept>
 
+static void registerParseTimeClass(ParserContext &ctx, const std::string &className,
+                                   const std::string &module_name,
+                                   const std::shared_ptr<CreationType> &parent_class)
+{
+    std::vector<std::shared_ptr<IConstraint>> constraints;
+    auto userClass = std::make_shared<CreationType>(
+        PrimitiveType::Class, className, module_name, parent_class, constraints);
+
+    ctx.registerType(userClass);
+    ctx.registerClassName(className);
+}
+
 std::unique_ptr<Stmt> CreateClassStmtRule::parse(ParserContext &ctx)
 {
     std::string stmt = "let there be";
@@ -76,7 +88,7 @@ std::unique_ptr<Stmt> CreateClassStmtRule::parse(ParserContext &ctx)
     {
         // Allowing 'empty-bodied' classes without ': amen'.
         // Just: let there be Light
-        ctx.registerClassName(className);
+        registerParseTimeClass(ctx, className, module_name, baseClassType);
         return std::make_unique<CreateClassStmt>(className, module_name, baseClassType, body);
     }
 
@@ -118,6 +130,6 @@ std::unique_ptr<Stmt> CreateClassStmtRule::parse(ParserContext &ctx)
     if (!ctx.match(TokenType::AMEN))
         throw std::runtime_error("Expected 'amen' after ':' in '" + stmt + "' to close class body.");
 
-    ctx.registerClassName(className);
+    registerParseTimeClass(ctx, className, module_name, baseClassType);
     return std::make_unique<CreateClassStmt>(className, module_name, baseClassType, body);
 }

--- a/src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
@@ -70,7 +70,10 @@ std::unique_ptr<Stmt> CreateVarStmtRule::parse(ParserContext &ctx)
     }
     if (!varType)
     {
-        varType = KnownTypes::resolve(varType_, "core");
+        varType = KnownTypes::resolve(varType_, ctx.moduleName);
+        if (!varType && ctx.isClassKnown(varType_))
+            varType = ctx.resolveType(varType_);
+
         if (!varType)
             throw std::runtime_error("Unknown variable type: '" + varType_ + "'");
     }
@@ -102,7 +105,7 @@ std::unique_ptr<Stmt> CreateVarStmtRule::parse(ParserContext &ctx)
         std::string value_str = "";
         if (varType->isClass())
         {
-            value = std::make_unique<CreateInstanceExpr>(varType);
+            value = std::make_unique<CreateInstanceExpr>(varName, varType);
         }
         // ------------------------------------------------------------
         // If the 'value' is a literal, validate it now, at parse time.

--- a/src/jesus/parser/grammar/stmt/create_var_type_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_var_type_stmt_rule.cpp
@@ -29,6 +29,17 @@ std::unique_ptr<Stmt> CreateVarTypeStmtRule::parse(ParserContext &ctx)
 
     std::string typeName = ctx.previous().lexeme;
 
+    int snapshot = ctx.snapshot();
+    // We check if there’s a constraint (like > 0)
+    // Otherwise it's not a variable type declaration
+    if (!ctx.matchAny({TokenType::GREATER, TokenType::LESS,
+                       TokenType::GREATER_EQUAL,
+                       TokenType::LESS_EQUAL,
+                       TokenType::MATCHES}))
+    {
+        return nullptr;
+    }
+    ctx.restore(snapshot); // because matchAny above calls advance()
 
     bool typeExistsLocally = ctx.varExistsInHierarchy(baseTypeStr);
     std::shared_ptr<CreationType> baseType = nullptr;
@@ -41,22 +52,13 @@ std::unique_ptr<Stmt> CreateVarTypeStmtRule::parse(ParserContext &ctx)
 
     if (!baseType)
     {
-        baseType = KnownTypes::resolve(baseTypeStr, "core");
+        baseType = KnownTypes::resolve(baseTypeStr, ctx.moduleName);
+        if (!baseType && ctx.isClassKnown(baseTypeStr))
+            baseType = ctx.resolveType(baseTypeStr);
+
         if (!baseType)
             throw std::runtime_error("Unknown base type: '" + baseTypeStr + "'");
     }
-
-    int snapshot = ctx.snapshot();
-    // Here comes the key difference: we check if there’s a constraint (like > 0)
-    // Otherwise it's not a variable type declaration
-    if (!ctx.matchAny({TokenType::GREATER, TokenType::LESS,
-                       TokenType::GREATER_EQUAL,
-                       TokenType::LESS_EQUAL,
-                       TokenType::MATCHES}))
-    {
-        return nullptr;
-    }
-    ctx.restore(snapshot);  // becauase matchAny above calls advance()
 
     std::vector<std::shared_ptr<IConstraint>> constraints;
 

--- a/src/jesus/parser/parser_context.cpp
+++ b/src/jesus/parser/parser_context.cpp
@@ -27,6 +27,21 @@ const std::shared_ptr<CreationType> ParserContext::getVarType(const std::string 
     return interpreter->getVarType(varName);
 }
 
+std::shared_ptr<CreationType> ParserContext::resolveType(const std::string &name)
+{
+    return interpreter->resolveType(name);
+}
+
+void ParserContext::registerType(const std::shared_ptr<CreationType> &type)
+{
+    interpreter->registerParseTimeType(type);
+}
+
+bool ParserContext::isClassKnown(const std::string &className) const
+{
+    return interpreter->isClassKnown(className);
+}
+
 void ParserContext::registerClassName(const std::string &className)
 {
     interpreter->registerClassName(className);

--- a/src/jesus/parser/parser_context.hpp
+++ b/src/jesus/parser/parser_context.hpp
@@ -180,7 +180,12 @@ public:
 
     void registerClassName(const std::string &className);
 
+    void registerType(const std::shared_ptr<CreationType> &type);
+
+    bool isClassKnown(const std::string &className) const;
+
     const std::shared_ptr<CreationType> getVarType(const std::string &varName);
+    std::shared_ptr<CreationType> resolveType(const std::string &name);
 
     void addScope(std::shared_ptr<Heart> scope);
 

--- a/src/jesus/spirit/heart.hpp
+++ b/src/jesus/spirit/heart.hpp
@@ -153,6 +153,11 @@ public:
         semantics_analyzer->registerClassName(className);
     }
 
+    bool isClassKnown(const std::string &className) const
+    {
+        return semantics_analyzer->isClassKnown(className);
+    }
+
     const std::shared_ptr<CreationType> getVarType(const std::string &varName)
     {
         auto type = semantics_analyzer->getVarType(varName);

--- a/src/jesus/spirit/spirit_of_understanding.hpp
+++ b/src/jesus/spirit/spirit_of_understanding.hpp
@@ -38,7 +38,7 @@ public:
 
     const std::shared_ptr<CreationType> getVarType(const std::string &varName);
 
-    bool isClassKnown(const std::string &className)
+    bool isClassKnown(const std::string &className) const
     {
         return classNames.find(className) != classNames.end();
     }

--- a/src/jesus/spirit/symbol_table.hpp
+++ b/src/jesus/spirit/symbol_table.hpp
@@ -119,7 +119,18 @@ public:
         current_scope->registerClassName(className);
     }
 
-    bool varExistsInHierarchy(const std::string &name) {
+    bool isClassKnown(const std::string &className) const
+    {
+        for (auto it = scopes.rbegin(); it != scopes.rend(); ++it)
+        {
+            if ((*it)->isClassKnown(className))
+                return true;
+        }
+        return false;
+    }
+
+    bool varExistsInHierarchy(const std::string &name)
+    {
         return current_scope->varExistsInHierarchy(name);
     }
 };

--- a/src/jesus/spirit/value.hpp
+++ b/src/jesus/spirit/value.hpp
@@ -135,6 +135,11 @@ public:
         return *std::get<std::shared_ptr<DictValue>>(value);
     }
 
+    std::shared_ptr<CreationType> asClass() const
+    {
+        return std::get<std::shared_ptr<CreationType>>(value);
+    }
+
     /**
      * @brief Output stream overload for Value
      *

--- a/src/jesus/types/type_registry.hpp
+++ b/src/jesus/types/type_registry.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include "creation_type.hpp"
+
+/**
+ * @brief Parse-time registry of known types.
+ *
+ * Stores both built-in types (number, text, etc.) and user-defined
+ * classes so that the parser can resolve types before execution.
+ *
+ * It was introduced when implementing class and instance
+ * support for the VM. Previously, user-defined classes only existed
+ * after being executed by the AST interpreter (REPL mode), meaning
+ * constructs such as:
+ *
+ *     let there be Light: amen
+ *     create Light jesus = 1
+ *
+ * were accepted in the REPL but failed when compiling an entire file
+ * (e.g. `jesus file.jesus` or `jesus --vm file.jesus`), because the
+ * class registration had not yet been executed.
+ *
+ * "The Spirit searches all things, even the deep things of God."
+ * — 1 Corinthians 2:10
+ */
+class TypeRegistry
+{
+public:
+    void registerType(std::shared_ptr<CreationType> type)
+    {
+        types[type->name] = type;
+    }
+
+    std::shared_ptr<CreationType> resolve(const std::string &name) const
+    {
+        auto it = types.find(name);
+        if (it != types.end())
+            return it->second;
+
+        return nullptr;
+    }
+
+    bool exists(const std::string &name) const
+    {
+        return types.contains(name);
+    }
+
+private:
+    std::unordered_map<std::string, std::shared_ptr<CreationType>> types;
+};

--- a/src/jesus/vm/compiler.cpp
+++ b/src/jesus/vm/compiler.cpp
@@ -1,4 +1,6 @@
 #include "compiler.hpp"
+#include "ast/stmt/create_method_stmt.hpp"
+#include "interpreter/runtime/method.hpp"
 
 Chunk Compiler::compile(const std::vector<std::unique_ptr<Stmt>> &statements)
 {
@@ -41,6 +43,12 @@ void Compiler::compileStmt(const Stmt &stmt)
         return;
     }
 
+    if (auto create_class = dynamic_cast<const CreateClassStmt *>(&stmt))
+    {
+        compileCreateClassStmt(*create_class);
+        return;
+    }
+
     throw std::runtime_error("Statement not supported by VM yet: " + stmt.toString());
 }
 
@@ -68,6 +76,12 @@ void Compiler::compileExpr(const Expr &expr)
     if (auto var = dynamic_cast<const VariableExpr *>(&expr))
     {
         compileVariableExpr(*var);
+        return;
+    }
+
+    if (auto instance = dynamic_cast<const CreateInstanceExpr *>(&expr))
+    {
+        compileCreateInstanceExpr(*instance);
         return;
     }
 
@@ -169,6 +183,12 @@ uint32_t Compiler::registerGlobalVar(const std::string &name)
 
 void Compiler::compileCreateVarStmt(const CreateVarStmt &stmt)
 {
+    if (auto instance = dynamic_cast<const CreateInstanceExpr *>(stmt.value.get()))
+    {
+        compileCreateInstanceExpr(*instance);
+        return;
+    }
+
     compileExpr(*stmt.value);
 
     uint32_t index = registerGlobalVar(stmt.name);
@@ -237,4 +257,61 @@ void Compiler::compileRepeatWhileStmt(const RepeatWhileStmt &stmt)
     emit(OpCode::JUMP, loopStart);
 
     patchJump(jumpOut);
+}
+
+void Compiler::compileCreateClassStmt(const CreateClassStmt &stmt)
+{
+    std::vector<std::shared_ptr<IConstraint>> constraints; // no constraints yet
+
+    auto scope = std::make_shared<Heart>("class::" + stmt.name);
+    auto userClass = std::make_shared<CreationType>(
+        PrimitiveType::Class,
+        stmt.name,
+        stmt.module_name,
+        stmt.parent_class,
+        constraints);
+
+    for (const auto &member : stmt.body)
+    {
+        // -----------------
+        // handle attributes
+        // -----------------
+        if (auto attr = dynamic_cast<CreateVarStmt *>(member.get()))
+        {
+            userClass->addAttribute(attr->base_type, attr->name, std::move(attr->value), scope);
+        }
+        // --------------
+        // handle methods
+        // --------------
+        else if (auto methodStmt = dynamic_cast<CreateMethodStmt *>(member.get()))
+        {
+            auto method = std::make_shared<Method>(
+                methodStmt->name,
+                methodStmt->params,
+                methodStmt->body,
+                methodStmt->returnType);
+
+            userClass->addMethod(methodStmt->name, method);
+        }
+        else
+        {
+            throw std::runtime_error("Class body member not supported yet");
+        }
+    }
+
+    classes[stmt.name] = std::move(userClass);
+}
+
+void Compiler::compileCreateInstanceExpr(const CreateInstanceExpr &expr)
+{
+    auto it = classes.find(expr.klass->name);
+    if (it == classes.end())
+        throw std::runtime_error("Unknown class: " + expr.klass->name);
+
+    uint32_t classIndex = addConstant(Value(it->second));
+    emit(OpCode::PUSH_LITERAL, classIndex);
+    emit(OpCode::CREATE_INSTANCE);
+
+    uint32_t varIndex = registerGlobalVar(expr.name);
+    emit(OpCode::CREATE_GLOBAL, varIndex);
 }

--- a/src/jesus/vm/compiler.hpp
+++ b/src/jesus/vm/compiler.hpp
@@ -3,10 +3,12 @@
 #include "chunk.hpp"
 
 #include "ast/expr/binary_expr.hpp"
+#include "ast/expr/create_instance_expr.hpp"
 #include "ast/expr/literal_expr.hpp"
 #include "ast/expr/variable_expr.hpp"
 
 #include "ast/stmt/create_var_stmt.hpp"
+#include "ast/stmt/create_class_stmt.hpp"
 #include "ast/stmt/update_var_stmt.hpp"
 #include "ast/stmt/print_stmt.hpp"
 #include "ast/stmt/repeat_while_stmt.hpp"
@@ -81,6 +83,7 @@ public:
 private:
     Chunk chunk;
     std::unordered_map<std::string, uint32_t> globals;
+    std::unordered_map<std::string, std::shared_ptr<CreationType>> classes;
 
     void compileStmt(const Stmt &stmt);
 
@@ -162,4 +165,7 @@ private:
      *  exit:
      */
     void compileRepeatWhileStmt(const RepeatWhileStmt &stmt);
+
+    void compileCreateClassStmt(const CreateClassStmt &stmt);
+    void compileCreateInstanceExpr(const CreateInstanceExpr &expr);
 };

--- a/src/jesus/vm/opcode.cpp
+++ b/src/jesus/vm/opcode.cpp
@@ -16,6 +16,15 @@ std::string opcodeToString(OpCode opcode)
     case OpCode::WRITE_GLOBAL:
         return "WRITE_GLOBAL";
 
+    case OpCode::CREATE_INSTANCE:
+        return "CREATE_INSTANCE";
+
+    case OpCode::READ_ATTR:
+        return "READ_ATTR";
+
+    case OpCode::WRITE_ATTR:
+        return "WRITE_ATTR";
+
     case OpCode::ADD:
         return "ADD";
 

--- a/src/jesus/vm/opcode.hpp
+++ b/src/jesus/vm/opcode.hpp
@@ -26,6 +26,10 @@ enum class OpCode : uint8_t
     READ_GLOBAL,
     WRITE_GLOBAL,
 
+    CREATE_INSTANCE,
+    READ_ATTR,
+    WRITE_ATTR,
+
     ADD,
     SUBTRACT,
     MULTIPLY,

--- a/src/jesus/vm/vm.cpp
+++ b/src/jesus/vm/vm.cpp
@@ -1,6 +1,9 @@
+#include <sstream>
+#include <memory>
+
 #include "vm.hpp"
 #include "opcode.hpp"
-#include <sstream>
+#include "interpreter/runtime/instance.hpp"
 
 void VM::run(const Chunk &chunk)
 {
@@ -187,6 +190,17 @@ void VM::run(const Chunk &chunk)
         {
             // Back to the beginning of the loop
             ip = begin + ip->operand;
+            break;
+        }
+
+        case OpCode::CREATE_INSTANCE:
+        {
+            auto klass = stack.back().asClass();
+            stack.pop_back();
+
+            stack.push_back(Value(std::make_shared<Instance>(klass)));
+
+            ++ip;
             break;
         }
 


### PR DESCRIPTION
# Description

This PR introduces the first stage of object-oriented support in the VM.

Previously, user-defined classes only worked in REPL mode, failing when
running the source file directly with `jesus file.jesus` or `jesus --vm file.jesus`.

This PR removes that limitation by introducing parse-time class
registration and adding VM support for creating class instances.

Example:

```jesus
let there be Light:
amen

create Light Jesus = 1

say Jesus
````

The program above now works both in REPL mode and when
compiled for the VM.

## Changes

* Introduced `TypeRegistry` for parse-time type resolution.
* Registered user-defined classes during parsing.
* Added VM support for class definitions.
* Added VM support for instance creation (`CREATE_INSTANCE`).

# ✝️ Wisdom

>  And God said, “Let there be light,” and there was light. — **_Genesis 1:3_**

