### PR TITLE
Step 94: feat(optimizer): Added ConstantPropagator optimizer and related test. Ref #93.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,10 +1,25 @@
+# Jesus Programming Language coding style.
+#
+# The formatter favors readability and pull request review over minimizing vertical space.
+# Long parameter lists are expanded rather than aligned after '(',
+# comments are preserved as written, and short declarations remain on a
+# single line whenever they fit.
+
 BasedOnStyle: LLVM
 
 BreakBeforeBraces: Allman
+AlignAfterOpenBracket: AlwaysBreak
+BinPackParameters: false
+BinPackArguments: false
+
 IndentWidth: 4
-ColumnLimit: 100
+ContinuationIndentWidth: 8
+ColumnLimit: 120
 UseTab: Never
 
 Standard: Latest
 SortIncludes: Never
+ReflowComments: false
+PenaltyReturnTypeOnItsOwnLine: 1000000
 
+AllowShortFunctionsOnASingleLine: All

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,7 @@ set(JESUS_CPP_FILES
     # ---------
     src/jesus/optimizer/optimizer.cpp
     src/jesus/optimizer/constant_folder.cpp
+    src/jesus/optimizer/constant_propagator.cpp
 
     # -----------
     # Interpreter

--- a/src/jesus/optimizer/constant_propagator.cpp
+++ b/src/jesus/optimizer/constant_propagator.cpp
@@ -1,0 +1,530 @@
+#include "constant_propagator.hpp"
+
+#include "ast/stmt/create_var_stmt.hpp"
+#include "ast/stmt/update_var_stmt.hpp"
+#include "ast/stmt/assign_stmt.hpp"
+#include "ast/stmt/print_stmt.hpp"
+#include "ast/stmt/return_stmt.hpp"
+#include "ast/stmt/if_stmt.hpp"
+#include "ast/stmt/repeat_while_stmt.hpp"
+#include "ast/stmt/repeat_times_stmt.hpp"
+#include "ast/stmt/repeat_forever_stmt.hpp"
+#include "ast/stmt/for_each_stmt.hpp"
+#include "ast/stmt/create_class_stmt.hpp"
+#include "ast/stmt/create_method_stmt.hpp"
+#include "ast/stmt/try_stmt.hpp"
+#include "ast/stmt/resist_stmt.hpp"
+#include "ast/stmt/create_var_with_ask_stmt.hpp"
+#include "ast/stmt/update_var_with_ask_stmt.hpp"
+
+#include "ast/expr/literal_expr.hpp"
+#include "ast/expr/variable_expr.hpp"
+#include "ast/expr/grouping_expr.hpp"
+#include "ast/expr/unary_expr.hpp"
+#include "ast/expr/binary_expr.hpp"
+#include "ast/expr/list_expr.hpp"
+#include "ast/expr/dict_expr.hpp"
+#include "ast/expr/conditional_expr.hpp"
+#include "ast/expr/formatted_string_expr.hpp"
+#include "ast/expr/method_call_expr.hpp"
+#include "ast/expr/get_attr_expr.hpp"
+#include "ast/expr/index_expr.hpp"
+
+#include "types/known_types.hpp"
+
+void ConstantPropagator::run(std::vector<std::unique_ptr<Stmt>> &program)
+{
+    std::unordered_set<std::string> modifiedVars;
+    std::unordered_set<std::string> declaredVars;
+    std::unordered_map<std::string, std::unique_ptr<Expr>> constVars;
+
+    // ----------------------------------------------------------------
+    // Pass 1
+    // ------
+    // Walk the entire program and discover which variables may change.
+    // Any variable that is reassigned, written by user input, modified
+    // inside loops, or otherwise mutated is marked as non-constant.
+    // ----------------------------------------------------------------
+    for (const auto &stmt : program)
+    {
+        if (stmt)
+            collectModifiedVars(*stmt, modifiedVars, declaredVars);
+    }
+
+    // -----------------------------------------------------------------------
+    // Pass 2
+    // ------
+    // Walk the program again. Whenever a read of a known constant variable is
+    // found, replace that VariableExpr with an equivalent LiteralExpr.
+    // -----------------------------------------------------------------------
+    for (auto &stmt : program)
+    {
+        if (!stmt)
+            continue;
+
+        replaceConstWithLiteralInStatement(*stmt, constVars);
+
+        if (auto create = dynamic_cast<CreateVarStmt *>(stmt.get()))
+        {
+            // --------------------------------------------------------
+            // Only variables that are never modified can be propagated.
+            // --------------------------------------------------------
+            bool isConstant = !modifiedVars.contains(create->name);
+            if (isConstant && create->value)
+            {
+                auto cloned = cloneExpr(*create->value);
+                if (cloned)
+                {
+                    constVars[create->name] = std::move(cloned);
+                }
+            }
+        }
+    }
+}
+
+void ConstantPropagator::collectModifiedVars(
+        const Stmt &statement,
+        std::unordered_set<std::string> &modifiedVars,
+        std::unordered_set<std::string> &declaredVars)
+{
+    if (auto create = dynamic_cast<const CreateVarStmt *>(&statement))
+    {
+        if (declaredVars.find(create->name) != declaredVars.end())
+        {
+            modifiedVars.insert(create->name);
+        }
+        else
+        {
+            declaredVars.insert(create->name);
+        }
+        return;
+    }
+
+    if (auto update = dynamic_cast<const UpdateVarStmt *>(&statement))
+    {
+        modifiedVars.insert(update->name);
+        return;
+    }
+
+    if (auto assign = dynamic_cast<const AssignStmt *>(&statement))
+    {
+        if (assign->target)
+            collectModifiedVarsFromExpr(assign->target.get(), modifiedVars);
+
+        return;
+    }
+
+    if (auto updateAsk = dynamic_cast<const UpdateVarWithAskStmt *>(&statement))
+    {
+        modifiedVars.insert(updateAsk->var_name);
+        return;
+    }
+
+    if (auto createAsk = dynamic_cast<const CreateVarWithAskStmt *>(&statement))
+    {
+        modifiedVars.insert(createAsk->var_name);
+        return;
+    }
+
+    if (auto ifStmt = dynamic_cast<const IfStmt *>(&statement))
+    {
+        for (const auto &child : ifStmt->thenBranch)
+            if (child)
+                collectModifiedVars(*child, modifiedVars, declaredVars);
+
+        for (const auto &child : ifStmt->otherwiseBranch)
+            if (child)
+                collectModifiedVars(*child, modifiedVars, declaredVars);
+
+        return;
+    }
+
+    if (auto repeatWhile = dynamic_cast<const RepeatWhileStmt *>(&statement))
+    {
+        for (const auto &child : repeatWhile->body)
+            if (child)
+                collectModifiedVars(*child, modifiedVars, declaredVars);
+
+        return;
+    }
+
+    if (auto repeatTimes = dynamic_cast<const RepeatTimesStmt *>(&statement))
+    {
+        for (const auto &child : repeatTimes->body)
+            if (child)
+                collectModifiedVars(*child, modifiedVars, declaredVars);
+
+        return;
+    }
+
+    if (auto repeatForever = dynamic_cast<const RepeatForeverStmt *>(&statement))
+    {
+        for (const auto &child : repeatForever->body)
+            if (child)
+                collectModifiedVars(*child, modifiedVars, declaredVars);
+
+        return;
+    }
+
+    if (auto forEach = dynamic_cast<const ForEachStmt *>(&statement))
+    {
+        for (const auto &name : forEach->varNames)
+            modifiedVars.insert(name);
+
+        for (const auto &child : forEach->body)
+            if (child)
+                collectModifiedVars(*child, modifiedVars, declaredVars);
+
+        return;
+    }
+
+    if (auto createClass = dynamic_cast<const CreateClassStmt *>(&statement))
+    {
+        for (const auto &child : createClass->body)
+            if (child)
+                collectModifiedVars(*child, modifiedVars, declaredVars);
+
+        return;
+    }
+
+    if (auto createMethod = dynamic_cast<const CreateMethodStmt *>(&statement))
+    {
+        for (const auto &child : createMethod->body)
+            if (child)
+                collectModifiedVars(*child, modifiedVars, declaredVars);
+
+        return;
+    }
+
+    if (auto tryStmt = dynamic_cast<const TryStmt *>(&statement))
+    {
+        for (const auto &child : tryStmt->tryBody)
+            if (child)
+                collectModifiedVars(*child, modifiedVars, declaredVars);
+
+        for (const auto &[type, body] : tryStmt->catchClauses)
+            for (const auto &child : body)
+                if (child)
+                    collectModifiedVars(*child, modifiedVars, declaredVars);
+
+        for (const auto &child : tryStmt->alwaysBody)
+            if (child)
+                collectModifiedVars(*child, modifiedVars, declaredVars);
+
+        return;
+    }
+}
+
+void ConstantPropagator::collectModifiedVarsFromExpr(
+        const Expr *expression, std::unordered_set<std::string> &modifiedVars)
+{
+    if (!expression)
+        return;
+
+    if (auto varExpr = dynamic_cast<const VariableExpr *>(expression))
+    {
+        modifiedVars.insert(varExpr->name);
+        return;
+    }
+
+    if (auto getAttr = dynamic_cast<const GetAttributeExpr *>(expression))
+    {
+        collectModifiedVarsFromExpr(getAttr->object.get(), modifiedVars);
+        return;
+    }
+
+    if (auto indexExpr = dynamic_cast<const IndexExpr *>(expression))
+    {
+        collectModifiedVarsFromExpr(indexExpr->collection.get(), modifiedVars);
+        return;
+    }
+}
+
+void ConstantPropagator::replaceConstWithLiteralInStatement(
+        Stmt &statement, const std::unordered_map<std::string, std::unique_ptr<Expr>> &constVars)
+{
+    if (auto create = dynamic_cast<CreateVarStmt *>(&statement))
+    {
+        create->value = replaceConstWithLiteralInExpression(std::move(create->value), constVars);
+        return;
+    }
+
+    if (auto update = dynamic_cast<UpdateVarStmt *>(&statement))
+    {
+        update->value = replaceConstWithLiteralInExpression(std::move(update->value), constVars);
+        return;
+    }
+
+    if (auto assign = dynamic_cast<AssignStmt *>(&statement))
+    {
+        assign->value = replaceConstWithLiteralInExpression(std::move(assign->value), constVars);
+        return;
+    }
+
+    if (auto printStmt = dynamic_cast<PrintStmt *>(&statement))
+    {
+        printStmt->message = replaceConstWithLiteralInExpression(std::move(printStmt->message), constVars);
+        return;
+    }
+
+    if (auto returnStmt = dynamic_cast<ReturnStmt *>(&statement))
+    {
+        returnStmt->value = replaceConstWithLiteralInExpression(std::move(returnStmt->value), constVars);
+        return;
+    }
+
+    if (auto ifStmt = dynamic_cast<IfStmt *>(&statement))
+    {
+        ifStmt->condition = replaceConstWithLiteralInExpression(std::move(ifStmt->condition), constVars);
+        for (auto &child : ifStmt->thenBranch)
+            if (child)
+                replaceConstWithLiteralInStatement(*child, constVars);
+
+        for (auto &child : ifStmt->otherwiseBranch)
+            if (child)
+                replaceConstWithLiteralInStatement(*child, constVars);
+
+        return;
+    }
+
+    if (auto repeatWhile = dynamic_cast<RepeatWhileStmt *>(&statement))
+    {
+        repeatWhile->condition = replaceConstWithLiteralInExpression(std::move(repeatWhile->condition), constVars);
+        for (auto &child : repeatWhile->body)
+            if (child)
+                replaceConstWithLiteralInStatement(*child, constVars);
+
+        return;
+    }
+
+    if (auto repeatTimes = dynamic_cast<RepeatTimesStmt *>(&statement))
+    {
+        repeatTimes->countExpr = replaceConstWithLiteralInExpression(std::move(repeatTimes->countExpr), constVars);
+        for (auto &child : repeatTimes->body)
+            if (child)
+                replaceConstWithLiteralInStatement(*child, constVars);
+
+        return;
+    }
+
+    if (auto repeatForever = dynamic_cast<RepeatForeverStmt *>(&statement))
+    {
+        for (auto &child : repeatForever->body)
+            if (child)
+                replaceConstWithLiteralInStatement(*child, constVars);
+        return;
+    }
+
+    if (auto forEach = dynamic_cast<ForEachStmt *>(&statement))
+    {
+        forEach->iterable = replaceConstWithLiteralInExpression(std::move(forEach->iterable), constVars);
+        for (auto &child : forEach->body)
+            if (child)
+                replaceConstWithLiteralInStatement(*child, constVars);
+
+        return;
+    }
+
+    if (auto createClass = dynamic_cast<CreateClassStmt *>(&statement))
+    {
+        for (auto &child : createClass->body)
+            if (child)
+                replaceConstWithLiteralInStatement(*child, constVars);
+
+        return;
+    }
+
+    if (auto createMethod = dynamic_cast<CreateMethodStmt *>(&statement))
+    {
+        for (auto &child : createMethod->body)
+            if (child)
+                replaceConstWithLiteralInStatement(*child, constVars);
+
+        return;
+    }
+
+    if (auto tryStmt = dynamic_cast<TryStmt *>(&statement))
+    {
+        for (auto &child : tryStmt->tryBody)
+            if (child)
+                replaceConstWithLiteralInStatement(*child, constVars);
+
+        for (auto &[type, body] : tryStmt->catchClauses)
+            for (auto &child : body)
+                if (child)
+                    replaceConstWithLiteralInStatement(*child, constVars);
+
+        for (auto &child : tryStmt->alwaysBody)
+            if (child)
+                replaceConstWithLiteralInStatement(*child, constVars);
+
+        return;
+    }
+
+    if (auto resist = dynamic_cast<ResistStmt *>(&statement))
+    {
+        resist->messageExpr = replaceConstWithLiteralInExpression(std::move(resist->messageExpr), constVars);
+        return;
+    }
+}
+
+std::unique_ptr<Expr> ConstantPropagator::replaceConstWithLiteralInExpression(
+        std::unique_ptr<Expr> expression, const std::unordered_map<std::string, std::unique_ptr<Expr>> &constVars)
+{
+    if (!expression)
+        return nullptr;
+
+    // ---------------------------------------------------------------
+    // This is the heart of Constant Propagator
+    //
+    // If it is a VariableExpr (read of a variable),
+    // let's check if it has a constant value (literalExpr).
+    // If so, let's replace it with its contant value directly.
+    //
+    // In other words:
+    //
+    //     If this expression is a variable,
+    //         and I know its constant value,
+    //             replace the variable with a copy of that constant.
+    //     Otherwise,
+    //         leave the expression unchanged.
+    // ---------------------------------------------------------------
+    if (auto varExpr = dynamic_cast<VariableExpr *>(expression.get()))
+    {
+        auto it = constVars.find(varExpr->name);
+        if (it != constVars.end() && it->second)
+        {
+            return cloneExpr(*it->second);
+        }
+
+        return expression;
+    }
+
+    if (auto grouping = dynamic_cast<GroupingExpr *>(expression.get()))
+    {
+        grouping->expression = replaceConstWithLiteralInExpression(std::move(grouping->expression), constVars);
+        return expression;
+    }
+
+    if (auto unary = dynamic_cast<UnaryExpr *>(expression.get()))
+    {
+        unary->right = replaceConstWithLiteralInExpression(std::move(unary->right), constVars);
+        return expression;
+    }
+
+    if (auto binary = dynamic_cast<BinaryExpr *>(expression.get()))
+    {
+        binary->left = replaceConstWithLiteralInExpression(std::move(binary->left), constVars);
+        binary->right = replaceConstWithLiteralInExpression(std::move(binary->right), constVars);
+
+        return expression;
+    }
+
+    if (auto listExpr = dynamic_cast<ListExpr *>(expression.get()))
+    {
+        for (auto &el : listExpr->elements)
+            el = replaceConstWithLiteralInExpression(std::move(el), constVars);
+
+        return expression;
+    }
+
+    if (auto dictExpr = dynamic_cast<DictExpr *>(expression.get()))
+    {
+        for (auto &[k, v] : dictExpr->entries)
+        {
+            k = replaceConstWithLiteralInExpression(std::move(k), constVars);
+            v = replaceConstWithLiteralInExpression(std::move(v), constVars);
+        }
+
+        return expression;
+    }
+
+    if (auto condExpr = dynamic_cast<ConditionalExpr *>(expression.get()))
+    {
+        condExpr->condition = replaceConstWithLiteralInExpression(std::move(condExpr->condition), constVars);
+        condExpr->thenBranch = replaceConstWithLiteralInExpression(std::move(condExpr->thenBranch), constVars);
+        condExpr->elseBranch = replaceConstWithLiteralInExpression(std::move(condExpr->elseBranch), constVars);
+
+        return expression;
+    }
+
+    if (auto methodCall = dynamic_cast<MethodCallExpr *>(expression.get()))
+    {
+        if (methodCall->object)
+            methodCall->object = replaceConstWithLiteralInExpression(std::move(methodCall->object), constVars);
+
+        for (auto &arg : methodCall->args)
+            arg = replaceConstWithLiteralInExpression(std::move(arg), constVars);
+
+        return expression;
+    }
+
+    if (auto getAttr = dynamic_cast<GetAttributeExpr *>(expression.get()))
+    {
+        if (getAttr->object)
+            getAttr->object = replaceConstWithLiteralInExpression(std::move(getAttr->object), constVars);
+
+        return expression;
+    }
+
+    if (auto indexExpr = dynamic_cast<IndexExpr *>(expression.get()))
+    {
+        if (indexExpr->collection)
+            indexExpr->collection = replaceConstWithLiteralInExpression(std::move(indexExpr->collection), constVars);
+
+        if (indexExpr->index)
+            indexExpr->index = replaceConstWithLiteralInExpression(std::move(indexExpr->index), constVars);
+
+        return expression;
+    }
+
+    if (auto fmtString = dynamic_cast<FormattedStringExpr *>(expression.get()))
+    {
+        for (auto &expr : fmtString->expressions)
+            expr = replaceConstWithLiteralInExpression(std::move(expr), constVars);
+
+        return expression;
+    }
+
+    return expression;
+}
+
+std::unique_ptr<Expr> ConstantPropagator::cloneExpr(const Expr &expr)
+{
+    if (auto lit = dynamic_cast<const LiteralExpr *>(&expr))
+    {
+        return std::make_unique<LiteralExpr>(lit->value, lit->type);
+    }
+
+    if (expr.canEvaluateAtParseTime())
+    {
+        try
+        {
+            Value val = expr.evaluate(nullptr);
+            return createLiteral(val);
+        }
+        catch (...)
+        {
+        }
+    }
+
+    return nullptr;
+}
+
+std::unique_ptr<Expr> ConstantPropagator::createLiteral(const Value &value)
+{
+    std::shared_ptr<CreationType> type = KnownTypes::NOTHING;
+    if (value.IS_INT)
+        type = KnownTypes::INT;
+
+    else if (value.IS_DOUBLE)
+        type = KnownTypes::DOUBLE;
+
+    else if (value.IS_BOOLEAN)
+        type = KnownTypes::BOOLEAN;
+
+    else if (value.IS_STRING)
+        type = KnownTypes::STRING;
+
+    return std::make_unique<LiteralExpr>(value, type);
+}

--- a/src/jesus/optimizer/constant_propagator.hpp
+++ b/src/jesus/optimizer/constant_propagator.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <vector>
+#include <memory>
+#include <unordered_set>
+#include <unordered_map>
+#include <string>
+
+#include "ast/stmt/stmt.hpp"
+#include "ast/expr/expr.hpp"
+#include "ast/expr/literal_expr.hpp"
+
+/**
+ * @brief Replaces reads of immutable variables with their constant values.
+ *
+ * Constant propagation is an optimization performed after ConstantFolder.
+ * It discovers variables whose values never change and substitutes later
+ * references to those variables with the corresponding constant expression.
+ *
+ * Example:
+ *
+ *     create number age = 33
+ *     say age
+ *
+ * becomes:
+ *
+ *     create number age = 33
+ *     say 33
+ *
+ * The declaration itself is intentionally preserved. This pass only replaces
+ * later reads of the variable. Removing the declaration is the responsibility
+ * of DeadCodeEliminator.
+ *
+ * To guarantee correctness, only variables that are never modified are
+ * propagated. Variables updated through assignments, loops, user input,
+ * object mutation, or any other write operation are excluded.
+ *
+ * Pipeline:
+ *
+ *     ConstantFolder
+ *         ↓
+ *     ConstantPropagator
+ *         ↓
+ *     DeadCodeEliminator
+ *
+ * "The simple inherit folly, but the prudent are crowned with knowledge."
+ * — Proverbs 14:18
+ */
+class ConstantPropagator
+{
+  public:
+    /**
+     * @brief Executes constant propagation on an AST.
+     *
+     * The optimization is intentionally divided into two passes.
+     *
+     * Pass 1:
+     *   Walk the entire program and discover which variables may change.
+     *   Any variable that is reassigned, written by user input, modified inside
+     *   loops, or otherwise mutated is marked as non-constant.
+     *
+     * Pass 2:
+     *   Walk the program again. Whenever a read of a known constant variable is
+     *   found, replace that VariableExpr with an equivalent LiteralExpr.
+     */
+    void run(std::vector<std::unique_ptr<Stmt>> &program);
+
+  private:
+    void collectModifiedVars(
+            const Stmt &statement,
+            std::unordered_set<std::string> &modifiedVars,
+            std::unordered_set<std::string> &declaredVars);
+
+    void collectModifiedVarsFromExpr(const Expr *expression, std::unordered_set<std::string> &modifiedVars);
+
+    void replaceConstWithLiteralInStatement(
+            Stmt &statement, const std::unordered_map<std::string, std::unique_ptr<Expr>> &constVars);
+
+    /**
+     * @brief This is the heart of ConstantPropagator.
+     *
+     * If this expression is a variable, and I know its constant value,
+     *    replace the variable by a copy of that constant.
+     * Otherwise,
+     *    leave the expression unchanged.
+     */
+    std::unique_ptr<Expr> replaceConstWithLiteralInExpression(
+            std::unique_ptr<Expr> expression, const std::unordered_map<std::string, std::unique_ptr<Expr>> &constVars);
+
+    std::unique_ptr<Expr> cloneExpr(const Expr &expr);
+    std::unique_ptr<Expr> createLiteral(const Value &value);
+};

--- a/src/jesus/optimizer/optimizer.cpp
+++ b/src/jesus/optimizer/optimizer.cpp
@@ -1,7 +1,9 @@
 #include "optimizer.hpp"
 #include "constant_folder.hpp"
+#include "constant_propagator.hpp"
 
 void Optimizer::optimize(std::vector<std::unique_ptr<Stmt>> &program)
 {
     ConstantFolder().run(program);
+    ConstantPropagator().run(program);
 }

--- a/src/jesus/tests/optimizer/constant_folder/fold_variable_expression.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_folder/fold_variable_expression.jesus.expected
@@ -1,2 +1,2 @@
 CreateVarStmt(age, LiteralExpr((int) 33))
-CreateVarStmt(older, BinaryExpr(operator: +, left: VariableExpr('age'), right: LiteralExpr((int) 2)))
+CreateVarStmt(older, BinaryExpr(operator: +, left: LiteralExpr((int) 33), right: LiteralExpr((int) 2)))

--- a/src/jesus/tests/optimizer/constant_propagator/propagation_variable_to_literal.jesus
+++ b/src/jesus/tests/optimizer/constant_propagator/propagation_variable_to_literal.jesus
@@ -1,0 +1,3 @@
+create number age = 33
+say age
+ast

--- a/src/jesus/tests/optimizer/constant_propagator/propagation_variable_to_literal.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_propagator/propagation_variable_to_literal.jesus.expected
@@ -1,0 +1,3 @@
+(int) 33
+CreateVarStmt(age, LiteralExpr((int) 33))
+PrintStmt(SAY: LiteralExpr((int) 33))

--- a/src/jesus/tests/repl/constant_propapator.jesus
+++ b/src/jesus/tests/repl/constant_propapator.jesus
@@ -1,0 +1,1 @@
+../optimizer/constant_propagator/propagation_variable_to_literal.jesus

--- a/src/jesus/tests/repl/constant_propapator.jesus.expected
+++ b/src/jesus/tests/repl/constant_propapator.jesus.expected
@@ -1,0 +1,4 @@
+(Jesus) (Jesus) (int) 33
+(Jesus) CreateVarStmt(age, LiteralExpr((int) 33))
+PrintStmt(SAY: VariableExpr('age'))
+(Jesus) 


### PR DESCRIPTION
# Description

This PR introduces the **_ConstantPropagator_** optimization pass.

This PR builds on top of PR #93. 

After **_ConstantFolder_** reduces constant expressions into literals,
**_ConstantPropagator_** replaces reads of variables whose values are known
to be constant with the corresponding LiteralExpr.

Example:

Before:
```
    create number age = 33
    say age
```

After optimization becomes:
```
    create number age = 33
    say 33
```

## Notes

 * The declaration itself (`create number age = 33`) is intentionally preserved. This pass only replaces later reads of the variable. 
 * Removing the declaration is the responsibility of **DeadCodeEliminator**, which will come in the next PRs.

# ✝️ Wisdom

> "Jesus Christ is the same yesterday and today and forever." — **_Hebrews 13:8_**