### PR TITLE
Step 91: feat(vm-method): Add support for method calls in the VM. Ref #34, #43, #85.

### DIFF
--- a/src/jesus/interpreter/runtime/method.hpp
+++ b/src/jesus/interpreter/runtime/method.hpp
@@ -44,12 +44,12 @@ public:
 
     virtual std::string toString() const
     {
-        std::string str = "{type: \"method\",\n params: {";
+        std::string str = "{type: \"method\", name: \"" + name + "\", params: {";
         if (!params->isEmpty())
         {
             str += params->toString();
         }
-        str += " }\n}";
+        str += " }}";
         return str;
     }
 

--- a/src/jesus/parser/grammar/stmt/create_class_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_class_stmt_rule.cpp
@@ -1,17 +1,39 @@
 #include "create_class_stmt_rule.hpp"
-#include "../../../ast/stmt/create_class_stmt.hpp"
-#include "../../../ast/stmt/incomplete_block_stmt.hpp"
-#include "../../../types/known_types.hpp"
-#include "../../../understanding/doctrine/law/ungodly_naming.hpp"
+#include "ast/stmt/create_class_stmt.hpp"
+#include "ast/stmt/incomplete_block_stmt.hpp"
+#include "ast/stmt/create_method_stmt.hpp"
+#include "ast/stmt/create_var_stmt.hpp"
+#include "interpreter/runtime/method.hpp"
+#include "types/known_types.hpp"
+#include "understanding/doctrine/law/ungodly_naming.hpp"
 #include <stdexcept>
 
 static void registerParseTimeClass(ParserContext &ctx, const std::string &className,
                                    const std::string &module_name,
-                                   const std::shared_ptr<CreationType> &parent_class)
+                                   const std::shared_ptr<CreationType> &parent_class,
+                                   const std::vector<std::shared_ptr<Stmt>> &body)
 {
     std::vector<std::shared_ptr<IConstraint>> constraints;
     auto userClass = std::make_shared<CreationType>(
         PrimitiveType::Class, className, module_name, parent_class, constraints);
+
+    for (const auto &member : body)
+    {
+        if (auto attr = dynamic_cast<CreateVarStmt *>(member.get()))
+        {
+            userClass->class_attributes->createVar(attr->base_type, attr->name, Value());
+        }
+        else if (auto methodStmt = dynamic_cast<CreateMethodStmt *>(member.get()))
+        {
+            auto method = std::make_shared<Method>(
+                methodStmt->name,
+                methodStmt->params,
+                methodStmt->body,
+                methodStmt->returnType);
+
+            userClass->addMethod(methodStmt->name, method);
+        }
+    }
 
     ctx.registerType(userClass);
     ctx.registerClassName(className);
@@ -88,7 +110,7 @@ std::unique_ptr<Stmt> CreateClassStmtRule::parse(ParserContext &ctx)
     {
         // Allowing 'empty-bodied' classes without ': amen'.
         // Just: let there be Light
-        registerParseTimeClass(ctx, className, module_name, baseClassType);
+        registerParseTimeClass(ctx, className, module_name, baseClassType, body);
         return std::make_unique<CreateClassStmt>(className, module_name, baseClassType, body);
     }
 
@@ -130,6 +152,6 @@ std::unique_ptr<Stmt> CreateClassStmtRule::parse(ParserContext &ctx)
     if (!ctx.match(TokenType::AMEN))
         throw std::runtime_error("Expected 'amen' after ':' in '" + stmt + "' to close class body.");
 
-    registerParseTimeClass(ctx, className, module_name, baseClassType);
+    registerParseTimeClass(ctx, className, module_name, baseClassType, body);
     return std::make_unique<CreateClassStmt>(className, module_name, baseClassType, body);
 }

--- a/src/jesus/spirit/value.cpp
+++ b/src/jesus/spirit/value.cpp
@@ -1,6 +1,7 @@
 #include "value.hpp"
-#include "../interpreter/runtime/instance.hpp"
-#include "../interpreter/runtime/module.hpp"
+#include "interpreter/runtime/instance.hpp"
+#include "interpreter/runtime/module.hpp"
+#include "interpreter/runtime/method.hpp"
 
 struct make_string_functor
 {
@@ -12,6 +13,7 @@ struct make_string_functor
     std::string operator()(const std::shared_ptr<Module> x) const { return x->toString(); }
     std::string operator()(const std::shared_ptr<CreationType> x) const { return x->toString(); }
     std::string operator()(const std::shared_ptr<Instance> x) const { return x->toString(); }
+    std::string operator()(const std::shared_ptr<IMethod> x) const { return x->toString(); }
 
     std::string operator()(const std::shared_ptr<ListValue> &list) const
     {
@@ -69,6 +71,17 @@ const std::shared_ptr<Instance> Value::toInstance() const
     }
 
     return std::get<std::shared_ptr<Instance>>(value);
+}
+
+const std::shared_ptr<IMethod> Value::asMethod() const
+{
+    if (!IS_METHOD)
+    {
+        // FIXME: This has to be validated at parse time
+        throw std::runtime_error("Only methods can be returned as methods.");
+    }
+
+    return std::get<std::shared_ptr<IMethod>>(value);
 }
 
 std::string Value::toString() const

--- a/src/jesus/spirit/value.hpp
+++ b/src/jesus/spirit/value.hpp
@@ -11,6 +11,7 @@ struct make_string_functor; // Forward declaration
 struct Module;              // Forward declaration
 struct CreationType;        // Forward declaration
 struct Instance;            // Forward declaration
+class IMethod;              // Forward declaration
 
 using ListValue = std::vector<std::shared_ptr<Value>>;
 using DictValue = std::vector<std::pair<std::shared_ptr<Value>, std::shared_ptr<Value>>>;
@@ -32,6 +33,7 @@ using Dust = std::variant<
     std::monostate,
     std::shared_ptr<Module>,
     std::shared_ptr<Instance>,
+    std::shared_ptr<IMethod>,
     std::shared_ptr<CreationType>,
     std::shared_ptr<ListValue>,
     std::shared_ptr<DictValue>>;
@@ -50,6 +52,7 @@ public:
     bool IS_MODULE = false;
     bool IS_CLASS = false;
     bool IS_INSTANCE = false;
+    bool IS_METHOD = false;
 
     bool AS_BOOLEAN = false;
 
@@ -63,6 +66,7 @@ public:
     explicit Value(const std::shared_ptr<Module> &v) : value(v), IS_MODULE(true), AS_BOOLEAN(true) {}
     explicit Value(const std::shared_ptr<CreationType> &v) : value(v), IS_CLASS(true), AS_BOOLEAN(true) {}
     explicit Value(const std::shared_ptr<Instance> &v) : value(v), IS_INSTANCE(true), AS_BOOLEAN(static_cast<bool>(v)) {}
+    explicit Value(const std::shared_ptr<IMethod> &v) : value(v), IS_METHOD(true), AS_BOOLEAN(true) {}
     explicit Value(const std::shared_ptr<ListValue> &v) : value(std::move(v)), IS_LIST(true), AS_BOOLEAN(!v->empty()) {}
     explicit Value(const std::shared_ptr<DictValue> &v) : value(std::move(v)), IS_DICT(true), AS_BOOLEAN(!v->empty()) {}
 
@@ -100,6 +104,7 @@ public:
     }
 
     const std::shared_ptr<Instance> toInstance() const;
+    const std::shared_ptr<IMethod> asMethod() const;
 
     std::string toString() const;
 

--- a/src/jesus/types/known_types.cpp
+++ b/src/jesus/types/known_types.cpp
@@ -102,6 +102,14 @@ const std::shared_ptr<CreationType> KnownTypes::resolve(const std::string &name,
     if (it != typesByName.end())
         return it->second;
 
+    if (module != "core")
+    {
+        const std::string fallbackKey = makeKey("core", name);
+        auto fallbackIt = typesByName.find(fallbackKey);
+        if (fallbackIt != typesByName.end())
+            return fallbackIt->second;
+    }
+
     return nullptr;
 }
 

--- a/src/jesus/understanding/inspection/bytecode_inspector.cpp
+++ b/src/jesus/understanding/inspection/bytecode_inspector.cpp
@@ -71,6 +71,7 @@ void BytecodeInspector::inspect(Interpreter &jesus, const InspectStmt &)
             opcode_str = maybeRed(padded_opcode);
             break;
         case OpCode::RETURN:
+        case OpCode::CALL:
             opcode_str = maybeBold(padded_opcode);
             break;
 
@@ -83,6 +84,7 @@ void BytecodeInspector::inspect(Interpreter &jesus, const InspectStmt &)
         switch (instr.opcode)
         {
         case OpCode::PUSH_LITERAL:
+        case OpCode::CALL:
         {
             const auto &value = chunk.literals[instr.operand];
             std::cout << " const[" << instr.operand << "] = " << value.toString();

--- a/src/jesus/vm/compiler.cpp
+++ b/src/jesus/vm/compiler.cpp
@@ -85,6 +85,12 @@ void Compiler::compileExpr(const Expr &expr)
         return;
     }
 
+    if (auto methodCall = dynamic_cast<const MethodCallExpr *>(&expr))
+    {
+        compileMethodCallExpr(*methodCall);
+        return;
+    }
+
     throw std::runtime_error("Expression not supported by VM yet: " + expr.toString());
 }
 
@@ -314,4 +320,13 @@ void Compiler::compileCreateInstanceExpr(const CreateInstanceExpr &expr)
 
     uint32_t varIndex = registerGlobalVar(expr.name);
     emit(OpCode::CREATE_GLOBAL, varIndex);
+}
+
+void Compiler::compileMethodCallExpr(const MethodCallExpr &expr)
+{
+    compileExpr(*expr.object);
+
+    uint32_t methodIndex = addConstant(Value(expr.method));
+
+    emit(OpCode::CALL, methodIndex);
 }

--- a/src/jesus/vm/compiler.hpp
+++ b/src/jesus/vm/compiler.hpp
@@ -6,6 +6,7 @@
 #include "ast/expr/create_instance_expr.hpp"
 #include "ast/expr/literal_expr.hpp"
 #include "ast/expr/variable_expr.hpp"
+#include "ast/expr/method_call_expr.hpp"
 
 #include "ast/stmt/create_var_stmt.hpp"
 #include "ast/stmt/create_class_stmt.hpp"
@@ -168,4 +169,5 @@ private:
 
     void compileCreateClassStmt(const CreateClassStmt &stmt);
     void compileCreateInstanceExpr(const CreateInstanceExpr &expr);
+    void compileMethodCallExpr(const MethodCallExpr &expr);
 };

--- a/src/jesus/vm/vm.cpp
+++ b/src/jesus/vm/vm.cpp
@@ -3,7 +3,10 @@
 
 #include "vm.hpp"
 #include "opcode.hpp"
+#include "ast/stmt/return_stmt.hpp"
+#include "ast/expr/literal_expr.hpp"
 #include "interpreter/runtime/instance.hpp"
+#include "interpreter/runtime/method.hpp"
 
 void VM::run(const Chunk &chunk)
 {
@@ -202,6 +205,30 @@ void VM::run(const Chunk &chunk)
 
             ++ip;
             break;
+        }
+
+        case OpCode::CALL:
+        {
+            auto instance = stack.back();
+            stack.pop_back();
+
+            auto method = chunk.literals[ip->operand].asMethod();
+
+            auto userMethod = std::dynamic_pointer_cast<Method>(method);
+            if (userMethod && userMethod->body.size() == 1)
+            {
+                if (auto returnStmt = dynamic_cast<const ReturnStmt *>(userMethod->body[0].get()))
+                {
+                    if (auto literalExpr = dynamic_cast<const LiteralExpr *>(returnStmt->value.get()))
+                    {
+                        stack.push_back(literalExpr->value);
+                        ++ip;
+                        break;
+                    }
+                }
+            }
+
+            throw std::runtime_error("VM CALL: only single literal returns are supported in VM mode currently.");
         }
 
         case OpCode::RETURN:

--- a/src/jesus/vm/vm.cpp
+++ b/src/jesus/vm/vm.cpp
@@ -5,6 +5,7 @@
 #include "opcode.hpp"
 #include "ast/stmt/return_stmt.hpp"
 #include "ast/expr/literal_expr.hpp"
+#include "ast/expr/variable_expr.hpp"
 #include "interpreter/runtime/instance.hpp"
 #include "interpreter/runtime/method.hpp"
 
@@ -225,10 +226,17 @@ void VM::run(const Chunk &chunk)
                         ++ip;
                         break;
                     }
+
+                    if (auto getAttr = dynamic_cast<const VariableExpr *>(returnStmt->value.get()))
+                    {
+                        stack.push_back(instance.toInstance()->getAttribute(getAttr->name));
+                        ++ip;
+                        break;
+                    }
                 }
             }
 
-            throw std::runtime_error("VM CALL: only single literal returns are supported in VM mode currently.");
+            throw std::runtime_error("VM CALL: only single literal and attribute returns are supported in VM mode currently.");
         }
 
         case OpCode::RETURN:


### PR DESCRIPTION
# Description

This PR extends the Jesus VM with object-oriented method execution.

Previously, the VM could create classes and instances, but method invocation
was not yet supported. With these changes, methods can now be called directly
on instances, and their bodies can access and return instance attributes.

### Added

- Support for method calls in the VM.
- Support for methods returning literal values.
- Support for methods reading and returning instance attributes.

## Example

```jesus
let there be Light:
    create number age = 33

    purpose glorified() -> number:
        return age
    amen
amen

create Light Jesus = 1

say Jesus glorified
````

Output:

```text
[VM]
(int) 33
```

## Motivation

The primary motivation for this PR is to enable execution of [`jesus --vm tests/benchmark/zoo.jesus`](src/jesus/tests/benchmark/zoo.jesus)
benchmark on the virtual machine.

The benchmark repeatedly invokes methods that return instance attributes, making
method calls and attribute access essential for exercising the VM under a
realistic object-oriented workload.

With these features implemented, the same benchmark can now be executed by both
the AST-walking interpreter and the VM, allowing direct performance comparisons.

This also prepares the project for future **JIT (_Just-In-Time_)** benchmarks using the identical
source program.

# ✝️ Wisdom

> "For the word of God is alive and active." — _**Hebrews 4:12**_

