### PR TITLE
Step 92: refactor: Improved runtime performance with slot-based variable addressing. Ref #85.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ include_directories(src/jesus src/bible/include)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+message(NOTICE "\n   Jesus Christ loves YOU!!!\n")
+message(NOTICE "   Confess Jesus Christ as your lord and savior, and live (type: jesus confess)")
+
 # ------------------------------------------------------------------------------
 # Version Information (auto-generated)
 #
@@ -63,7 +66,8 @@ configure_file(
     ${CMAKE_SOURCE_DIR}/src/jesus/utils/version.hpp
     @ONLY
 )
-message(STATUS "\n   Build date (Jerusalem Scriptural Time / UTC+9): ${JESUS_BUILD_DATE} ${JESUS_BUILD_TIME}\n")
+message(NOTICE "\n   Build date (Jerusalem Scriptural Time / UTC+9): ${JESUS_BUILD_DATE} ${JESUS_BUILD_TIME}\n")
+message(NOTICE "   Build type: ${CMAKE_BUILD_TYPE}\n")
 
 # -------------------
 # Define source files

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,16 @@ TARGET = Jesus
 CMAKE = cmake
 MAKE = make
 
+# ---------------------------
+# Default build type: Release
+# ---------------------------
+BUILD_TYPE ?= Release
+
 # -----------------------------------------------------------------------
 # Default target: It first builds the C++ executable using cmake and make
 # -----------------------------------------------------------------------
 all: $(BUILD_DIR)
-	cd $(BUILD_DIR) && $(CMAKE) .. && $(MAKE)
+	cd $(BUILD_DIR) && $(CMAKE) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) .. && $(MAKE)
 
 # ----------------------------------------------
 # Create the build directory if it doesn't exist
@@ -25,6 +30,23 @@ $(BUILD_DIR):
 # --------------------------
 run: $(BUILD_DIR)/jesus
 	./$(BUILD_DIR)/jesus
+
+# ---------------------------------
+# Convenience targets:
+#   make          → Release (fastest normal build)
+#   make debug    → debugging with gdb: gdb jesus # then: run
+#   make profile  → profiling with perf or valgrind:
+#                     valgrind --tool=callgrind jesus benchmark.jesus
+#                     kcachegrind callgrind.out.*
+# ---------------------------------
+release:
+	$(MAKE) BUILD_TYPE=Release
+
+debug:
+	$(MAKE) BUILD_TYPE=Debug
+
+profile:
+	$(MAKE) BUILD_TYPE=RelWithDebInfo
 
 # ------------------------
 # Clean up build directory

--- a/src/jesus/ast/expr/formatted_string_expr.hpp
+++ b/src/jesus/ast/expr/formatted_string_expr.hpp
@@ -65,5 +65,5 @@ public:
      * "For nothing is hidden that will not be made manifest, nor is anything
      * secret that will not be known and come to light." — Luke 8:17
      */
-    virtual std::string toString() const override { return "FormattedStringExpr('" + raw + ")'"; }
+    virtual std::string toString() const override { return "FormattedStringExpr(\"" + raw + ")\""; }
 };

--- a/src/jesus/ast/expr/get_attr_expr.cpp
+++ b/src/jesus/ast/expr/get_attr_expr.cpp
@@ -28,5 +28,5 @@ void GetAttributeExpr::assign(Interpreter &interpreter, const Value &value) cons
             "Tip: ensure the value is a valid object before accessing its attributes.");
     }
 
-    instance->setAttribute(attribute, value);
+    instance->setAttribute(address, value);
 }

--- a/src/jesus/ast/expr/get_attr_expr.hpp
+++ b/src/jesus/ast/expr/get_attr_expr.hpp
@@ -13,9 +13,10 @@ class GetAttributeExpr : public AssignableExpr
 public:
     std::unique_ptr<Expr> object;
     std::string attribute;
+    const VariableAddress address;
 
-    GetAttributeExpr(std::unique_ptr<Expr> object, std::string attribute)
-        : object(std::move(object)), attribute(std::move(attribute)), AssignableExpr(ExprKind::GetAttribute) {}
+    GetAttributeExpr(std::unique_ptr<Expr> object, std::string attribute, const VariableAddress address)
+        : object(std::move(object)), attribute(std::move(attribute)), address(address), AssignableExpr(ExprKind::GetAttribute) {}
 
     Value evaluate(std::shared_ptr<Heart> heart) const override
     {
@@ -33,4 +34,9 @@ public:
      * "Flesh gives birth to flesh, but the Spirit gives birth to spirit." — John 3:6
      */
     std::shared_ptr<CreationType> getReturnType(ParserContext &ctx) const override;
+
+    std::string toString() const override
+    {
+        return "GetAttributeExpr(" + attribute + ")";
+    }
 };

--- a/src/jesus/ast/expr/method_call_expr.cpp
+++ b/src/jesus/ast/expr/method_call_expr.cpp
@@ -35,19 +35,20 @@ bool MethodCallExpr::isArgumentAssignable(const std::shared_ptr<CreationType> &p
 void MethodCallExpr::validate(ParserContext &ctx) const
 {
     const auto &paramNames = method->params->getVariableNames();
+    const auto &paramsCount = method->params->paramsCount;
 
-    if (args.size() != paramNames.size())
+    if (args.size() != paramsCount)
     {
         std::string message =
             "Method '" + method->name +
-            "' expects " + std::to_string(paramNames.size()) +
+            "' expects " + std::to_string(paramsCount) +
             " argument(s), but got " + std::to_string(args.size()) + ".";
 
-        if (args.size() < paramNames.size())
+        if (args.size() < paramsCount)
         {
             message += "\n\nMissing parameter(s):";
 
-            for (size_t i = args.size(); i < paramNames.size(); ++i)
+            for (size_t i = args.size(); i < paramsCount; ++i)
             {
                 auto paramType = method->params->getVarType(paramNames[i]);
                 message += "\n - " + paramNames[i] + ": " + paramType->name;

--- a/src/jesus/ast/expr/variable_expr.hpp
+++ b/src/jesus/ast/expr/variable_expr.hpp
@@ -24,6 +24,7 @@ class VariableExpr : public Expr
 {
 public:
     std::string name;
+    const VariableAddress address;
 
     /**
      * @brief Constructs a VariableExpr with a given name.
@@ -38,12 +39,12 @@ public:
      *
      * @param name The name of the variable being referenced (e.g., prophet).
      */
-    explicit VariableExpr(const std::string &name)
-        : name(name), Expr(ExprKind::Variable) {}
+    explicit VariableExpr(const VariableAddress address, std::string name)
+        : address(address), name(name), Expr(ExprKind::Variable) {}
 
     Value evaluate(std::shared_ptr<Heart> heart) const override
     {
-        return heart->getVar(name);
+        return heart->getVar(address);
     }
 
     Value accept(ExprVisitor &visitor) const override;
@@ -62,5 +63,5 @@ public:
      * "For nothing is hidden that will not be made manifest, nor is anything
      * secret that will not be known and come to light." — Luke 8:17
      */
-    virtual std::string toString() const override { return "VariableExpr(" + name + ")"; }
+    virtual std::string toString() const override { return "VariableExpr('" + name + "')"; }
 };

--- a/src/jesus/ast/stmt/create_class_stmt.hpp
+++ b/src/jesus/ast/stmt/create_class_stmt.hpp
@@ -32,13 +32,36 @@ public:
     std::string module_name;
     const std::shared_ptr<CreationType> parent_class;
     std::vector<std::shared_ptr<Stmt>> body;
+    const std::shared_ptr<CreationType> userClass;
 
     CreateClassStmt(const std::string &name, const std::string &module_name,
                     const std::shared_ptr<CreationType> &parent_class,
-                    const std::vector<std::shared_ptr<Stmt>> &body)
+                    const std::vector<std::shared_ptr<Stmt>> &body,
+                    const std::shared_ptr<CreationType> userClass)
         : name(name), module_name(module_name),
-        parent_class(parent_class),
-        body(body) {}
+          parent_class(parent_class),
+          body(body),
+          userClass(std::move(userClass)) {}
 
     void accept(StmtVisitor &visitor) const override;
+
+    std::string toString() const override
+    {
+        std::string str = "CreateClassStmt(name: '" + name + "', body: [";
+        bool isFirst = true;
+
+        for (auto &stmt : body)
+        {
+            if (!isFirst)
+                str += ",";
+
+            str += "\n  " + stmt->toString();
+
+            isFirst = false;
+        }
+
+        str += "])";
+
+        return str;
+    }
 };

--- a/src/jesus/ast/stmt/create_method_stmt.hpp
+++ b/src/jesus/ast/stmt/create_method_stmt.hpp
@@ -60,7 +60,22 @@ public:
      */
     std::string toString() const override
     {
-        return "CreateMethodStmt( " + name + " (\n" + params->toString() + "))";
+        std::string str = "CreateMethodStmt('" + name + "', body: [";
+        bool isFirst = true;
+
+        for (auto &stmt : body)
+        {
+            if (!isFirst)
+                str += ",";
+
+            str += "\n    " + stmt->toString();
+
+            isFirst = false;
+        }
+
+        str += "])";
+
+        return str;
     }
 
     void accept(StmtVisitor &visitor) const override {};

--- a/src/jesus/ast/stmt/create_var_stmt.hpp
+++ b/src/jesus/ast/stmt/create_var_stmt.hpp
@@ -19,12 +19,12 @@ REGISTER_FOR_UML(
 class CreateVarStmt : public Stmt
 {
 public:
-    std::shared_ptr<CreationType> base_type;
     std::string name;
+    VariableAddress address;
     std::unique_ptr<Expr> value;
 
-    CreateVarStmt(std::shared_ptr<CreationType> type, std::string name, std::unique_ptr<Expr> value)
-        : base_type(type), name(name), value(std::move(value)) {}
+    CreateVarStmt(std::string name, VariableAddress address, std::unique_ptr<Expr> value)
+        : name(name), address(address), value(std::move(value)) {}
 
     /**
      * @brief Returns a string representation of the statement.

--- a/src/jesus/ast/stmt/create_var_with_ask_stmt.hpp
+++ b/src/jesus/ast/stmt/create_var_with_ask_stmt.hpp
@@ -24,10 +24,11 @@ class CreateVarWithAskStmt : public Stmt
 public:
     const std::shared_ptr<CreationType> var_type;
     std::string var_name;
+    VariableAddress address;
     std::shared_ptr<Expr> ask_expr; // Type is AskExpr
 
-    CreateVarWithAskStmt(const std::shared_ptr<CreationType> type, std::string name, std::unique_ptr<Expr> ask_expr)
-        : var_type(type), var_name(name), ask_expr(std::move(ask_expr)) {}
+    CreateVarWithAskStmt(const std::shared_ptr<CreationType> type, std::string name, VariableAddress address, std::unique_ptr<Expr> ask_expr)
+        : var_type(type), var_name(name), address(address), ask_expr(std::move(ask_expr)) {}
 
     void accept(StmtVisitor &visitor) const override;
 

--- a/src/jesus/ast/stmt/for_each_stmt.hpp
+++ b/src/jesus/ast/stmt/for_each_stmt.hpp
@@ -22,14 +22,17 @@ public:
     std::vector<std::string> varNames;
     std::unique_ptr<Expr> iterable;
     std::vector<std::unique_ptr<Stmt>> body;
+    std::shared_ptr<Heart> scope;
 
     ForEachStmt(
         std::vector<std::string> varNames,
         std::unique_ptr<Expr> iterable,
+        std::shared_ptr<Heart> scope,
         std::vector<std::unique_ptr<Stmt>> body)
         : varNames(std::move(varNames)),
           iterable(std::move(iterable)),
+          scope(std::move(scope)),
           body(std::move(body)) {}
 
-  void accept(StmtVisitor &visitor) const override;
+    void accept(StmtVisitor &visitor) const override;
 };

--- a/src/jesus/ast/stmt/update_var_stmt.hpp
+++ b/src/jesus/ast/stmt/update_var_stmt.hpp
@@ -19,10 +19,17 @@ class UpdateVarStmt : public Stmt
 {
 public:
     std::string name;
+    const VariableAddress address;
     std::unique_ptr<Expr> value;
 
-    UpdateVarStmt(const std::string name, std::unique_ptr<Expr> value)
-        : name(name), value(std::move(value)) {}
+    UpdateVarStmt(const std::string name, const VariableAddress address, std::unique_ptr<Expr> value)
+        : name(name), address(address), value(std::move(value)) {}
 
     void accept(StmtVisitor &visitor) const override;
+
+    std::string toString() const override
+    {
+        std::string str = "UpdateVarStmt('" + name + "', value: " + value->toString() + ")";
+        return str;
+    }
 };

--- a/src/jesus/ast/stmt/update_var_with_ask_stmt.hpp
+++ b/src/jesus/ast/stmt/update_var_with_ask_stmt.hpp
@@ -21,10 +21,11 @@ class UpdateVarWithAskStmt : public Stmt
 public:
     const std::shared_ptr<CreationType> var_type;
     const std::string var_name;
+    const VariableAddress address;
     std::shared_ptr<Expr> ask_expr; // Type is AskExpr
 
-    UpdateVarWithAskStmt(const std::shared_ptr<CreationType> type, std::string name, std::unique_ptr<Expr> ask_expr)
-        : var_type(type), var_name(name), ask_expr(std::move(ask_expr)) {}
+    UpdateVarWithAskStmt(const std::shared_ptr<CreationType> type, std::string name, const VariableAddress address, std::unique_ptr<Expr> ask_expr)
+        : var_type(type), var_name(name), address(address), ask_expr(std::move(ask_expr)) {}
 
     void accept(StmtVisitor &visitor) const override;
 

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -44,14 +44,14 @@ void Interpreter::execute(const std::shared_ptr<Stmt> &stmt)
     stmt->accept(*this);
 }
 
-void Interpreter::createVariable(const VarType &type, const std::string &name, const Value &value)
+void Interpreter::createVariable(const VariableAddress address, const Value &value)
 {
-    currentModule->symbol_table->createVar(type, name, value);
+    currentModule->symbol_table->updateVar(address, value);
 }
 
-void Interpreter::updateVariable(const std::string &name, const Value &value)
+void Interpreter::updateVariable(const VariableAddress address, const Value &value)
 {
-    currentModule->symbol_table->updateVar(name, value);
+    currentModule->symbol_table->updateVar(address, value);
 }
 
 Value Interpreter::visitBinary(const BinaryExpr &expr)
@@ -76,7 +76,7 @@ Value Interpreter::visitVariable(const VariableExpr &expr)
 
 Value Interpreter::visitCreateInstanceExpr(const CreateInstanceExpr &expr)
 {
-    auto instance = std::make_shared<Instance>(expr.klass);
+    auto instance = std::make_shared<Instance>(expr.klass, expr.name);
     return Value(instance);
 }
 
@@ -86,7 +86,7 @@ Value Interpreter::visitGetAttribute(const GetAttributeExpr &expr)
 
     std::shared_ptr<Instance> instance = obj.toInstance();
 
-    return instance->getAttribute(expr.attribute);
+    return instance->getAttribute(expr.address);
 }
 
 Value Interpreter::visitParityCheckExpr(const ParityCheckExpr &expr)
@@ -144,7 +144,7 @@ std::string Interpreter::valueToString(const Value &value)
 void Interpreter::visitCreateVar(const CreateVarStmt &stmt)
 {
     Value val = evaluate(stmt.value);
-    createVariable(stmt.base_type, stmt.name, val);
+    createVariable(stmt.address, val);
     registerAstNodeForInspection(stmt.name, &stmt);
 }
 
@@ -182,26 +182,20 @@ Value Interpreter::askAndValidate(const std::shared_ptr<Expr> ask_expr, std::sha
 void Interpreter::visitCreateVarWithAsk(const CreateVarWithAskStmt &stmt)
 {
     Value value = askAndValidate(stmt.ask_expr, stmt.var_type);
-    createVariable(stmt.var_type, stmt.var_name, value);
+    createVariable(stmt.address, value);
     registerAstNodeForInspection(stmt.var_name, &stmt);
 }
 
 void Interpreter::visitUpdateVarWithAsk(const UpdateVarWithAskStmt &stmt)
 {
     Value value = askAndValidate(stmt.ask_expr, stmt.var_type);
-    updateVariable(stmt.var_name, value);
+    updateVariable(stmt.address, value);
 }
 
 void Interpreter::visitCreateClass(const CreateClassStmt &stmt)
 {
-    std::vector<std::shared_ptr<IConstraint>> constraints; // no constraints yet
-
-    auto userClass = std::make_shared<CreationType>(
-        PrimitiveType::Class,
-        stmt.name,
-        stmt.module_name,
-        stmt.parent_class,
-        constraints);
+    auto userClass = stmt.userClass;
+    auto scope = currentModule->symbol_table->currentScope();
 
     for (auto &member : stmt.body)
     {
@@ -210,25 +204,12 @@ void Interpreter::visitCreateClass(const CreateClassStmt &stmt)
         // -----------------
         if (auto attr = dynamic_cast<CreateVarStmt *>(member.get()))
         {
-            userClass->addAttribute(attr->base_type, attr->name, std::move(attr->value), currentModule->symbol_table->currentScope());
-        }
-        // --------------
-        // handle methods
-        // --------------
-        else if (auto methodStmt = dynamic_cast<CreateMethodStmt *>(member.get()))
-        {
-            auto method = std::make_shared<Method>(
-                methodStmt->name,
-                methodStmt->params,
-                methodStmt->body,
-                methodStmt->returnType);
-
-            userClass->addMethod(methodStmt->name, method);
+            auto initialValue = attr->value->evaluate(scope);
+            userClass->class_attributes->updateVar(attr->address.slot, initialValue); // FIXME: Set only non-literals. Literals must be set at parse time, on registerParseTimeClass
         }
     }
 
     KnownTypes::registerType(userClass);
-    currentModule->symbol_table->createVar(userClass, userClass->name, Value(userClass));
     registerAstNodeForInspection(userClass->name, &stmt);
 }
 
@@ -239,6 +220,7 @@ void Interpreter::visitCreateVarType(const CreateVarTypeStmt &stmt)
         stmt.name,
         stmt.module_name,
         stmt.base_type,
+        stmt.base_type->class_attributes,
         stmt.constraints);
 
     KnownTypes::registerType(std::move(custom_type));
@@ -248,7 +230,7 @@ void Interpreter::visitCreateVarType(const CreateVarTypeStmt &stmt)
 void Interpreter::visitUpdateVar(const UpdateVarStmt &stmt)
 {
     Value val = evaluate(stmt.value);
-    updateVariable(stmt.name, val);
+    currentModule->symbol_table->updateVar(stmt.name, val);
 }
 
 void Interpreter::visitAssignStmt(const AssignStmt &stmt)
@@ -515,7 +497,7 @@ void Interpreter::visitForEach(const ForEachStmt &stmt)
 
     auto &items = listValue.asList();
 
-    currentModule->symbol_table->addScope(std::make_shared<Heart>("foreach"));
+    currentModule->symbol_table->addScope(stmt.scope);
     for (const std::shared_ptr<Value> &value : items)
     {
         // ----------------------
@@ -523,7 +505,7 @@ void Interpreter::visitForEach(const ForEachStmt &stmt)
         // ----------------------
         if (stmt.varNames.size() == 1)
         {
-            updateVariable(stmt.varNames[0], *value);
+            stmt.scope->updateVar(0, *value);
         }
         // --------------------------------
         // foreach key, value in dict.pairs
@@ -544,8 +526,8 @@ void Interpreter::visitForEach(const ForEachStmt &stmt)
                 throw std::runtime_error("foreach key,value expects pairs with exactly 2 values. Got '" +std::to_string(pair.size()) + "' values.");
             }
 
-            updateVariable(stmt.varNames[0], *pair[0]);
-            updateVariable(stmt.varNames[1], *pair[1]);
+            stmt.scope->updateVar(0, *pair[0]);
+            stmt.scope->updateVar(1, *pair[1]);
         }
 
         try
@@ -829,9 +811,10 @@ void Interpreter::visitImportModuleStmt(const ImportModuleStmt &stmt)
     if (stmt.importedSymbols.empty())
     {
         std::string name = stmt.moduleAlias.empty() ? importedModule->name : stmt.moduleAlias;
+        const bool isParam = false;
 
         // Bind module object to its name
-        currentModule->symbol_table->createVar(KnownTypes::MODULE, name, Value(importedModule));
+        currentModule->symbol_table->createVar(KnownTypes::MODULE, name, Value(importedModule), isParam);
         registerAstNodeForInspection(name, &stmt);
         return;
     }
@@ -839,15 +822,17 @@ void Interpreter::visitImportModuleStmt(const ImportModuleStmt &stmt)
     // -------------------------------
     // from moduleName come MemberName
     // -------------------------------
-    for (const auto& symbol : stmt.importedSymbols)
-    {
-        std::string symbolToExpose = symbol.alias.empty() ? symbol.originalName : symbol.alias;
-        Value member = importedModule->getVar(symbol.originalName);
-        auto memberType = importedModule->getVarType(symbol.originalName);
+    // FIXME: This was disabled when using slots instead of string as varnames to speed things up. We need it back.
+    // for (const auto& symbol : stmt.importedSymbols)
+    // {
+    //     std::string symbolToExpose = symbol.alias.empty() ? symbol.originalName : symbol.alias;
+    //     // Value member = importedModule->getVar(symbol.originalName);
+    //     Value member = importedModule->getVar(symbol.originalName);
+    //     auto memberType = importedModule->getVarType(symbol.originalName);
 
-        currentModule->symbol_table->createVar(memberType, symbolToExpose, member);
-        registerAstNodeForInspection(symbolToExpose, &stmt);
-    }
+    //     currentModule->symbol_table->createVar(memberType, symbolToExpose, member);
+    //     registerAstNodeForInspection(symbolToExpose, &stmt);
+    // }
 }
 
 void Interpreter::addModule(const std::string &path, std::shared_ptr<Module> module)

--- a/src/jesus/interpreter/interpreter.hpp
+++ b/src/jesus/interpreter/interpreter.hpp
@@ -65,8 +65,8 @@ public:
      */
     Value evaluate(const std::unique_ptr<Expr> &expr);
 
-    void createVariable(const VarType &type, const std::string &name, const Value &value);
-    void updateVariable(const std::string &name, const Value &value);
+    void createVariable(const VariableAddress address, const Value &value);
+    void updateVariable(const VariableAddress address, const Value &value);
 
     /**
      * @brief Executes a single statement node in the abstract syntax tree (AST).
@@ -110,6 +110,11 @@ public:
     void registerVarType(const VarType &type, const std::string &name)
     {
         currentModule->symbol_table->registerVarType(type, name);
+    }
+
+    VariableAddress declareVar(const VarType &type, const std::string &name)
+    {
+        return currentModule->symbol_table->declareVar(type, name);
     }
 
     void updatePolymorphicVarType(const std::string &name, const VarType &type)
@@ -156,7 +161,7 @@ public:
     {
         if (!Interpreter::moduleRegistered(fullpath))
         {
-            auto scope = std::make_shared<Heart>(name);
+            auto scope = std::make_shared<Heart>("file:" + name);
             auto symbolTable = std::make_shared<SymbolTable>(scope);
             auto newModule = std::make_shared<Module>(name, fullpath, symbolTable);
             Interpreter::addModule(fullpath, newModule);
@@ -192,11 +197,12 @@ public:
         persistedAST.push_back(std::move(node));
     }
 
+    std::shared_ptr<Module> currentModule;
+
 private:
     /**
      * @brief Prevent re-imports / circular imports
      */
-    std::shared_ptr<Module> currentModule;
     static std::unordered_map<std::string, std::shared_ptr<Module>> modules;
     HttpRuntime httpRuntime;
     bool useVm;

--- a/src/jesus/interpreter/runtime/instance.hpp
+++ b/src/jesus/interpreter/runtime/instance.hpp
@@ -57,21 +57,21 @@ public:
      * @brief Construct a new Instance with a given spirit (class).
      * @param klass The class (spirit) that defines this instance.
      */
-    explicit Instance(std::shared_ptr<CreationType> klass)
+    explicit Instance(std::shared_ptr<CreationType> klass, const std::string &name = "")
         : spirit(std::move(klass))
     {
         // Copy default class attributes into the instance's heart
-        attributes = spirit->class_attributes->clone("i-" + std::to_string(InstanceID++));
+        attributes = spirit->class_attributes->clone("instance:" + std::to_string(InstanceID++) + ":" + name);
     }
 
-    const Value getAttribute(const std::string &name) const
+    const Value getAttribute(const VariableAddress &address) const
     {
-        return attributes->getVar(name);
+        return attributes->getVar(address);
     }
 
-    void setAttribute(const std::string &name, const Value &value)
+    void setAttribute(const VariableAddress &address, const Value &value)
     {
-        attributes->updateVar(name, value);
+        attributes->updateVar(address, value);
     }
 
     std::string toString()

--- a/src/jesus/interpreter/runtime/method.cpp
+++ b/src/jesus/interpreter/runtime/method.cpp
@@ -12,9 +12,10 @@ Value Method::call(Interpreter &interpreter, Value &object, const std::vector<Va
 
     // Bind the actual 'arguments' to the 'param' names
     int index = 0;
-    for (const auto &name : paramsScope->getVariableNames())
-        paramsScope->updateVar(name, args[index++]);
+    for (int index = 0; index < paramsScope->paramsCount; index++)
+        paramsScope->updateVar(index, args[index]);
 
+    interpreter.addScope(instance->attributes); // FIXME: should not add two scopes here. SymbolTable::updateVar should instead consider scope->parent_attributes
     interpreter.addScope(paramsScope);
 
     // 2. Execute method body
@@ -28,6 +29,7 @@ Value Method::call(Interpreter &interpreter, Value &object, const std::vector<Va
     }
 
     // 3. Pop'params' (and 'attributes') scope
+    interpreter.popScope();
     interpreter.popScope();
 
     return returnValue;

--- a/src/jesus/interpreter/runtime/module.hpp
+++ b/src/jesus/interpreter/runtime/module.hpp
@@ -26,18 +26,24 @@ public:
     explicit Module(std::string name, std::string path, std::shared_ptr<SymbolTable> symbol_table)
         : name(name), file_path(path), symbol_table(std::move(symbol_table)) {}
 
-    void createVar(const VarType &type, const std::string &name, const Value &value)
+    void createVar(const VarType &type, const std::string &name, const Value &value, bool isParam)
     {
-        symbol_table->createVar(type, name, value);
+        symbol_table->createVar(type, name, value, isParam);
     }
 
-    bool varExistsInHierarchy(const std::string &name) {
+    bool varExistsInHierarchy(const std::string &name)
+    {
         return symbol_table->varExistsInHierarchy(name);
     }
 
-    Value getVar(const std::string &name) const
+    Value getVar(const VariableAddress address) const
     {
-        return symbol_table->getVar(name);
+        return symbol_table->getVar(address);
+    }
+
+    VariableAddress resolveVariableAddress(std::string &name)
+    {
+        return symbol_table->resolveVariableAddress(name);
     }
 
     std::shared_ptr<CreationType> getVarType(const std::string &name) const

--- a/src/jesus/parser/grammar/expr/ask_expr_rule.cpp
+++ b/src/jesus/parser/grammar/expr/ask_expr_rule.cpp
@@ -45,7 +45,8 @@ std::unique_ptr<Expr> AskExprRule::parse(ParserContext &ctx)
         throw std::runtime_error("Error: 'ask' expects a variable of primitive type 'text' as its prompt, but received variable '" + varName + "' of primitive type '" + varType->primitiveTypeName() + "'.");
     }
 
-    return std::make_unique<AskExpr>(std::make_unique<VariableExpr>(varName));
+    auto address = ctx.resolveVariableAddress(varName);
+    return std::make_unique<AskExpr>(std::make_unique<VariableExpr>(address, varName));
 }
 
 std::string AskExprRule::toStr(GrammarRuleHashTable &visited) const

--- a/src/jesus/parser/grammar/expr/atomic/literals/variable_rule.cpp
+++ b/src/jesus/parser/grammar/expr/atomic/literals/variable_rule.cpp
@@ -4,7 +4,11 @@
 std::unique_ptr<Expr> VariableRule::parse(ParserContext &ctx)
 {
     if (ctx.match(TokenType::IDENTIFIER))
-        return std::make_unique<VariableExpr>(ctx.previous().lexeme);
+    {
+        auto varname = ctx.previous().lexeme;
+        auto address = ctx.resolveVariableAddress(varname);
+        return std::make_unique<VariableExpr>(address, varname);
+    }
 
     return nullptr;
 }

--- a/src/jesus/parser/grammar/expr/postfix/get_attr_rule.cpp
+++ b/src/jesus/parser/grammar/expr/postfix/get_attr_rule.cpp
@@ -83,7 +83,8 @@ std::unique_ptr<Expr> GetAttributeRule::parse(ParserContext &ctx)
                 // -----------------
                 if (member->isAttribute())
                 {
-                    expr = std::make_unique<GetAttributeExpr>(std::move(expr), name);
+                    auto address = member->declaring_class->class_attributes->resolveVariableAddressInHierarchy(name);
+                    expr = std::make_unique<GetAttributeExpr>(std::move(expr), name, address);
                 }
 
                 // ------------
@@ -96,7 +97,7 @@ std::unique_ptr<Expr> GetAttributeRule::parse(ParserContext &ctx)
                     // If the next token(s) indicate arguments, parse them
                     if (!ctx.check(TokenType::NEWLINE) && !ctx.check(TokenType::END_OF_FILE))
                     {
-                        auto expectedParams = member->method->params->size();
+                        auto expectedParams = member->method->params->paramsCount;
                         if (expectedParams > 0)
                         do
                         {

--- a/src/jesus/parser/grammar/stmt/create_class_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_class_stmt_rule.cpp
@@ -8,22 +8,20 @@
 #include "understanding/doctrine/law/ungodly_naming.hpp"
 #include <stdexcept>
 
-static void registerParseTimeClass(ParserContext &ctx, const std::string &className,
-                                   const std::string &module_name,
-                                   const std::shared_ptr<CreationType> &parent_class,
-                                   const std::vector<std::shared_ptr<Stmt>> &body)
+static std::shared_ptr<CreationType> registerParseTimeClass(
+    ParserContext &ctx, const std::string &className,
+    const std::string &module_name,
+    const std::shared_ptr<CreationType> &parent_class,
+    const std::shared_ptr<Heart> &attributes,
+    const std::vector<std::shared_ptr<Stmt>> &body)
 {
     std::vector<std::shared_ptr<IConstraint>> constraints;
     auto userClass = std::make_shared<CreationType>(
-        PrimitiveType::Class, className, module_name, parent_class, constraints);
+        PrimitiveType::Class, className, module_name, parent_class, std::move(attributes), constraints);
 
     for (const auto &member : body)
     {
-        if (auto attr = dynamic_cast<CreateVarStmt *>(member.get()))
-        {
-            userClass->class_attributes->createVar(attr->base_type, attr->name, Value());
-        }
-        else if (auto methodStmt = dynamic_cast<CreateMethodStmt *>(member.get()))
+        if (auto methodStmt = dynamic_cast<CreateMethodStmt *>(member.get()))
         {
             auto method = std::make_shared<Method>(
                 methodStmt->name,
@@ -37,6 +35,8 @@ static void registerParseTimeClass(ParserContext &ctx, const std::string &classN
 
     ctx.registerType(userClass);
     ctx.registerClassName(className);
+
+    return userClass;
 }
 
 std::unique_ptr<Stmt> CreateClassStmtRule::parse(ParserContext &ctx)
@@ -101,6 +101,7 @@ std::unique_ptr<Stmt> CreateClassStmtRule::parse(ParserContext &ctx)
     // ---------------------------
     // The class may not have body
     // ---------------------------
+    auto attributes = std::make_shared<Heart>("class:" + className, baseClassType->class_attributes);
     std::vector<std::shared_ptr<Stmt>> body;
     std::string module_name = ctx.moduleName;
 
@@ -110,8 +111,8 @@ std::unique_ptr<Stmt> CreateClassStmtRule::parse(ParserContext &ctx)
     {
         // Allowing 'empty-bodied' classes without ': amen'.
         // Just: let there be Light
-        registerParseTimeClass(ctx, className, module_name, baseClassType, body);
-        return std::make_unique<CreateClassStmt>(className, module_name, baseClassType, body);
+        auto userClass = registerParseTimeClass(ctx, className, module_name, baseClassType, std::move(attributes), body);
+        return std::make_unique<CreateClassStmt>(className, module_name, baseClassType, body, std::move(userClass));
     }
 
     if (!ctx.match(TokenType::COLON))
@@ -122,7 +123,6 @@ std::unique_ptr<Stmt> CreateClassStmtRule::parse(ParserContext &ctx)
     // ----------
     // Class body
     // ----------
-    auto attributes = std::make_shared<Heart>(className);
     ctx.addScope(attributes); // <🟢️>
 
     while (!ctx.check(TokenType::AMEN) && !ctx.isAtEnd())
@@ -152,6 +152,6 @@ std::unique_ptr<Stmt> CreateClassStmtRule::parse(ParserContext &ctx)
     if (!ctx.match(TokenType::AMEN))
         throw std::runtime_error("Expected 'amen' after ':' in '" + stmt + "' to close class body.");
 
-    registerParseTimeClass(ctx, className, module_name, baseClassType, body);
-    return std::make_unique<CreateClassStmt>(className, module_name, baseClassType, body);
+    auto userClass = registerParseTimeClass(ctx, className, module_name, baseClassType, std::move(attributes), body);
+    return std::make_unique<CreateClassStmt>(className, module_name, baseClassType, body, std::move(userClass));
 }

--- a/src/jesus/parser/grammar/stmt/create_method_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_method_stmt_rule.cpp
@@ -34,12 +34,11 @@ std::unique_ptr<Stmt> CreateMethodStmtRule::parse(ParserContext &ctx)
     if (nameIsUngodly && !isUngodlyDeclared)
     {
         doctrine::law::handleUngodlyNaming(
-            "Method name '" + methodName + "' does not appear to reflect God's standards.\n"
-            "To hide this warning, declare the method explicitly as 'ungodly'.\n\n"
-            "Example:\n"
-            "   ungodly purpose " + methodName + "():\n   amen\n\n"
-            + bibleReference
-        );
+            "Method name '" + methodName + "' does not appear to reflect God's standards.\n" +
+            "To hide this warning, declare the method explicitly as 'ungodly'.\n\n" +
+            "Example:\n" +
+            "   ungodly purpose " + methodName + "():\n   amen\n\n" +
+            bibleReference);
     }
 
     // ----------
@@ -48,8 +47,9 @@ std::unique_ptr<Stmt> CreateMethodStmtRule::parse(ParserContext &ctx)
     if (!ctx.match(TokenType::LEFT_PAREN))
         throw std::runtime_error("Expected '(' after method name in 'calling' statement.");
 
-    auto params = std::make_shared<Heart>(methodName);
+    auto params = std::make_shared<Heart>("method:" + methodName);
     ctx.addScope(params); // <🟢️>
+    const bool isParam = true;
 
     if (!ctx.check(TokenType::RIGHT_PAREN))
     {
@@ -71,7 +71,7 @@ std::unique_ptr<Stmt> CreateMethodStmtRule::parse(ParserContext &ctx)
 
             std::string name = ctx.previous().lexeme;
 
-            params->createVar(type, name, Value(1)); // FIXME: Validate `type` and allow initial values
+            params->createVar(type, name, Value(1), isParam); // FIXME: Validate `type` and allow initial values
 
         } while (ctx.match(TokenType::SEMICOLON)); // TODO: allow more args of same type: int x, y, z; string name, surname;
     }
@@ -193,5 +193,5 @@ std::unique_ptr<Stmt> CreateMethodStmtRule::parse(ParserContext &ctx)
         }
     }
 
-    return std::make_unique<CreateMethodStmt>(methodName, params, returnType, body, /*isGenesis=*/false);
+    return std::make_unique<CreateMethodStmt>(methodName, std::move(params), returnType, body, /*isGenesis=*/false);
 }

--- a/src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/create_var_stmt_rule.cpp
@@ -43,17 +43,16 @@ std::unique_ptr<Stmt> CreateVarStmtRule::parse(ParserContext &ctx)
     // Ungodly semantic validation
     // -----------------------------------
     std::string bibleReference;
-    bool nameIsUngodly =  doctrine::law::isUngodlyName(varName, bibleReference);
+    bool nameIsUngodly = doctrine::law::isUngodlyName(varName, bibleReference);
 
     if (nameIsUngodly && !isUngodlyDeclared)
     {
         doctrine::law::handleUngodlyNaming(
             "Variable name '" + varName + "' does not appear to reflect God's standards.\n" +
-            "To hide this warning, declare the symbol explicitly as 'ungodly'.\n\n"
-            "Example:\n"
-            "   create ungodly " + varType_ + " " + varName+" = ...\n\n"
-            + bibleReference
-        );
+            "To hide this warning, declare the symbol explicitly as 'ungodly'.\n\n" +
+            "Example:\n" +
+            "   create ungodly " + varType_ + " " + varName + " = ...\n\n" +
+            bibleReference);
     }
 
     // ---------------------
@@ -94,9 +93,8 @@ std::unique_ptr<Stmt> CreateVarStmtRule::parse(ParserContext &ctx)
             if (!ask_expr)
                 throw std::runtime_error("Expected a text literal or a text-typed variable after 'ask' (e.g., ask \"What is your name?\" or ask question).");
 
-            ctx.registerVarType(varType, varName);
-
-            return std::make_unique<CreateVarWithAskStmt>(varType, varName, std::move(ask_expr));
+            auto address = ctx.declareVar(varType, varName);
+            return std::make_unique<CreateVarWithAskStmt>(varType, varName, address, std::move(ask_expr));
         }
         value = expression->parse(ctx);
         if (!value)
@@ -112,7 +110,7 @@ std::unique_ptr<Stmt> CreateVarStmtRule::parse(ParserContext &ctx)
         // ------------------------------------------------------------
         else if (value->canEvaluateAtParseTime())
         {
-            auto empty_scope = std::make_shared<Heart>("creating_var");
+            auto empty_scope = std::make_shared<Heart>("parser:create_var:" + varName);
             Value literal = value->evaluate(empty_scope);
 
             varType->validate(literal);
@@ -134,9 +132,8 @@ std::unique_ptr<Stmt> CreateVarStmtRule::parse(ParserContext &ctx)
         {
             varType = valueType;
         }
-
-        ctx.registerVarType(varType, varName);
     }
 
-    return std::make_unique<CreateVarStmt>(varType, varName, std::move(value));
+    auto address = ctx.declareVar(varType, varName);
+    return std::make_unique<CreateVarStmt>(varName, address, std::move(value));
 }

--- a/src/jesus/parser/grammar/stmt/foreach_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/foreach_stmt_rule.cpp
@@ -68,9 +68,10 @@ std::unique_ptr<Stmt> ForEachStmtRule::parse(ParserContext &ctx)
     auto elementType = listType->elementType;
 
     auto foreachScope = std::make_shared<Heart>("foreach." + varNames[0]);
+    auto isParam = false;
     if (varNames.size() == 1)
     {
-        foreachScope->createVar(elementType, varNames[0], Value::formless());
+        foreachScope->declareVar(elementType, varNames[0], isParam);
     }
     else
     {
@@ -84,8 +85,8 @@ std::unique_ptr<Stmt> ForEachStmtRule::parse(ParserContext &ctx)
                 listType->elementType->name + "'.");
         }
 
-        foreachScope->createVar(innerListType->elementType, varNames[0], Value::formless());
-        foreachScope->createVar(innerListType->elementType, varNames[1], Value::formless());
+        foreachScope->declareVar(innerListType->elementType, varNames[0], isParam);
+        foreachScope->declareVar(innerListType->elementType, varNames[1], isParam);
     }
 
     // ----------
@@ -103,7 +104,7 @@ std::unique_ptr<Stmt> ForEachStmtRule::parse(ParserContext &ctx)
     }
     ctx.popScope(); // </🟢️>
 
-    return std::make_unique<ForEachStmt>(std::move(varNames), std::move(iterable), std::move(body));
+    return std::make_unique<ForEachStmt>(std::move(varNames), std::move(iterable), foreachScope, std::move(body));
 }
 
 std::vector<std::unique_ptr<Stmt>> ForEachStmtRule::parseBody(ParserContext &ctx)

--- a/src/jesus/parser/grammar/stmt/update_var_stmt_rule.cpp
+++ b/src/jesus/parser/grammar/stmt/update_var_stmt_rule.cpp
@@ -34,7 +34,8 @@ std::unique_ptr<Stmt> UpdateVarStmtRule::parse(ParserContext &ctx)
         if (!ask_expr)
             throw std::runtime_error("Expected a text literal or a text-typed variable after 'ask' (e.g., ask \"What is your name again?\" or ask question).");
 
-        return std::make_unique<UpdateVarWithAskStmt>(varType, varName, std::move(ask_expr));
+        auto address = ctx.resolveVariableAddress(varName);
+        return std::make_unique<UpdateVarWithAskStmt>(varType, varName, address, std::move(ask_expr));
     }
 
     std::unique_ptr<Expr> value = expression->parse(ctx);
@@ -45,7 +46,7 @@ std::unique_ptr<Stmt> UpdateVarStmtRule::parse(ParserContext &ctx)
     bool typesMatch = valueType->isA(varType);
     if (!typesMatch)
     {
-        if (! (valueType->isPolymorphic() && valueType->parent_class->isA(varType)))
+        if (!(valueType->isPolymorphic() && valueType->parent_class->isA(varType)))
         {
             throw std::runtime_error("Variable '" + varName + "' expects a '" + varType->name + "', but got: '" + valueType->name + "'.");
         }
@@ -58,5 +59,6 @@ std::unique_ptr<Stmt> UpdateVarStmtRule::parse(ParserContext &ctx)
         ctx.updatePolymorphicVarType(varName, polymorphicType);
     }
 
-    return std::make_unique<UpdateVarStmt>(varName, std::move(value));
+    auto address = ctx.resolveVariableAddress(varName);
+    return std::make_unique<UpdateVarStmt>(varName, address, std::move(value));
 }

--- a/src/jesus/parser/parser_context.cpp
+++ b/src/jesus/parser/parser_context.cpp
@@ -1,6 +1,7 @@
 
 #include "parser_context.hpp"
 #include "../interpreter/interpreter.hpp"
+#include "interpreter/runtime/module.hpp"
 
 ParserContext::ParserContext(
     std::vector<Token> tokens, Interpreter *interpreter,
@@ -15,6 +16,11 @@ bool ParserContext::varExistsInHierarchy(const std::string &name)
 void ParserContext::registerVarType(const VarType &type, const std::string &name)
 {
     interpreter->registerVarType(type, name);
+}
+
+VariableAddress ParserContext::declareVar(const VarType &type, const std::string &name)
+{
+    return interpreter->declareVar(type, name);
 }
 
 void ParserContext::updatePolymorphicVarType(const std::string &name, const VarType &type)
@@ -55,4 +61,12 @@ void ParserContext::addScope(std::shared_ptr<Heart> scope)
 void ParserContext::popScope()
 {
     interpreter->popScope();
+}
+
+VariableAddress ParserContext::resolveVariableAddress(const std::string &name)
+{
+    return interpreter
+        ->currentModule
+        ->symbol_table
+        ->resolveVariableAddress(name);
 }

--- a/src/jesus/parser/parser_context.hpp
+++ b/src/jesus/parser/parser_context.hpp
@@ -9,6 +9,8 @@
 class Interpreter;  // Forward declaration
 class CreationType; // Forward declaration
 class Heart;        // Forward declaration
+class VariableAddress;  // Forward declaration
+using VarType = std::shared_ptr<CreationType>;
 
 /**
  * @brief The context passed around during parsing, holding tokens and parsing position.
@@ -175,6 +177,10 @@ public:
     bool varExistsInHierarchy(const std::string &name);
 
     void registerVarType(const std::shared_ptr<CreationType> &type, const std::string &name);
+
+    VariableAddress declareVar(const VarType &type, const std::string &name);
+
+    VariableAddress resolveVariableAddress(const std::string &name);
 
     void updatePolymorphicVarType(const std::string &name, const std::shared_ptr<CreationType> &type);
 

--- a/src/jesus/spirit/heart.cpp
+++ b/src/jesus/spirit/heart.cpp
@@ -1,58 +1,84 @@
 #include "heart.hpp"
 #include <stdexcept>
 
-void Heart::createVar(const VarType &type, const std::string &name, const Value &value)
+uint32_t Heart::nextId = 0;
+
+VariableAddress Heart::declareVar(const VarType &type, const std::string &name, bool isParam)
 {
-    if (localVarExists(name))
+    if (slots.contains(name))
     {
         throw std::runtime_error("The variable '" + name + "' already exists in this scope (" + scope_name + ").");
     }
 
-    variables[name] = value;
+    uint32_t slot = values.size();
+
+    slots[name] = slot;
+    values.emplace_back();         // default-constructed Value
+    variableOrder.push_back(name); // preserve insertion order to assign 'args' to method 'params' by index.
+
     registerVarType(type, name);
 
-    variableOrder.push_back(name); // preserve insertion order to assign 'args' to method 'params' by index.
+    if (isParam)
+        paramsCount++;
+
+    return VariableAddress{.slot = slot, .scopeId = scopeId};
 }
 
-Value Heart::getVar(const std::string &name) const
+void Heart::createVar(const VarType &type, const std::string &name, const Value &value, bool isParam)
 {
-    auto it = variables.find(name);
-    if (it != variables.end())
-    {
-        return it->second;
-    }
+    auto address = declareVar(type, name, isParam);
+    updateVar(address, value);
+}
+
+Value Heart::getVar(const VariableAddress address) const
+{
+    if (address.scopeId == scopeId)
+        return values[address.slot];
 
     if (parent_attributes)
     {
-        return parent_attributes->getVar(name);
+        return parent_attributes->getVar(address);
     }
 
-    throw std::runtime_error("Undefined variable: " + name + " (scope: " + scope_name + ")");
+    throw std::runtime_error(
+        "Invalid variable address (scopeId=" + std::to_string(address.scopeId) + ", slot=" + std::to_string(address.slot) + ")." +
+        " Current scope: " + scope_name + " (scopeId=" + std::to_string(scopeId) + ").");
 }
 
-void Heart::updateVar(const std::string &name, const Value &value)
+void Heart::updateVar(const uint32_t slot, const Value &value)
+{
+    if (slot >= values.size())
+    {
+        throw std::runtime_error("updateVar: Invalid variable slot " + std::to_string(slot) + " (scope: " + scope_name + ", values: " + std::to_string(values.size()) + ")");
+    }
+
+    values[slot] = value;
+}
+
+void Heart::updateVar(const VariableAddress &address, const Value &value)
 {
      // If it exists locally, update here
-    auto it = variables.find(name);
-    if (it != variables.end())
+    if (address.scopeId == scopeId)
     {
-        it->second = value;
+        updateVar(address.slot, value);
         return;
     }
 
     // Otherwise, recurse to parent
     if (parent_attributes)
     {
-        parent_attributes->updateVar(name, value);
+        parent_attributes->updateVar(address, value);
         return;
     }
 
-    throw std::runtime_error("Cannot assign to undefined variable: " + name + " (scope: " + scope_name + ")");
+    throw std::runtime_error(
+        "Cannot assign to undefined variable (scopeId=" + std::to_string(address.scopeId) + ", slot=" + std::to_string(address.slot) + ")." +
+        " Current scope: " + scope_name + " (scopeId=" + std::to_string(scopeId) + ").");
 }
 
 bool Heart::localVarExists(const std::string &name) const
 {
-    return variables.find(name) != variables.end();
+    return slots.contains(name);
 }
 
 bool Heart::varExistsInHierarchy(const std::string &name) const

--- a/src/jesus/spirit/heart.hpp
+++ b/src/jesus/spirit/heart.hpp
@@ -16,6 +16,12 @@ REGISTER_FOR_UML(
                       "registerVarType", "updatePolymorphicVarType",
                       "registerClassName"}));
 
+struct VariableAddress
+{
+    uint32_t slot;
+    uint32_t scopeId;
+};
+
 /**
  * @brief The Heart class stores variables declared during execution.
  *
@@ -32,6 +38,7 @@ class Heart : JesusProgrammingLanguage
 {
 
 public:
+    uint32_t scopeId;
     const std::string scope_name;
 
     /**
@@ -41,26 +48,29 @@ public:
      */
     explicit Heart(std::string scope_name, std::shared_ptr<Heart> parent = nullptr)
         : scope_name(scope_name),
+          scopeId(nextId++),
           parent_attributes(std::move(parent)),
           semantics_analyzer(std::make_shared<SpiritOfUnderstanding>()) {}
 
     /**
      * @brief Construct a new Heart object
      *
-     * @param scope_name The scope name of the final copy
-     * @param other The original that will be used as a copy
+     * @param new_scope_name The scope name of the final copy
      */
     std::shared_ptr<Heart> clone(const std::string &new_scope_name, std::shared_ptr<Heart> parent_attributes_override = nullptr) const
     {
-        auto copy = std::make_shared<Heart>(scope_name);
-        copy->variables = variables;
+        auto copy = std::make_shared<Heart>(new_scope_name);
+        copy->slots = slots;
+        copy->values = values;
+        copy->paramsCount = paramsCount;
+        copy->scopeId = scopeId;
         copy->variableOrder = variableOrder;
         copy->semantics_analyzer = semantics_analyzer;
 
         if (parent_attributes_override)
             copy->parent_attributes = parent_attributes_override;
         else
-            copy->parent_attributes = parent_attributes;
+            copy->parent_attributes = parent_attributes ? parent_attributes->clone(new_scope_name + ":parent") : nullptr;
 
         return copy;
     }
@@ -101,7 +111,8 @@ public:
      * @param name The name of the variable (e.g., "age")
      * @param value The value to assign (e.g., "33")
      */
-    void createVar(const VarType &type, const std::string &name, const Value &value);
+    void createVar(const VarType &type, const std::string &name, const Value &value, bool isParam = false);
+    VariableAddress declareVar(const VarType &type, const std::string &name, bool isParam);
 
     /**
      * @brief Retrieves the value of a variable.
@@ -110,10 +121,10 @@ public:
      * Kingdom of Heaven is like a man who is a householder,
      * who brings out of his treasure new and old things.” - Matthew 13:52
      *
-     * @param name The name of the variable to retrieve.
+     * @param address The address of the variable to retrieve.
      * @return Value The value, which may be std::monostate if not found.
      */
-    Value getVar(const std::string &name) const;
+    Value getVar(const VariableAddress address) const;
 
     /**
      * @brief Updates the value of an already existing variable.
@@ -126,16 +137,17 @@ public:
      *
      * @throws std::runtime_error If the variable doesn't exist yet.
      */
-    void updateVar(const std::string &name, const Value &value);
+    void updateVar(const uint32_t slot, const Value &value);
+    void updateVar(const VariableAddress &address, const Value &value);
 
     bool isEmpty() const
     {
-        return variables.empty();
+        return values.empty();
     }
 
     bool size() const
     {
-        return variables.size();
+        return values.size();
     }
 
     void registerVarType(const VarType &type, const std::string &name)
@@ -169,22 +181,33 @@ public:
         return variableOrder;
     }
 
+    void appendToString(std::string &out, std::unordered_set<std::string> &vars_printed) const
+    {
+
+        for (size_t i = 0; i < variableOrder.size(); ++i)
+        {
+            const auto &name = variableOrder[i];
+
+            if (vars_printed.contains(name))
+                continue;
+
+            vars_printed.insert(name);
+
+            out += "\n  " + name + ": \"" + values[i].toString() + "\",";
+        }
+
+        if (parent_attributes)
+            parent_attributes->appendToString(out, vars_printed);
+    }
+
     const std::string toString() const
     {
         std::string str = "";
-        bool removeLastComma = false;
+        std::unordered_set<std::string> vars_printed;
 
-        if (parent_attributes)
-            str = parent_attributes->toString();
+        appendToString(str, vars_printed);
 
-        for (auto &pair : variables)
-        {
-            const std::string &key = pair.first;
-            const Value &value = pair.second;
-
-            str += "\n  " + key + ": \"" + value.toString() + "\",";
-            removeLastComma = true;
-        }
+        bool removeLastComma = !str.empty();
 
         if (removeLastComma)
         {
@@ -195,9 +218,38 @@ public:
         return str;
     }
 
+    VariableAddress resolveVariableAddress(const std::string &name) const
+    {
+        if (!slots.contains(name))
+        {
+            throw std::runtime_error("No slot found in " + scope_name + " for : " + name);
+        }
+
+        return {.slot = slots.at(name), .scopeId = scopeId};
+    }
+
+    /**
+     * @brief Resolves a variable slot walking the inheritance chain (child before parent).
+     */
+    VariableAddress resolveVariableAddressInHierarchy(const std::string &name) const
+    {
+        if (slots.contains(name))
+            return {.slot = slots.at(name), .scopeId = scopeId};
+
+        if (parent_attributes)
+            return parent_attributes->resolveVariableAddressInHierarchy(name);
+
+        throw std::runtime_error("No slot found in hierarchy of " + scope_name + " for: " + name);
+    }
+
+    int paramsCount = 0;
+
 private:
     std::shared_ptr<Heart> parent_attributes = nullptr;
+    std::unordered_map<std::string, uint32_t> slots;
+    static uint32_t nextId;
+
     std::vector<std::string> variableOrder; // insertion order
-    std::unordered_map<std::string, Value> variables;
+    std::vector<Value> values;
     std::shared_ptr<SpiritOfUnderstanding> semantics_analyzer;
 };

--- a/src/jesus/spirit/symbol_table.hpp
+++ b/src/jesus/spirit/symbol_table.hpp
@@ -48,47 +48,79 @@ public:
         }
     }
 
-    void createVar(const VarType &type, const std::string &name, const Value &value)
+    void createVar(const VarType &type, const std::string &name, const Value &value, bool isParam)
     {
-        current_scope->createVar(type, name, value);
+        current_scope->createVar(type, name, value, isParam);
+    }
+
+    VariableAddress resolveVariableAddress(const std::string &name)
+    {
+        for (auto scope = scopes.rbegin(); scope != scopes.rend(); ++scope)
+        {
+            if ((*scope)->varExistsInHierarchy(name))
+                return (*scope)->resolveVariableAddressInHierarchy(name);
+        }
+
+        throw std::runtime_error("Undefined variable: " + name + " (scope: " + current_scope->scope_name + ")");
     }
 
     Value getVar(const std::string &name) const
     {
-        // FIXME: speed it up:
-        //  1 - Store scope level 'enum class ScopeLevel { PARAMS, INSTANCE_ATTR, GLOBAL };' at parseTime on GetParamExpr|GetAttributeExpr|GetGlobalVarExpr
-        //  2 - store an index into the Heart (like int slot) at parse time, so getVar doesn’t even need to hash the 'name' at runtime — just array access.
+        // FIXME: Use only 'getVar(const VariableAddress address)', which is faster then this 'getVar(const std::string &name)'
+        for (auto scope = scopes.rbegin(); scope != scopes.rend(); ++scope)
+        {
+            if ((*scope)->varExistsInHierarchy(name))
+            {
+                auto address = (*scope)->resolveVariableAddressInHierarchy(name);
+                return (*scope)->getVar(address);
+            }
+        }
 
+        throw std::runtime_error("Undefined variable: " + name + " (scope: " + current_scope->scope_name + ")");
+    }
+
+    Value getVar(const VariableAddress address) const
+    {
         // Iterate over the scopes in reverse order (rbegin, rend)
         for (auto scope = scopes.rbegin(); scope != scopes.rend(); ++scope)
         {
-            auto isVarOnScope = (*scope)->varExistsInHierarchy(name);
-            if (isVarOnScope)
-                return (*scope)->getVar(name);
+            if ((*scope)->scopeId == address.scopeId)
+                return (*scope)->getVar(address);
         }
 
-        return current_scope->getVar(name);
+        return current_scope->getVar(address);
     }
 
     void updateVar(const std::string &name, const Value &value)
     {
-        // FIXME: speed it up:
-        //  1 - Store scope level 'enum class ScopeLevel { PARAMS, INSTANCE_ATTR, GLOBAL };' at parseTime on GetParamExpr|GetAttributeExpr|GetGlobalVarExpr
-        //  2 - store an index into the Heart (like int slot) at parse time, so getVar doesn’t even need to hash the 'name' at runtime — just array access.
+        // FIXME: Use only 'updateVar(const VariableAddress address', which is faster then this 'updateVar(const std::string &name'
+        for (auto scope = scopes.rbegin(); scope != scopes.rend(); ++scope)
+        {
+            if ((*scope)->varExistsInHierarchy(name))
+            {
+                auto address = (*scope)->resolveVariableAddressInHierarchy(name);
+                (*scope)->updateVar(address, value);
+                return;
+            }
+        }
 
+        throw std::runtime_error("Undefined variable: " + name + " (scope: " + current_scope->scope_name + ")");
+    }
+
+    void updateVar(const VariableAddress address, const Value &value)
+    {
         // Iterate over the scopes in reverse order (rbegin, rend)
         for (auto scope = scopes.rbegin(); scope != scopes.rend(); ++scope)
         {
-            auto isVarOnScope = (*scope)->varExistsInHierarchy(name);
-            if (isVarOnScope)
+            if ((*scope)->scopeId == address.scopeId)
             {
-                (*scope)->updateVar(name, value);
+                (*scope)->updateVar(address.slot, value);
 
                 return;
             }
         }
 
-        current_scope->updateVar(name, value);
+        throw std::runtime_error("Invalid variable address (scopeId=" + std::to_string(address.scopeId) + ", slot=" + std::to_string(address.slot) + ").");
     }
 
     std::shared_ptr<CreationType> getVarType(const std::string &varName)
@@ -107,6 +139,12 @@ public:
     void registerVarType(const VarType &type, const std::string &name)
     {
         current_scope->registerVarType(type, name);
+    }
+
+    VariableAddress declareVar(const VarType &type, const std::string &name)
+    {
+        const bool isParam = false;
+        return current_scope->declareVar(type, name, isParam);
     }
 
     void updatePolymorphicVarType(const std::string &name, const VarType &type)

--- a/src/jesus/tests/repl/040-many-tests.jesus.expected
+++ b/src/jesus/tests/repl/040-many-tests.jesus.expected
@@ -4,7 +4,7 @@ CreateVarStmt(messiah, LiteralExpr(Jesus))
 CreateVarStmt(age, LiteralExpr((int) 33))
 CreateVarStmt(priest, LiteralExpr(me))
 CreateVarStmt(average, LiteralExpr((double) 2.300000))
-PrintStmt(SAY: VariableExpr(age))
+PrintStmt(SAY: VariableExpr('age'))
 (Jesus) Jesus
 (Jesus) me
 (Jesus) (int) 33
@@ -102,15 +102,15 @@ PrintStmt(SAY: VariableExpr(age))
 (Jesus) (Jesus) (int) 0
 (Jesus) (Jesus) (double) 3.140000
 (Jesus) (Jesus) (double) -6.000000
-(Jesus) ❌ Error: Unknown base type: 'positive'
+(Jesus) ❌ Error: Unknown variable type: 'positive'
 (Jesus) ❌ Error: Undefined variable: elders (scope: __jesus__)
-(Jesus) ❌ Error: Unknown base type: 'positive'
+(Jesus) ❌ Error: Unknown variable type: 'positive'
 (Jesus) ❌ Error: Undefined variable: sinful (scope: __jesus__)
-(Jesus) ❌ Error: Unknown base type: 'negative'
+(Jesus) ❌ Error: Unknown variable type: 'negative'
 (Jesus) ❌ Error: Undefined variable: debt (scope: __jesus__)
-(Jesus) ❌ Error: Unknown base type: 'negative'
+(Jesus) ❌ Error: Unknown variable type: 'negative'
 (Jesus) ❌ Error: Undefined variable: credit (scope: __jesus__)
-(Jesus) ❌ Error: Unknown base type: 'negative'
+(Jesus) ❌ Error: Unknown variable type: 'negative'
 (Jesus) ❌ Error: Undefined variable: void (scope: __jesus__)
 (Jesus) (Jesus) (int) 7
 (Jesus) ❌ Error: Expected value >= (double) 0.000000
@@ -137,7 +137,7 @@ Example:
 1 John 1:9 — If we confess our sins (to Jesus Christ, not to man), he is faithful and just and will forgive us our sins and purify us from all unrighteousness.
 ❌ Error: Invalid value '(int) 13' for variable 'rebellion' declared as type text
 (Jesus) ❌ Error: Undefined variable: rebellion (scope: __jesus__)
-(Jesus) ❌ Error: Unknown base type: 'car'
+(Jesus) ❌ Error: Unknown variable type: 'car'
 (Jesus) ❌ Error: Undefined variable: hilux (scope: __jesus__)
 (Jesus) (Jesus) (int) 490
 (Jesus) (Jesus) Jesus loves YOU
@@ -192,9 +192,9 @@ What is your age again (curent: (int) 33)? (Jesus) (double) 2025.000000
 (Jesus) {type: "instance",
  class: "Person",
  attributes: {
-  age: "(int) 930",
+  name: "Adam",
   wife: "Eve",
-  name: "Adam"
+  age: "(int) 930"
  }
 }
 (Jesus) I am inside functionWithoutParams
@@ -227,9 +227,9 @@ null
 (Jesus) Hi, {type: "instance",
  class: "Person",
  attributes: {
-  age: "(int) 930",
+  name: "Adopted by Jesus Christ",
   wife: "Eve",
-  name: "Adopted by Jesus Christ"
+  age: "(int) 930"
  }
 } (double-quoted)
 (Jesus) Your name is Adopted by Jesus Christ
@@ -311,7 +311,15 @@ null
 (Jesus) (Jesus) Inside try-repent.
 Pleas forgive my sins, Oh God Almighty.
 God always wins.
-(Jesus) (Jesus) CreateClassStmt
+(Jesus) (Jesus) CreateClassStmt(name: 'GrandSon', body: [
+  CreateVarStmt(surname, LiteralExpr(Isaacson)),
+  CreateMethodStmt('praise', body: [
+    UpdateVarStmt('name', value: LiteralExpr(Jacob)),
+    PrintStmt(SAY: FormattedStringExpr("Bethel ({name} {surname}),)")]),
+  CreateMethodStmt('who', body: [
+    PrintStmt(SAY: FormattedStringExpr("I am Israel, previously named {name}.)")]),
+  CreateMethodStmt('generateJudah', body: [
+    PrintStmt(SAY: FormattedStringExpr("Judah is my lion, and my name is {name}.)")])])
 AST Memory: 8 bytes
 (Jesus) (Jesus) Class name 'Alien' does not appear to reflect God's standards.
 To hide this warning, declare the class explicitly as 'ungodly'.
@@ -349,18 +357,16 @@ It has 3 elements (valid indexes: 0 to 2).
 (Jesus) (Jesus) (Jesus) (Jesus) [[{type: "instance",
  class: "Son",
  attributes: {
-  surname: "Terahson",
-  name: "Jacob"
-
-  surname: "Hijo"
+  surname: "Hijo",
+  name: "Abraham"
  }
 }]]
 (Jesus) (Jesus) Apostle Matt
 Apostle Marcos
 Apostle Luke
-(Jesus) Luke
+(Jesus) null
 (Jesus) (Jesus) (Jesus) name -> Jesus
 surname -> Christ
 role -> Savior
-(Jesus) Savior
+(Jesus) null
 (Jesus) 

--- a/src/jesus/types/composite/dict_type.cpp
+++ b/src/jesus/types/composite/dict_type.cpp
@@ -5,12 +5,13 @@
 
 void DictType::registerMethods()
 {
+    const bool isParam = true;
     // ----------------
     // contains(key)
     // ----------------
     {
         auto params = std::make_shared<Heart>("dict.contains");
-        params->createVar(keyType, "key", Value::formless());
+        params->createVar(keyType, "key", Value::formless(), isParam);
         addMethod("contains", std::make_shared<NativeMethod>("contains", params, KnownTypes::BOOLEAN, DictType::contains));
     }
 
@@ -19,7 +20,7 @@ void DictType::registerMethods()
     // -------------
     {
         auto params = std::make_shared<Heart>("dict.remove");
-        params->createVar(keyType, "key", Value::formless());
+        params->createVar(keyType, "key", Value::formless(), isParam);
         addMethod("remove", std::make_shared<NativeMethod>("remove", params, KnownTypes::BOOLEAN, DictType::remove));
     }
 
@@ -78,8 +79,8 @@ void DictType::registerMethods()
     // ------
     {
         auto params = std::make_shared<Heart>("dict.get");
-        params->createVar(keyType, "key", Value::formless());
-        params->createVar(valueType, "default", Value::formless());
+        params->createVar(keyType, "key", Value::formless(), isParam);
+        params->createVar(valueType, "default", Value::formless(), isParam);
         addMethod("get", std::make_shared<NativeMethod>("get", params, valueType, DictType::get));
     }
 
@@ -96,7 +97,7 @@ void DictType::registerMethods()
     // ---------
     {
         auto params = std::make_shared<Heart>("dict.update");
-        params->createVar(KnownTypes::DICT, "other", Value::formless());
+        params->createVar(KnownTypes::DICT, "other", Value::formless(), isParam);
         addMethod("update", std::make_shared<NativeMethod>("update", params, KnownTypes::VOID, DictType::update));
     }
 }

--- a/src/jesus/types/composite/list_type.cpp
+++ b/src/jesus/types/composite/list_type.cpp
@@ -4,12 +4,13 @@
 
 void ListType::registerMethods()
 {
+    const bool isParam = true;
     // -----------
     // add(value)
     // -----------
     {
         auto params = std::make_shared<Heart>("list.add");
-        params->createVar(elementType, "item", Value::formless());
+        params->createVar(elementType, "item", Value::formless(), isParam);
         addMethod("add", std::make_shared<NativeMethod>("add", params, KnownTypes::VOID, ListType::addItem));
     }
 
@@ -18,7 +19,7 @@ void ListType::registerMethods()
     // --------------
     {
         auto params = std::make_shared<Heart>("list.remove");
-        params->createVar(elementType, "item", Value::formless());
+        params->createVar(elementType, "item", Value::formless(), isParam);
         addMethod("remove", std::make_shared<NativeMethod>("remove", params, KnownTypes::BOOLEAN, ListType::removeItem));
     }
 
@@ -27,7 +28,7 @@ void ListType::registerMethods()
     // -----------------
     {
         auto params = std::make_shared<Heart>("list.remove_at");
-        params->createVar(KnownTypes::INT, "index", Value::formless());
+        params->createVar(KnownTypes::INT, "index", Value::formless(), isParam);
         addMethod("remove_at", std::make_shared<NativeMethod>("remove_at", params, elementType, ListType::removeAt));
     }
 
@@ -52,7 +53,7 @@ void ListType::registerMethods()
     // ----------------
     {
         auto params = std::make_shared<Heart>("list.contains");
-        params->createVar(elementType, "item", Value::formless());
+        params->createVar(elementType, "item", Value::formless(), isParam);
         addMethod("contains", std::make_shared<NativeMethod>("contains", params, KnownTypes::BOOLEAN, ListType::contains));
     }
 

--- a/src/jesus/types/creation_type.hpp
+++ b/src/jesus/types/creation_type.hpp
@@ -49,21 +49,14 @@ public:
 
     CreationType(PrimitiveType primitive_type, std::string name, std::string module = "core",
                  std::shared_ptr<CreationType> parent = nullptr,
+                 std::shared_ptr<Heart> attributes = nullptr,
                  std::vector<std::shared_ptr<IConstraint>> constraints = {})
         : primitive_type(primitive_type),
           name(name), module_name(module),
           parent_class(std::move(parent)),
+          class_attributes(std::move(attributes)),
           constraints(std::move(constraints)), id(lastId++)
     {
-
-        if (primitive_type == PrimitiveType::Class)
-        {
-            std::shared_ptr<Heart> parent_attributes = nullptr;
-            if (parent_class)
-                parent_attributes = parent_class->class_attributes;
-
-            class_attributes = std::make_shared<Heart>(name, parent_attributes);
-        }
     }
 
     virtual Value parseFromString(const std::string &raw) const
@@ -129,12 +122,8 @@ public:
             initVal = initializer->evaluate(heart);
         }
 
-        class_attributes->createVar(type, name, initVal);
-    }
-
-    const Value getAttribute(const std::string &name) const
-    {
-        return class_attributes->getVar(name);
+        const bool isParam = false;
+        class_attributes->createVar(type, name, initVal, isParam);
     }
 
     void addMethod(const std::string &name, std::shared_ptr<IMethod> method)

--- a/src/jesus/vm/compiler.cpp
+++ b/src/jesus/vm/compiler.cpp
@@ -270,12 +270,7 @@ void Compiler::compileCreateClassStmt(const CreateClassStmt &stmt)
     std::vector<std::shared_ptr<IConstraint>> constraints; // no constraints yet
 
     auto scope = std::make_shared<Heart>("class::" + stmt.name);
-    auto userClass = std::make_shared<CreationType>(
-        PrimitiveType::Class,
-        stmt.name,
-        stmt.module_name,
-        stmt.parent_class,
-        constraints);
+    auto userClass = stmt.userClass;
 
     for (const auto &member : stmt.body)
     {
@@ -284,24 +279,18 @@ void Compiler::compileCreateClassStmt(const CreateClassStmt &stmt)
         // -----------------
         if (auto attr = dynamic_cast<CreateVarStmt *>(member.get()))
         {
-            userClass->addAttribute(attr->base_type, attr->name, std::move(attr->value), scope);
+            auto initialValue = attr->value->evaluate(scope);
+            userClass->class_attributes->updateVar(attr->address.slot, initialValue);
         }
         // --------------
         // handle methods
         // --------------
         else if (auto methodStmt = dynamic_cast<CreateMethodStmt *>(member.get()))
         {
-            auto method = std::make_shared<Method>(
-                methodStmt->name,
-                methodStmt->params,
-                methodStmt->body,
-                methodStmt->returnType);
-
-            userClass->addMethod(methodStmt->name, method);
         }
         else
         {
-            throw std::runtime_error("Class body member not supported yet");
+            throw std::runtime_error("Class body member not supported yet: " + member->toString());
         }
     }
 

--- a/src/jesus/vm/vm.cpp
+++ b/src/jesus/vm/vm.cpp
@@ -229,7 +229,7 @@ void VM::run(const Chunk &chunk)
 
                     if (auto getAttr = dynamic_cast<const VariableExpr *>(returnStmt->value.get()))
                     {
-                        stack.push_back(instance.toInstance()->getAttribute(getAttr->name));
+                        stack.push_back(instance.toInstance()->getAttribute(getAttr->address));
                         ++ip;
                         break;
                     }


### PR DESCRIPTION

# Description

This PR introduces two improvements:

1. Replaces variable name lookups with **slot-based** addressing throughout the language runtime.
2. Adds dedicated Makefile targets for release, debug, and profiling builds.

## Variable slot addressing

The runtime now resolves variables through `VariableAddress { slot, scopeId }` instead of repeatedly searching by variable name.

`Heart` storage was redesigned from:

```cpp
std::unordered_map<std::string, Value> variables;
````

to:

```cpp
std::unordered_map<std::string, uint32_t> slots;
std::vector<Value> values;
```

This allows variables to be resolved once during parsing and accessed directly by slot during execution.

### Benefits

* Faster interpreter execution
* Faster VM execution
* O(1) indexed variable access
* Reduced runtime hash lookups

## Build improvements

The `Makefile` now supports dedicated build configurations:

```bash
make          # release (default)
make debug
make profile
```

These targets make it easier to debug, benchmark, and optimize the language.

## Notes

This refactor touches multiple compiler and runtime components because variable addressing is shared across:

* Parser
* AST
* Symbol table
* Interpreter
* Virtual Machine
* Runtime (`Heart`, `Instance`, `Method`)
* Tests

Although many files changed, they are all part of _one logical change_.


# ✝️ Wisdom

> "Test everything; hold fast what is good." — **_1 Thessalonians 5:21_**