### PR TITLE
Step 93: feat(optimizer): Added ConstantFolder optimizer and related tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,12 @@ set(JESUS_CPP_FILES
     src/jesus/parser/grammar/stmt/on_stmt_rule.cpp
     src/jesus/parser/grammar/stmt/serve_stmt_rule.cpp
 
+    # ---------
+    # Optimizer
+    # ---------
+    src/jesus/optimizer/optimizer.cpp
+    src/jesus/optimizer/constant_folder.cpp
+
     # -----------
     # Interpreter
     # -----------

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Make sure both the `jesus` binary and the `test_runner` are built. Build the `te
 ```
 cd src/jesus/
 
-g++ -std=c++17 -o test_runner test_runner.cpp
+g++ -std=c++23 -o test_runner test_runner.cpp
 ```
 
 Then simply run:

--- a/src/jesus/ast/expr/binary_expr.cpp
+++ b/src/jesus/ast/expr/binary_expr.cpp
@@ -1,6 +1,7 @@
 #include "binary_expr.hpp"
-#include "../../interpreter/expr_visitor.hpp"
-#include "../../types/creation_type.hpp"
+#include "interpreter/expr_visitor.hpp"
+#include "types/creation_type.hpp"
+#include "types/known_types.hpp"
 
 Value BinaryExpr::accept(ExprVisitor &visitor) const
 {
@@ -9,5 +10,53 @@ Value BinaryExpr::accept(ExprVisitor &visitor) const
 
 std::shared_ptr<CreationType> BinaryExpr::getReturnType(ParserContext &ctx) const
 {
-    return right->getReturnType(ctx);
-};
+    switch (op.type)
+    {
+    case TokenType::LESS:
+    case TokenType::LESS_EQUAL:
+    case TokenType::GREATER:
+    case TokenType::GREATER_EQUAL:
+    case TokenType::IS:
+    case TokenType::NOT_EQUAL:
+    case TokenType::AND:
+    case TokenType::OR:
+        return KnownTypes::TRUTH;
+
+    case TokenType::VERSUS:
+    {
+        // bool XOR bool -> truth
+        if (left->getReturnType(ctx) == KnownTypes::TRUTH)
+            return KnownTypes::TRUTH;
+
+        // int XOR int -> int
+        return KnownTypes::INT;
+    }
+
+    case TokenType::PLUS:
+    case TokenType::MINUS:
+    case TokenType::STAR:
+    case TokenType::MOD:
+    {
+        auto leftType = left->getReturnType(ctx);
+        auto rightType = right->getReturnType(ctx);
+
+        if (leftType == KnownTypes::STRING || rightType == KnownTypes::STRING)
+        {
+            return KnownTypes::STRING;
+        }
+
+        if (leftType == KnownTypes::DOUBLE || rightType == KnownTypes::DOUBLE)
+        {
+            return KnownTypes::DOUBLE;
+        }
+
+        return KnownTypes::INT;
+    }
+
+    case TokenType::SLASH:
+        return KnownTypes::DOUBLE;
+
+    default:
+        return right->getReturnType(ctx);
+    }
+}

--- a/src/jesus/ast/expr/grouping_expr.hpp
+++ b/src/jesus/ast/expr/grouping_expr.hpp
@@ -47,6 +47,11 @@ public:
         return expression->evaluate(heart);
     }
 
+    bool canEvaluateAtParseTime() const override
+    {
+        return expression ? expression->canEvaluateAtParseTime() : false;
+    }
+
     Value accept(ExprVisitor &visitor) const override;
 
     /**

--- a/src/jesus/ast/stmt/if_stmt.hpp
+++ b/src/jesus/ast/stmt/if_stmt.hpp
@@ -16,7 +16,7 @@ REGISTER_FOR_UML(
 class IfStmt : public Stmt
 {
 public:
-  const std::unique_ptr<Expr> condition;
+  std::unique_ptr<Expr> condition;
   std::vector<std::unique_ptr<Stmt>> thenBranch;
   std::vector<std::unique_ptr<Stmt>> otherwiseBranch;
 

--- a/src/jesus/cli/cli_parser.cpp
+++ b/src/jesus/cli/cli_parser.cpp
@@ -53,6 +53,27 @@ ParsedCLI CLIParser::parse(int argc, char **argv)
             continue;
         }
 
+        // -----------------------------------------------------------------------
+        // By default, the AST is only preserved in the REPL, which is started by
+        // running `jesus` without a source file. This allows users to inspect the
+        // original (non-optimized) AST with the `ast` command while learning how
+        // the parser builds the syntax tree.
+        //
+        // When executing a source file (e.g. `jesus program.jesus`), the compiler
+        // performs optimization passes before execution. The optimized AST is then
+        // discarded because it is no longer needed, reducing memory usage.
+        //
+        // The `--keep-ast` option preserves the optimized AST when executing a
+        // source file, allowing users to inspect the result of the optimization
+        // passes with the `ast` command. This option exists primarily for learning,
+        // debugging, and developing the compiler.
+        // -----------------------------------------------------------------------
+        if (arg == "--keep-ast")
+        {
+            out.keepAst = true;
+            continue;
+        }
+
         if (arg.starts_with("-"))
         {
             std::cerr << "Unknown option: " << arg << "\n";

--- a/src/jesus/cli/cli_parser.hpp
+++ b/src/jesus/cli/cli_parser.hpp
@@ -11,6 +11,7 @@ REGISTER_FOR_UML(
 struct ParsedCLI
 {
     bool quiet = false;
+    bool keepAst = false;
     bool showHelp = false;
     bool fileExists = false;
     bool showBibleHelp = false;

--- a/src/jesus/cli/faith.cpp
+++ b/src/jesus/cli/faith.cpp
@@ -1,7 +1,8 @@
 #include "faith.hpp"
 #include "lexer/lexer.hpp"
 #include "parser/parser.hpp"
-#include "../utils/file_utils.hpp"
+#include "utils/file_utils.hpp"
+#include "optimizer/optimizer.hpp"
 #include "vm/compiler.hpp"
 #include "vm/vm.hpp"
 
@@ -20,6 +21,9 @@ void Faith::interpret(Interpreter &jesus, const std::string &source, const std::
             statements.push_back(std::move(stmt));
     }
 
+    Optimizer optimizer;
+    optimizer.optimize(statements);
+
     if (useVm)
     {
         Compiler compiler;
@@ -30,8 +34,21 @@ void Faith::interpret(Interpreter &jesus, const std::string &source, const std::
         return;
     }
 
-    for (auto &you : statements)
-        jesus.loves(you);
+    if (keepAst)
+    {
+        for (auto &you : statements)
+        {
+            jesus.loves(you);
+            jesus.persistAST(std::move(you));
+        }
+    }
+    else
+    {
+        for (auto &you : statements)
+        {
+            jesus.loves(you);
+        }
+    }
 }
 
 int Faith::execute(std::string filename)
@@ -42,7 +59,7 @@ int Faith::execute(std::string filename)
         std::string moduleName = utils::basenameWithoutExtension(filename);
 
         auto newModule = Interpreter::createModule(moduleName, filename);
-        Interpreter jesus(newModule, useVm);
+        Interpreter jesus(newModule, useVm, keepAst);
 
         interpret(jesus, source, moduleName);
         return 0;

--- a/src/jesus/cli/faith.hpp
+++ b/src/jesus/cli/faith.hpp
@@ -26,7 +26,7 @@ REGISTER_FOR_UML(
 class Faith
 {
 public:
-    explicit Faith(bool useVm) : useVm(useVm) {};
+    explicit Faith(bool useVm, bool keepAst) : useVm(useVm), keepAst(keepAst) {};
 
     /**
      * @brief Loads a file and execute it.
@@ -37,6 +37,7 @@ public:
 
 private:
     bool useVm;
+    bool keepAst;
     /**
      * @brief Interpret and execute the source of a file
      *

--- a/src/jesus/interpreter/interpreter.cpp
+++ b/src/jesus/interpreter/interpreter.cpp
@@ -800,7 +800,7 @@ void Interpreter::visitImportModuleStmt(const ImportModuleStmt &stmt)
         // --------------------
         // Interpret the module
         // --------------------
-        Faith michael(useVm);
+        Faith michael(useVm, keepAst);
         michael.execute(fullpath); // Declare classes, methods, etc.
     }
     auto importedModule = Interpreter::getModule(fullpath);

--- a/src/jesus/interpreter/interpreter.hpp
+++ b/src/jesus/interpreter/interpreter.hpp
@@ -54,8 +54,8 @@ REGISTER_FOR_UML(
 class Interpreter : public ExprVisitor, public StmtVisitor
 {
 public:
-    explicit Interpreter(std::shared_ptr<Module> module, bool useVm)
-        : currentModule(module), httpRuntime(*this), useVm(useVm),
+    explicit Interpreter(std::shared_ptr<Module> module, bool useVm, bool keepAst)
+        : currentModule(module), httpRuntime(*this), useVm(useVm), keepAst(keepAst),
           typeRegistry(std::make_shared<TypeRegistry>()) {}
     /**
      * @brief Evaluates a given expression and returns its computed value.
@@ -198,6 +198,7 @@ public:
     }
 
     std::shared_ptr<Module> currentModule;
+    const bool keepAst;
 
 private:
     /**

--- a/src/jesus/main.cpp
+++ b/src/jesus/main.cpp
@@ -83,7 +83,7 @@ int main(int argc, char **argv)
             return 1;
         }
 
-        Faith michael(cli.useVm);
+        Faith michael(cli.useVm, cli.keepAst);
         return michael.execute(cli.filename);
     }
 
@@ -99,7 +99,8 @@ int main(int argc, char **argv)
     auto scope = std::make_shared<Heart>(replName);
     auto symbol_table = std::make_shared<SymbolTable>(scope);
     auto repl = std::make_shared<Module>(replName, replPath, symbol_table);
-    Interpreter jesus(repl, cli.useVm);
+    cli.keepAst = true;
+    Interpreter jesus(repl, cli.useVm, cli.keepAst);
 
     Disciple follower(jesus);
     follower.walk();

--- a/src/jesus/optimizer/constant_folder.cpp
+++ b/src/jesus/optimizer/constant_folder.cpp
@@ -1,0 +1,316 @@
+#include "constant_folder.hpp"
+
+#include "ast/stmt/create_var_stmt.hpp"
+#include "ast/stmt/update_var_stmt.hpp"
+#include "ast/stmt/assign_stmt.hpp"
+#include "ast/stmt/print_stmt.hpp"
+#include "ast/stmt/return_stmt.hpp"
+#include "ast/stmt/if_stmt.hpp"
+#include "ast/stmt/repeat_while_stmt.hpp"
+#include "ast/stmt/repeat_times_stmt.hpp"
+#include "ast/stmt/repeat_forever_stmt.hpp"
+#include "ast/stmt/for_each_stmt.hpp"
+#include "ast/stmt/create_class_stmt.hpp"
+#include "ast/stmt/create_method_stmt.hpp"
+#include "ast/stmt/try_stmt.hpp"
+#include "ast/stmt/resist_stmt.hpp"
+
+#include "ast/expr/literal_expr.hpp"
+#include "ast/expr/grouping_expr.hpp"
+#include "ast/expr/unary_expr.hpp"
+#include "ast/expr/binary_expr.hpp"
+#include "ast/expr/list_expr.hpp"
+#include "ast/expr/dict_expr.hpp"
+#include "ast/expr/conditional_expr.hpp"
+// #include "ast/expr/formatted_string_expr.hpp"
+#include "ast/expr/method_call_expr.hpp"
+#include "ast/expr/get_attr_expr.hpp"
+#include "ast/expr/index_expr.hpp"
+
+#include "types/known_types.hpp"
+
+void ConstantFolder::run(std::vector<std::unique_ptr<Stmt>> &program)
+{
+    for (auto &stmt : program)
+    {
+        if (stmt)
+            optimizeStatement(*stmt);
+    }
+}
+
+void ConstantFolder::optimizeStatement(Stmt &statement)
+{
+    if (auto create = dynamic_cast<CreateVarStmt *>(&statement))
+    {
+        create->value = optimizeExpression(std::move(create->value));
+        return;
+    }
+
+    if (auto update = dynamic_cast<UpdateVarStmt *>(&statement))
+    {
+        update->value = optimizeExpression(std::move(update->value));
+        return;
+    }
+
+    if (auto assign = dynamic_cast<AssignStmt *>(&statement))
+    {
+        assign->value = optimizeExpression(std::move(assign->value));
+        return;
+    }
+
+    if (auto printStmt = dynamic_cast<PrintStmt *>(&statement))
+    {
+        printStmt->message = optimizeExpression(std::move(printStmt->message));
+        return;
+    }
+
+    if (auto returnStmt = dynamic_cast<ReturnStmt *>(&statement))
+    {
+        returnStmt->value = optimizeExpression(std::move(returnStmt->value));
+        return;
+    }
+
+    if (auto ifStmt = dynamic_cast<IfStmt *>(&statement))
+    {
+        ifStmt->condition = optimizeExpression(std::move(ifStmt->condition));
+
+        for (auto &child : ifStmt->thenBranch)
+            if (child)
+                optimizeStatement(*child);
+
+        for (auto &child : ifStmt->otherwiseBranch)
+            if (child)
+                optimizeStatement(*child);
+
+        return;
+    }
+
+    if (auto repeatWhile = dynamic_cast<RepeatWhileStmt *>(&statement))
+    {
+        repeatWhile->condition = optimizeExpression(std::move(repeatWhile->condition));
+        for (auto &child : repeatWhile->body)
+            if (child)
+                optimizeStatement(*child);
+        return;
+    }
+
+    if (auto repeatTimes = dynamic_cast<RepeatTimesStmt *>(&statement))
+    {
+        repeatTimes->countExpr = optimizeExpression(std::move(repeatTimes->countExpr));
+        for (auto &child : repeatTimes->body)
+            if (child)
+                optimizeStatement(*child);
+        return;
+    }
+
+    if (auto repeatForever = dynamic_cast<RepeatForeverStmt *>(&statement))
+    {
+        for (auto &child : repeatForever->body)
+            if (child)
+                optimizeStatement(*child);
+        return;
+    }
+
+    if (auto forEach = dynamic_cast<ForEachStmt *>(&statement))
+    {
+        forEach->iterable = optimizeExpression(std::move(forEach->iterable));
+        for (auto &child : forEach->body)
+            if (child)
+                optimizeStatement(*child);
+        return;
+    }
+
+    if (auto createClass = dynamic_cast<CreateClassStmt *>(&statement))
+    {
+        for (auto &child : createClass->body)
+            if (child)
+                optimizeStatement(*child);
+        return;
+    }
+
+    if (auto createMethod = dynamic_cast<CreateMethodStmt *>(&statement))
+    {
+        for (auto &child : createMethod->body)
+            if (child)
+                optimizeStatement(*child);
+        return;
+    }
+
+    if (auto tryStmt = dynamic_cast<TryStmt *>(&statement))
+    {
+        for (auto &child : tryStmt->tryBody)
+            if (child)
+                optimizeStatement(*child);
+
+        for (auto &[type, body] : tryStmt->catchClauses)
+            for (auto &child : body)
+                if (child)
+                    optimizeStatement(*child);
+
+        for (auto &child : tryStmt->alwaysBody)
+            if (child)
+                optimizeStatement(*child);
+
+        return;
+    }
+
+    if (auto resist = dynamic_cast<ResistStmt *>(&statement))
+    {
+        resist->messageExpr = optimizeExpression(std::move(resist->messageExpr));
+        return;
+    }
+}
+
+std::unique_ptr<Expr> ConstantFolder::optimizeExpression(std::unique_ptr<Expr> expression)
+{
+    if (!expression)
+        return nullptr;
+
+    if (auto grouping = dynamic_cast<GroupingExpr *>(expression.get()))
+    {
+        grouping->expression = optimizeExpression(std::move(grouping->expression));
+        if (grouping->canEvaluateAtParseTime())
+        {
+            try
+            {
+                auto value = grouping->evaluate(nullptr);
+                return createLiteral(value);
+            }
+            catch (...)
+            {
+            }
+        }
+        return expression;
+    }
+
+    if (auto unary = dynamic_cast<UnaryExpr *>(expression.get()))
+    {
+        unary->right = optimizeExpression(std::move(unary->right));
+        if (unary->canEvaluateAtParseTime())
+        {
+            try
+            {
+                auto value = unary->evaluate(nullptr);
+                return createLiteral(value);
+            }
+            catch (...)
+            {
+            }
+        }
+        return expression;
+    }
+
+    if (auto binary = dynamic_cast<BinaryExpr *>(expression.get()))
+    {
+        return optimizeBinaryExpr(
+            std::unique_ptr<BinaryExpr>(static_cast<BinaryExpr *>(expression.release())));
+    }
+
+    if (auto listExpr = dynamic_cast<ListExpr *>(expression.get()))
+    {
+        for (auto &el : listExpr->elements)
+            el = optimizeExpression(std::move(el));
+
+        return expression;
+    }
+
+    if (auto dictExpr = dynamic_cast<DictExpr *>(expression.get()))
+    {
+        for (auto &[k, v] : dictExpr->entries)
+        {
+            k = optimizeExpression(std::move(k));
+            v = optimizeExpression(std::move(v));
+        }
+        return expression;
+    }
+
+    if (auto condExpr = dynamic_cast<ConditionalExpr *>(expression.get()))
+    {
+        condExpr->condition = optimizeExpression(std::move(condExpr->condition));
+        condExpr->thenBranch = optimizeExpression(std::move(condExpr->thenBranch));
+        condExpr->elseBranch = optimizeExpression(std::move(condExpr->elseBranch));
+
+        if (condExpr->canEvaluateAtParseTime())
+        {
+            try
+            {
+                auto value = condExpr->evaluate(nullptr);
+                return createLiteral(value);
+            }
+            catch (...)
+            {
+            }
+        }
+        return expression;
+    }
+
+    if (auto methodCall = dynamic_cast<MethodCallExpr *>(expression.get()))
+    {
+        if (methodCall->object)
+            methodCall->object = optimizeExpression(std::move(methodCall->object));
+
+        for (auto &arg : methodCall->args)
+            arg = optimizeExpression(std::move(arg));
+
+        return expression;
+    }
+
+    if (auto getAttr = dynamic_cast<GetAttributeExpr *>(expression.get()))
+    {
+        if (getAttr->object)
+            getAttr->object = optimizeExpression(std::move(getAttr->object));
+
+        return expression;
+    }
+
+    if (auto indexExpr = dynamic_cast<IndexExpr *>(expression.get()))
+    {
+        if (indexExpr->collection)
+            indexExpr->collection = optimizeExpression(std::move(indexExpr->collection));
+
+        if (indexExpr->index)
+            indexExpr->index = optimizeExpression(std::move(indexExpr->index));
+
+        return expression;
+    }
+
+    return expression;
+}
+
+std::unique_ptr<Expr> ConstantFolder::optimizeBinaryExpr(std::unique_ptr<BinaryExpr> expression)
+{
+    expression->left = optimizeExpression(std::move(expression->left));
+    expression->right = optimizeExpression(std::move(expression->right));
+
+    if (!expression->canEvaluateAtParseTime())
+        return expression;
+
+    try
+    {
+        auto value = expression->evaluate(nullptr);
+        return createLiteral(value);
+    }
+    catch (...)
+    {
+    }
+
+    return expression;
+}
+
+std::unique_ptr<Expr> ConstantFolder::createLiteral(const Value &value)
+{
+    std::shared_ptr<CreationType> type = KnownTypes::NOTHING;
+    if (value.IS_INT)
+        type = KnownTypes::INT;
+
+    else if (value.IS_DOUBLE)
+        type = KnownTypes::DOUBLE;
+
+    else if (value.IS_BOOLEAN)
+        type = KnownTypes::BOOLEAN;
+
+    else if (value.IS_STRING)
+        type = KnownTypes::STRING;
+
+    return std::make_unique<LiteralExpr>(value, type);
+}

--- a/src/jesus/optimizer/constant_folder.hpp
+++ b/src/jesus/optimizer/constant_folder.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <vector>
+#include <memory>
+#include "ast/stmt/stmt.hpp"
+#include "ast/expr/expr.hpp"
+#include "ast/expr/binary_expr.hpp"
+
+/**
+ * @brief Replaces compile-time constant expressions with their computed values.
+ *
+ * Example:
+ *
+ *     create number result = (2 + 3) * 4
+ *
+ * becomes:
+ *
+ *     create number result = 20
+ *
+ * "When you beat the olives from your trees, do not go over the branches a second time.
+ * Leave what remains for the foreigner, the fatherless and the widow."
+ * — Deuteronomy 24:20
+ */
+class ConstantFolder
+{
+  public:
+    void run(std::vector<std::unique_ptr<Stmt>> &program);
+
+  private:
+    void optimizeStatement(Stmt &statement);
+
+    std::unique_ptr<Expr> optimizeExpression(std::unique_ptr<Expr> expression);
+
+    std::unique_ptr<Expr> optimizeBinaryExpr(std::unique_ptr<BinaryExpr> expression);
+
+    std::unique_ptr<Expr> createLiteral(const Value &value);
+};

--- a/src/jesus/optimizer/optimizer.cpp
+++ b/src/jesus/optimizer/optimizer.cpp
@@ -1,0 +1,7 @@
+#include "optimizer.hpp"
+#include "constant_folder.hpp"
+
+void Optimizer::optimize(std::vector<std::unique_ptr<Stmt>> &program)
+{
+    ConstantFolder().run(program);
+}

--- a/src/jesus/optimizer/optimizer.hpp
+++ b/src/jesus/optimizer/optimizer.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <vector>
+#include "ast/stmt/stmt.hpp"
+
+class Optimizer
+{
+  public:
+    void optimize(std::vector<std::unique_ptr<Stmt>> &program);
+};

--- a/src/jesus/test_runner.cpp
+++ b/src/jesus/test_runner.cpp
@@ -5,9 +5,10 @@
 #include <optional>
 #include "utils/file_utils.hpp"
 
-std::string runJesusInterpreter(const std::string &inputFile, bool useRepl)
+std::string runJesusInterpreter(const std::string &inputFile, bool useRepl, bool keepAst)
 {
-    std::string command = "jesus '" + inputFile + "' 2>&1";
+    std::string command =
+        std::string("jesus") + (keepAst ? " --keep-ast " : " ") + "'" + inputFile + "' 2>&1";
 
     if (useRepl)
         command = "jesus --quiet < '" + inputFile + "' 2>&1";
@@ -30,7 +31,15 @@ std::string runJesusInterpreter(const std::string &inputFile, bool useRepl)
 
 bool shouldUseRepl(const std::filesystem::path &path)
 {
-    if (path.string().find("tests/repl/") != std::string::npos)
+    if (path.string().contains("tests/repl/"))
+        return true;
+
+    return false;
+}
+
+bool shouldKeepAst(const std::string &path)
+{
+    if (path.contains("tests/optimizer/"))
         return true;
 
     return false;
@@ -97,7 +106,8 @@ int main()
                 expectedFile = inputFile + ".expected";
             }
 
-            std::string output = runJesusInterpreter(inputFile, useRepl);
+            bool keepAst = shouldKeepAst(fullInputFile);
+            std::string output = runJesusInterpreter(inputFile, useRepl, keepAst);
             auto expectedOpt = loadFile(expectedFile);
 
             if (!expectedOpt.has_value())
@@ -107,7 +117,9 @@ int main()
                 std::cout << "    " << fullExpectedFile << "\n\n";
 
                 std::cout << "    Create it with:\n";
-                std::cout << "      jesus " << (useRepl ? "--quiet < " : "") << "'" << fullInputFile << "' &> '" << fullExpectedFile << "'\n\n";
+                std::cout << "      jesus "
+                          << (useRepl ? "--quiet < " : (keepAst ? "--keep-ast " : "")) << "'"
+                          << fullInputFile << "' &> '" << fullExpectedFile << "'\n\n";
 
                 allPassed = false;
                 continue;

--- a/src/jesus/tests/optimizer/constant_folder/fold_boolean_and.jesus
+++ b/src/jesus/tests/optimizer/constant_folder/fold_boolean_and.jesus
@@ -1,0 +1,2 @@
+create truth value = yes and no
+ast

--- a/src/jesus/tests/optimizer/constant_folder/fold_boolean_and.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_folder/fold_boolean_and.jesus.expected
@@ -1,0 +1,1 @@
+CreateVarStmt(value, LiteralExpr((logic) 0))

--- a/src/jesus/tests/optimizer/constant_folder/fold_boolean_or.jesus
+++ b/src/jesus/tests/optimizer/constant_folder/fold_boolean_or.jesus
@@ -1,0 +1,2 @@
+create truth value = no or yes
+ast

--- a/src/jesus/tests/optimizer/constant_folder/fold_boolean_or.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_folder/fold_boolean_or.jesus.expected
@@ -1,0 +1,1 @@
+CreateVarStmt(value, LiteralExpr((logic) 1))

--- a/src/jesus/tests/optimizer/constant_folder/fold_boolean_xor.jesus
+++ b/src/jesus/tests/optimizer/constant_folder/fold_boolean_xor.jesus
@@ -1,0 +1,2 @@
+create truth value = yes versus no
+ast

--- a/src/jesus/tests/optimizer/constant_folder/fold_boolean_xor.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_folder/fold_boolean_xor.jesus.expected
@@ -1,0 +1,1 @@
+CreateVarStmt(value, LiteralExpr((logic) 1))

--- a/src/jesus/tests/optimizer/constant_folder/fold_greater_equal.jesus
+++ b/src/jesus/tests/optimizer/constant_folder/fold_greater_equal.jesus
@@ -1,0 +1,3 @@
+create truth value = 5 >= 5
+create truth value2 = 5 >= 7
+ast

--- a/src/jesus/tests/optimizer/constant_folder/fold_greater_equal.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_folder/fold_greater_equal.jesus.expected
@@ -1,0 +1,2 @@
+CreateVarStmt(value, LiteralExpr((logic) 1))
+CreateVarStmt(value2, LiteralExpr((logic) 0))

--- a/src/jesus/tests/optimizer/constant_folder/fold_greater_than.jesus
+++ b/src/jesus/tests/optimizer/constant_folder/fold_greater_than.jesus
@@ -1,0 +1,3 @@
+create truth value1 = 5 > 2
+create truth value2 = 2 > 5
+ast

--- a/src/jesus/tests/optimizer/constant_folder/fold_greater_than.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_folder/fold_greater_than.jesus.expected
@@ -1,0 +1,2 @@
+CreateVarStmt(value1, LiteralExpr((logic) 1))
+CreateVarStmt(value2, LiteralExpr((logic) 0))

--- a/src/jesus/tests/optimizer/constant_folder/fold_integer_addition.jesus
+++ b/src/jesus/tests/optimizer/constant_folder/fold_integer_addition.jesus
@@ -1,0 +1,2 @@
+create number value = 2 + 3
+ast

--- a/src/jesus/tests/optimizer/constant_folder/fold_integer_addition.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_folder/fold_integer_addition.jesus.expected
@@ -1,0 +1,1 @@
+CreateVarStmt(value, LiteralExpr((int) 5))

--- a/src/jesus/tests/optimizer/constant_folder/fold_integer_division.jesus
+++ b/src/jesus/tests/optimizer/constant_folder/fold_integer_division.jesus
@@ -1,0 +1,2 @@
+create number value = 14 / 2
+ast

--- a/src/jesus/tests/optimizer/constant_folder/fold_integer_division.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_folder/fold_integer_division.jesus.expected
@@ -1,0 +1,1 @@
+CreateVarStmt(value, LiteralExpr((double) 7.000000))

--- a/src/jesus/tests/optimizer/constant_folder/fold_integer_modulo.jesus
+++ b/src/jesus/tests/optimizer/constant_folder/fold_integer_modulo.jesus
@@ -1,0 +1,2 @@
+create number value = 13 mod 5
+ast

--- a/src/jesus/tests/optimizer/constant_folder/fold_integer_modulo.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_folder/fold_integer_modulo.jesus.expected
@@ -1,0 +1,1 @@
+CreateVarStmt(value, LiteralExpr((int) 3))

--- a/src/jesus/tests/optimizer/constant_folder/fold_integer_multiplication.jesus
+++ b/src/jesus/tests/optimizer/constant_folder/fold_integer_multiplication.jesus
@@ -1,0 +1,2 @@
+create number value = 12 * 10
+ast

--- a/src/jesus/tests/optimizer/constant_folder/fold_integer_multiplication.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_folder/fold_integer_multiplication.jesus.expected
@@ -1,0 +1,1 @@
+CreateVarStmt(value, LiteralExpr((int) 120))

--- a/src/jesus/tests/optimizer/constant_folder/fold_integer_subtraction.jesus
+++ b/src/jesus/tests/optimizer/constant_folder/fold_integer_subtraction.jesus
@@ -1,0 +1,2 @@
+create number value = 8 - 3
+ast

--- a/src/jesus/tests/optimizer/constant_folder/fold_integer_subtraction.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_folder/fold_integer_subtraction.jesus.expected
@@ -1,0 +1,1 @@
+CreateVarStmt(value, LiteralExpr((int) 5))

--- a/src/jesus/tests/optimizer/constant_folder/fold_integer_xor.jesus
+++ b/src/jesus/tests/optimizer/constant_folder/fold_integer_xor.jesus
@@ -1,0 +1,2 @@
+create number value = 10 versus 3
+ast

--- a/src/jesus/tests/optimizer/constant_folder/fold_integer_xor.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_folder/fold_integer_xor.jesus.expected
@@ -1,0 +1,1 @@
+CreateVarStmt(value, LiteralExpr((int) 9))

--- a/src/jesus/tests/optimizer/constant_folder/fold_is.jesus
+++ b/src/jesus/tests/optimizer/constant_folder/fold_is.jesus
@@ -1,0 +1,3 @@
+create truth value1 = 5 is 5
+create truth value2 = 5 is 6
+ast

--- a/src/jesus/tests/optimizer/constant_folder/fold_is.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_folder/fold_is.jesus.expected
@@ -1,0 +1,2 @@
+CreateVarStmt(value1, LiteralExpr((logic) 1))
+CreateVarStmt(value2, LiteralExpr((logic) 0))

--- a/src/jesus/tests/optimizer/constant_folder/fold_is_not.jesus
+++ b/src/jesus/tests/optimizer/constant_folder/fold_is_not.jesus
@@ -1,0 +1,3 @@
+create truth value1 = 5 is not 4
+create truth value2 = 5 is not 5
+ast

--- a/src/jesus/tests/optimizer/constant_folder/fold_is_not.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_folder/fold_is_not.jesus.expected
@@ -1,0 +1,2 @@
+CreateVarStmt(value1, LiteralExpr((logic) 1))
+CreateVarStmt(value2, LiteralExpr((logic) 0))

--- a/src/jesus/tests/optimizer/constant_folder/fold_less_equal.jesus
+++ b/src/jesus/tests/optimizer/constant_folder/fold_less_equal.jesus
@@ -1,0 +1,3 @@
+create truth value1 = 3 <= 3
+create truth value2 = 3 <= 2
+ast

--- a/src/jesus/tests/optimizer/constant_folder/fold_less_equal.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_folder/fold_less_equal.jesus.expected
@@ -1,0 +1,2 @@
+CreateVarStmt(value1, LiteralExpr((logic) 1))
+CreateVarStmt(value2, LiteralExpr((logic) 0))

--- a/src/jesus/tests/optimizer/constant_folder/fold_less_than.jesus
+++ b/src/jesus/tests/optimizer/constant_folder/fold_less_than.jesus
@@ -1,0 +1,3 @@
+create truth value1 = 2 < 3
+create truth value2 = 3 < 3
+ast

--- a/src/jesus/tests/optimizer/constant_folder/fold_less_than.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_folder/fold_less_than.jesus.expected
@@ -1,0 +1,2 @@
+CreateVarStmt(value1, LiteralExpr((logic) 1))
+CreateVarStmt(value2, LiteralExpr((logic) 0))

--- a/src/jesus/tests/optimizer/constant_folder/fold_nested_expression.jesus
+++ b/src/jesus/tests/optimizer/constant_folder/fold_nested_expression.jesus
@@ -1,0 +1,2 @@
+create number value = ((2 + 3) * (10 - 4) * 4 + 24) * 1000
+ast

--- a/src/jesus/tests/optimizer/constant_folder/fold_nested_expression.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_folder/fold_nested_expression.jesus.expected
@@ -1,0 +1,1 @@
+CreateVarStmt(value, LiteralExpr((int) 144000))

--- a/src/jesus/tests/optimizer/constant_folder/fold_string_concatenation.jesus
+++ b/src/jesus/tests/optimizer/constant_folder/fold_string_concatenation.jesus
@@ -1,0 +1,2 @@
+create text value = "Hello " + "Jesus"
+ast

--- a/src/jesus/tests/optimizer/constant_folder/fold_string_concatenation.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_folder/fold_string_concatenation.jesus.expected
@@ -1,0 +1,1 @@
+CreateVarStmt(value, LiteralExpr(Hello Jesus))

--- a/src/jesus/tests/optimizer/constant_folder/fold_variable_expression.jesus
+++ b/src/jesus/tests/optimizer/constant_folder/fold_variable_expression.jesus
@@ -1,0 +1,3 @@
+create number age = 33
+create number older = age + 2
+ast

--- a/src/jesus/tests/optimizer/constant_folder/fold_variable_expression.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_folder/fold_variable_expression.jesus.expected
@@ -1,0 +1,2 @@
+CreateVarStmt(age, LiteralExpr((int) 33))
+CreateVarStmt(older, BinaryExpr(operator: +, left: VariableExpr('age'), right: LiteralExpr((int) 2)))

--- a/src/jesus/tests/repl/fold_greater_equal.jesus
+++ b/src/jesus/tests/repl/fold_greater_equal.jesus
@@ -1,0 +1,1 @@
+../optimizer/constant_folder/fold_greater_equal.jesus

--- a/src/jesus/tests/repl/fold_greater_equal.jesus.expected
+++ b/src/jesus/tests/repl/fold_greater_equal.jesus.expected
@@ -1,0 +1,3 @@
+(Jesus) (Jesus) (Jesus) CreateVarStmt(value, BinaryExpr(operator: >=, left: LiteralExpr((int) 5), right: LiteralExpr((int) 5)))
+CreateVarStmt(value2, BinaryExpr(operator: >=, left: LiteralExpr((int) 5), right: LiteralExpr((int) 7)))
+(Jesus) 

--- a/src/jesus/understanding/inspection/ast_inspector.cpp
+++ b/src/jesus/understanding/inspection/ast_inspector.cpp
@@ -4,6 +4,21 @@
 
 void AstInspector::inspect(Interpreter &jesus, const InspectStmt &stmt)
 {
+    if (!jesus.keepAst)
+    {
+        std::cout << "The AST is not available (`ast` petition).\n\n"
+                  << "When running a source file (e.g. `jesus program.jesus`), the "
+                     "optimized AST is discarded after compilation to reduce memory "
+                     "usage.\n\n"
+                  << "If you want to inspect the optimized AST, run:\n\n"
+                  << "    jesus --keep-ast <file>.jesus \n\n"
+                  << "Alternatively, start the REPL by running:\n\n"
+                  << "    jesus\n\n"
+                  << "The REPL always preserves the original (non-optimized) AST for inspection.\n";
+
+        return;
+    }
+
     // Case 1 - print the whole AST.
     if (stmt.symbolName.empty())
     {


### PR DESCRIPTION
# Description

This PR introduces the first optimization pass in the Jesus compiler pipeline:
`ConstantFolder`.

The optimizer evaluates expressions whose values are known at compile time and
replaces them with `LiteralExpr` nodes.

Example:

Before:

```jesus
create number result = (2 * 3) + 1
````

After optimization becomes:

```jesus
create number result = 7
```

## Why

_**Constant folding**_ is the first optimization step in the compiler pipeline.
Besides improving generated code, it provides a simple and visible example of
how compilers transform programs before execution.

This also establishes the foundation for future optimization passes:

* ConstantPropagator
* MethodInliner
* DeadCodeEliminator
* LoopOptimizer

## Tests

Added isolated tests covering:

* integer arithmetic
* nested expressions
* comparisons
* boolean operations
* XOR operations
* modulo
* string concatenation
* variable expressions

Each test verifies the optimized AST output.

## AST Inspection

The **optimizer intentionally does not run in REPL mode** because the REPL is an
educational environment where users can inspect the original AST using the
`ast` statement.

When running the REPL (`jesus` without a filename), the original AST is always
preserved so users can inspect it by typing `ast`.

When running a source file (for example, `jesus program.jesus`), the AST is
discarded after optimization and execution to reduce memory usage.

If the user wants to inspect the optimized AST while running a source file,
he or she can enable AST preservation:

```bash
jesus --keep-ast program.jesus
```

If the `ast` statement is used without `--keep-ast`, users get a message similar to the following:

```
The AST is not available (`ast` petition).

When running a source file (e.g. `jesus program.jesus`),
the optimized AST is discarded after compilation to reduce memory usage.

If you want to inspect the optimized AST, run:

    jesus --keep-ast <file>.jesus 

Alternatively, start the REPL by running:

    jesus

The REPL always preserves the original (non-optimized) AST for inspection.
```

# ✝️ Wisdom 
"When you **_beat the olives_** from your trees, do not go over the branches a second time. 
Leave what remains for the foreigner, the fatherless and the widow." **_— Deuteronomy 24:20_**