### PR TITLE
Step 96: feat(optimizer): Added MethodInliner optimizer and related test. Ref #93, #94, #95.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,7 +13,6 @@ BinPackParameters: false
 BinPackArguments: false
 
 IndentWidth: 4
-ContinuationIndentWidth: 8
 ColumnLimit: 120
 UseTab: Never
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,7 @@ set(JESUS_CPP_FILES
     src/jesus/optimizer/constant_folder.cpp
     src/jesus/optimizer/constant_propagator.cpp
     src/jesus/optimizer/dead_code_eliminator.cpp
+    src/jesus/optimizer/method_inliner.cpp
 
     # -----------
     # Interpreter

--- a/src/jesus/optimizer/method_inliner.cpp
+++ b/src/jesus/optimizer/method_inliner.cpp
@@ -1,0 +1,597 @@
+#include "method_inliner.hpp"
+#include "interpreter/runtime/method.hpp"
+
+#include "ast/stmt/create_var_stmt.hpp"
+#include "ast/stmt/update_var_stmt.hpp"
+#include "ast/stmt/assign_stmt.hpp"
+#include "ast/stmt/print_stmt.hpp"
+#include "ast/stmt/return_stmt.hpp"
+#include "ast/stmt/if_stmt.hpp"
+#include "ast/stmt/repeat_while_stmt.hpp"
+#include "ast/stmt/repeat_times_stmt.hpp"
+#include "ast/stmt/repeat_forever_stmt.hpp"
+#include "ast/stmt/for_each_stmt.hpp"
+#include "ast/stmt/create_class_stmt.hpp"
+#include "ast/stmt/create_method_stmt.hpp"
+#include "ast/stmt/try_stmt.hpp"
+#include "ast/stmt/resist_stmt.hpp"
+#include "ast/stmt/create_var_with_ask_stmt.hpp"
+#include "ast/stmt/update_var_with_ask_stmt.hpp"
+
+#include "ast/expr/literal_expr.hpp"
+#include "ast/expr/variable_expr.hpp"
+#include "ast/expr/grouping_expr.hpp"
+#include "ast/expr/unary_expr.hpp"
+#include "ast/expr/binary_expr.hpp"
+#include "ast/expr/list_expr.hpp"
+#include "ast/expr/dict_expr.hpp"
+#include "ast/expr/conditional_expr.hpp"
+#include "ast/expr/formatted_string_expr.hpp"
+#include "ast/expr/method_call_expr.hpp"
+#include "ast/expr/get_attr_expr.hpp"
+#include "ast/expr/index_expr.hpp"
+#include "ast/expr/ask_expr.hpp"
+#include "ast/expr/create_instance_expr.hpp"
+#include "ast/expr/parity_check_expr.hpp"
+#include "ast/expr/convert_to_expr.hpp"
+
+void MethodInliner::run(std::vector<std::unique_ptr<Stmt>> &program)
+{
+    std::unordered_map<std::string, const CreateMethodStmt *> knownMethods;
+
+    // Pass 1: Collect method definitions
+    for (const auto &stmt : program)
+    {
+        if (stmt)
+            collectMethodsFromStmt(*stmt, knownMethods);
+    }
+
+    // Pass 2: Inline method calls across statements and expressions
+    optimizeBlock(program, knownMethods);
+}
+
+void MethodInliner::collectMethodsFromStmt(
+    const Stmt &statement, std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods)
+{
+    // ----------------------------------------------------
+    // Methods in Jesus are always declared inside classes.
+    // Therefore only class bodies need to be scanned.
+    // ----------------------------------------------------
+    if (auto createClass = dynamic_cast<const CreateClassStmt *>(&statement))
+    {
+        for (const auto &stmt : createClass->body)
+        {
+            if (stmt)
+            {
+                if (auto method = dynamic_cast<const CreateMethodStmt *>(stmt.get()))
+                {
+                    // FIXME: two classes may have the same method names
+                    knownMethods[method->name] = method;
+                }
+            }
+        }
+        return;
+    }
+}
+
+void MethodInliner::optimizeBlock(
+    std::vector<std::unique_ptr<Stmt>> &stmts,
+    const std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods)
+{
+    for (auto &stmt : stmts)
+    {
+        if (stmt)
+            optimizeStatement(*stmt, knownMethods);
+    }
+}
+
+void MethodInliner::optimizeBlock(
+    std::vector<std::shared_ptr<Stmt>> &stmts,
+    const std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods)
+{
+    for (auto &stmt : stmts)
+    {
+        if (stmt)
+            optimizeStatement(*stmt, knownMethods);
+    }
+}
+
+void MethodInliner::optimizeStatement(
+    Stmt &statement, const std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods)
+{
+    if (auto create = dynamic_cast<CreateVarStmt *>(&statement))
+    {
+        create->value = optimizeExpression(std::move(create->value), knownMethods);
+        return;
+    }
+
+    if (auto update = dynamic_cast<UpdateVarStmt *>(&statement))
+    {
+        update->value = optimizeExpression(std::move(update->value), knownMethods);
+        return;
+    }
+
+    if (auto assign = dynamic_cast<AssignStmt *>(&statement))
+    {
+        if (assign->target)
+        {
+            auto optTarget = optimizeExpression(std::move(assign->target), knownMethods);
+            if (auto assignable = dynamic_cast<AssignableExpr *>(optTarget.get()))
+            {
+                optTarget.release();
+                assign->target.reset(assignable);
+            }
+        }
+        assign->value = optimizeExpression(std::move(assign->value), knownMethods);
+        return;
+    }
+
+    if (auto printStmt = dynamic_cast<PrintStmt *>(&statement))
+    {
+        printStmt->message = optimizeExpression(std::move(printStmt->message), knownMethods);
+        return;
+    }
+
+    if (auto returnStmt = dynamic_cast<ReturnStmt *>(&statement))
+    {
+        returnStmt->value = optimizeExpression(std::move(returnStmt->value), knownMethods);
+        return;
+    }
+
+    if (auto resist = dynamic_cast<ResistStmt *>(&statement))
+    {
+        resist->messageExpr = optimizeExpression(std::move(resist->messageExpr), knownMethods);
+        return;
+    }
+
+    if (auto createAsk = dynamic_cast<CreateVarWithAskStmt *>(&statement))
+    {
+        return;
+    }
+
+    if (auto updateAsk = dynamic_cast<UpdateVarWithAskStmt *>(&statement))
+    {
+        return;
+    }
+
+    if (auto ifStmt = dynamic_cast<IfStmt *>(&statement))
+    {
+        ifStmt->condition = optimizeExpression(std::move(ifStmt->condition), knownMethods);
+        optimizeBlock(ifStmt->thenBranch, knownMethods);
+        optimizeBlock(ifStmt->otherwiseBranch, knownMethods);
+        return;
+    }
+
+    if (auto repeatWhile = dynamic_cast<RepeatWhileStmt *>(&statement))
+    {
+        repeatWhile->condition = optimizeExpression(std::move(repeatWhile->condition), knownMethods);
+        optimizeBlock(repeatWhile->body, knownMethods);
+        return;
+    }
+
+    if (auto repeatTimes = dynamic_cast<RepeatTimesStmt *>(&statement))
+    {
+        repeatTimes->countExpr = optimizeExpression(std::move(repeatTimes->countExpr), knownMethods);
+        optimizeBlock(repeatTimes->body, knownMethods);
+        return;
+    }
+
+    if (auto repeatForever = dynamic_cast<RepeatForeverStmt *>(&statement))
+    {
+        optimizeBlock(repeatForever->body, knownMethods);
+        return;
+    }
+
+    if (auto forEach = dynamic_cast<ForEachStmt *>(&statement))
+    {
+        forEach->iterable = optimizeExpression(std::move(forEach->iterable), knownMethods);
+        optimizeBlock(forEach->body, knownMethods);
+        return;
+    }
+
+    if (auto createClass = dynamic_cast<CreateClassStmt *>(&statement))
+    {
+        optimizeBlock(createClass->body, knownMethods);
+        return;
+    }
+
+    if (auto createMethod = dynamic_cast<CreateMethodStmt *>(&statement))
+    {
+        optimizeBlock(createMethod->body, knownMethods);
+        return;
+    }
+
+    if (auto tryStmt = dynamic_cast<TryStmt *>(&statement))
+    {
+        optimizeBlock(tryStmt->tryBody, knownMethods);
+        for (auto &[type, catchBody] : tryStmt->catchClauses)
+        {
+            optimizeBlock(catchBody, knownMethods);
+        }
+        optimizeBlock(tryStmt->alwaysBody, knownMethods);
+        return;
+    }
+}
+
+std::unique_ptr<Expr> MethodInliner::optimizeExpression(
+    std::unique_ptr<Expr> expression, const std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods)
+{
+    if (!expression)
+        return nullptr;
+
+    if (auto methodCall = dynamic_cast<MethodCallExpr *>(expression.get()))
+    {
+        std::unique_ptr<MethodCallExpr> call(static_cast<MethodCallExpr *>(expression.release()));
+        return inlineMethodCall(std::move(call), knownMethods);
+    }
+
+    if (auto grouping = dynamic_cast<GroupingExpr *>(expression.get()))
+    {
+        grouping->expression = optimizeExpression(std::move(grouping->expression), knownMethods);
+        return expression;
+    }
+
+    if (auto unary = dynamic_cast<UnaryExpr *>(expression.get()))
+    {
+        unary->right = optimizeExpression(std::move(unary->right), knownMethods);
+        return expression;
+    }
+
+    if (auto binary = dynamic_cast<BinaryExpr *>(expression.get()))
+    {
+        binary->left = optimizeExpression(std::move(binary->left), knownMethods);
+        binary->right = optimizeExpression(std::move(binary->right), knownMethods);
+        return expression;
+    }
+
+    if (auto listExpr = dynamic_cast<ListExpr *>(expression.get()))
+    {
+        for (auto &el : listExpr->elements)
+            el = optimizeExpression(std::move(el), knownMethods);
+
+        return expression;
+    }
+
+    if (auto dictExpr = dynamic_cast<DictExpr *>(expression.get()))
+    {
+        for (auto &[key, value] : dictExpr->entries)
+        {
+            key = optimizeExpression(std::move(key), knownMethods);
+            value = optimizeExpression(std::move(value), knownMethods);
+        }
+        return expression;
+    }
+
+    if (auto condExpr = dynamic_cast<ConditionalExpr *>(expression.get()))
+    {
+        condExpr->condition = optimizeExpression(std::move(condExpr->condition), knownMethods);
+        condExpr->thenBranch = optimizeExpression(std::move(condExpr->thenBranch), knownMethods);
+        condExpr->elseBranch = optimizeExpression(std::move(condExpr->elseBranch), knownMethods);
+        return expression;
+    }
+
+    if (auto getAttr = dynamic_cast<GetAttributeExpr *>(expression.get()))
+    {
+        if (getAttr->object)
+            getAttr->object = optimizeExpression(std::move(getAttr->object), knownMethods);
+
+        return expression;
+    }
+
+    if (auto indexExpr = dynamic_cast<IndexExpr *>(expression.get()))
+    {
+        if (indexExpr->collection)
+            indexExpr->collection = optimizeExpression(std::move(indexExpr->collection), knownMethods);
+
+        if (indexExpr->index)
+            indexExpr->index = optimizeExpression(std::move(indexExpr->index), knownMethods);
+
+        return expression;
+    }
+
+    if (auto fmtString = dynamic_cast<FormattedStringExpr *>(expression.get()))
+    {
+        for (auto &expr : fmtString->expressions)
+            expr = optimizeExpression(std::move(expr), knownMethods);
+
+        return expression;
+    }
+
+    if (auto parity = dynamic_cast<ParityCheckExpr *>(expression.get()))
+    {
+        if (parity->target)
+            parity->target = optimizeExpression(std::move(parity->target), knownMethods);
+
+        return expression;
+    }
+
+    if (auto ask = dynamic_cast<AskExpr *>(expression.get()))
+    {
+        if (ask->prompt)
+            ask->prompt = optimizeExpression(std::move(ask->prompt), knownMethods);
+
+        return expression;
+    }
+
+    if (auto createInst = dynamic_cast<CreateInstanceExpr *>(expression.get()))
+    {
+        if (createInst->constructorArgs)
+            createInst->constructorArgs = optimizeExpression(std::move(createInst->constructorArgs), knownMethods);
+
+        return expression;
+    }
+
+    if (auto convert = dynamic_cast<ConvertToExpr *>(expression.get()))
+    {
+        if (convert->valueExpr)
+            convert->valueExpr = optimizeExpression(std::move(convert->valueExpr), knownMethods);
+
+        return expression;
+    }
+
+    return expression;
+}
+
+std::unique_ptr<Expr> MethodInliner::inlineMethodCall(
+    std::unique_ptr<MethodCallExpr> methodCall,
+    const std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods)
+{
+    if (methodCall->object)
+        methodCall->object = optimizeExpression(std::move(methodCall->object), knownMethods);
+
+    for (auto &arg : methodCall->args)
+        arg = optimizeExpression(std::move(arg), knownMethods);
+
+    const std::vector<std::shared_ptr<Stmt>> *methodBody = nullptr;
+    const Heart *methodParams = nullptr;
+    std::string methodName;
+
+    if (methodCall->method)
+        methodName = methodCall->method->name;
+
+    // TODO: Inline also NativeMethod
+    if (auto method = dynamic_cast<Method *>(methodCall->method.get()))
+    {
+        methodBody = &method->body;
+        methodParams = method->params.get();
+    }
+
+    if (methodBody && methodBody->size() == 1)
+    {
+        // -----------------------------------------------
+        // Currently only methods consisting of a single
+        // `return expression` are inlined.
+        //
+        // Methods whose body performs actions (say, warn,
+        // update variables, loops, etc.) are intentionally
+        // left untouched.
+        //
+        // If MethodCallStmt has to be replaced with SayStmt,
+        // that is modifying statements, not expressions.
+        // We only optimize expressions for now.
+        // -----------------------------------------------
+        if (auto retStmt = dynamic_cast<const ReturnStmt *>((*methodBody)[0].get()))
+        {
+            if (retStmt->value)
+            {
+                /**
+                 * @brief argumentValues["x"] = LiteralExpr(2);
+                 */
+                std::unordered_map<std::string, const Expr *> argumentValues;
+                if (methodParams)
+                {
+                    const auto &paramNames = methodParams->getVariableNames();
+                    for (size_t i = 0; i < paramNames.size() && i < methodCall->args.size(); ++i)
+                    {
+                        argumentValues[paramNames[i]] = methodCall->args[i].get();
+                    }
+                }
+
+                auto inlined =
+                    cloneExpressionReplacingParamsWithArgs(*retStmt->value, argumentValues, methodCall->object.get());
+                if (inlined)
+                {
+                    return optimizeExpression(std::move(inlined), knownMethods);
+                }
+            }
+        }
+    }
+
+    return methodCall;
+}
+
+std::unique_ptr<Expr> MethodInliner::cloneExpressionReplacingParamsWithArgs(
+    const Expr &expression, const std::unordered_map<std::string, const Expr *> &argumentValues, const Expr *objectExpr)
+{
+    //--------------------------------------------------------------
+    // Parameter substitution.
+    //
+    // VariableExpr is the only AST node whose meaning may change.
+    // If the variable is a method parameter, replace it with the
+    // corresponding argument expression.
+    //--------------------------------------------------------------
+    if (auto varExpr = dynamic_cast<const VariableExpr *>(&expression))
+    {
+        // -------------------------------------
+        // This is the 'heart' of this method,
+        // replacing params with their values
+        //
+        // it = std::pair<Key, Value>
+        // it = std::pair<first, second>
+        // it->first --> param name
+        // it->second --> arg value
+        // argumentValues["x"] = LiteralExpr(2);
+        // -------------------------------------
+        auto it = argumentValues.find(varExpr->name);
+        if (it != argumentValues.end() && it->second)
+        {
+            // This call clones the literal argument value (it->second is the value)
+            return cloneExpressionReplacingParamsWithArgs(*it->second, {}, nullptr);
+        }
+        // The 'heart' of the method ends here.
+        // ------------------------------------
+
+        if ((varExpr->name == "my" || varExpr->name == "this" || varExpr->name == "I" || varExpr->name == "self") &&
+            objectExpr)
+        {
+            return cloneExpressionReplacingParamsWithArgs(*objectExpr, {}, nullptr);
+        }
+
+        return std::make_unique<VariableExpr>(varExpr->address, varExpr->name);
+    }
+
+    // ----------------------------------------------------------
+    // Literal cloning
+    //----------------
+    // Why clone the literal instead of reusing it?
+    //
+    // The original LiteralExpr belongs to the method definition.
+    // We don't modify the body of existing methods
+    // The inlined expression needs its own copy.
+    // ----------------------------------------------------------
+    if (auto lit = dynamic_cast<const LiteralExpr *>(&expression))
+    {
+        return std::make_unique<LiteralExpr>(lit->value, lit->type);
+    }
+
+    //---------------------------------------------------------
+    // Recursive cloning compound expressions.
+    //
+    // All remaining expression types preserve their semantics.
+    // We simply clone the current node and recursively clone
+    // its child expressions.
+    //---------------------------------------------------------
+    if (auto grouping = dynamic_cast<const GroupingExpr *>(&expression))
+    {
+        return std::make_unique<GroupingExpr>(
+            cloneExpressionReplacingParamsWithArgs(*grouping->expression, argumentValues, objectExpr));
+    }
+
+    if (auto unary = dynamic_cast<const UnaryExpr *>(&expression))
+    {
+        return std::make_unique<UnaryExpr>(
+            unary->op, cloneExpressionReplacingParamsWithArgs(*unary->right, argumentValues, objectExpr));
+    }
+
+    if (auto binary = dynamic_cast<const BinaryExpr *>(&expression))
+    {
+        return std::make_unique<BinaryExpr>(
+            cloneExpressionReplacingParamsWithArgs(*binary->left, argumentValues, objectExpr),
+            binary->op,
+            cloneExpressionReplacingParamsWithArgs(*binary->right, argumentValues, objectExpr));
+    }
+
+    if (auto listExpr = dynamic_cast<const ListExpr *>(&expression))
+    {
+        std::vector<std::unique_ptr<Expr>> elements;
+        for (const auto &el : listExpr->elements)
+            if (el)
+                elements.push_back(cloneExpressionReplacingParamsWithArgs(*el, argumentValues, objectExpr));
+
+        return std::make_unique<ListExpr>(std::move(elements), listExpr->listType);
+    }
+
+    if (auto dictExpr = dynamic_cast<const DictExpr *>(&expression))
+    {
+        std::vector<std::pair<std::unique_ptr<Expr>, std::unique_ptr<Expr>>> entries;
+        for (const auto &[key, value] : dictExpr->entries)
+        {
+            auto newK = key ? cloneExpressionReplacingParamsWithArgs(*key, argumentValues, objectExpr) : nullptr;
+            auto newV = value ? cloneExpressionReplacingParamsWithArgs(*value, argumentValues, objectExpr) : nullptr;
+            entries.push_back({std::move(newK), std::move(newV)});
+        }
+
+        return std::make_unique<DictExpr>(std::move(entries), dictExpr->dictType);
+    }
+
+    if (auto condExpr = dynamic_cast<const ConditionalExpr *>(&expression))
+    {
+        return std::make_unique<ConditionalExpr>(
+            cloneExpressionReplacingParamsWithArgs(*condExpr->condition, argumentValues, objectExpr),
+            cloneExpressionReplacingParamsWithArgs(*condExpr->thenBranch, argumentValues, objectExpr),
+            cloneExpressionReplacingParamsWithArgs(*condExpr->elseBranch, argumentValues, objectExpr));
+    }
+
+    if (auto getAttr = dynamic_cast<const GetAttributeExpr *>(&expression))
+    {
+        std::unique_ptr<Expr> newObj =
+            getAttr->object ? cloneExpressionReplacingParamsWithArgs(*getAttr->object, argumentValues, objectExpr)
+                            : nullptr;
+
+        return std::make_unique<GetAttributeExpr>(std::move(newObj), getAttr->attribute, getAttr->address);
+    }
+
+    if (auto indexExpr = dynamic_cast<const IndexExpr *>(&expression))
+    {
+        std::unique_ptr<Expr> newColl =
+            indexExpr->collection
+                ? cloneExpressionReplacingParamsWithArgs(*indexExpr->collection, argumentValues, objectExpr)
+                : nullptr;
+
+        std::unique_ptr<Expr> newIdx =
+            indexExpr->index ? cloneExpressionReplacingParamsWithArgs(*indexExpr->index, argumentValues, objectExpr)
+                             : nullptr;
+
+        return std::make_unique<IndexExpr>(std::move(newColl), std::move(newIdx));
+    }
+
+    if (auto fmtString = dynamic_cast<const FormattedStringExpr *>(&expression))
+    {
+        std::vector<std::unique_ptr<Expr>> exprs;
+        for (const auto &e : fmtString->expressions)
+            if (e)
+                exprs.push_back(cloneExpressionReplacingParamsWithArgs(*e, argumentValues, objectExpr));
+
+        return std::make_unique<FormattedStringExpr>(fmtString->raw, fmtString->parts, std::move(exprs));
+    }
+
+    if (auto parity = dynamic_cast<const ParityCheckExpr *>(&expression))
+    {
+        std::unique_ptr<Expr> newTarget =
+            parity->target ? cloneExpressionReplacingParamsWithArgs(*parity->target, argumentValues, objectExpr)
+                           : nullptr;
+
+        return std::make_unique<ParityCheckExpr>(std::move(newTarget), parity->negate, parity->checkOdd);
+    }
+
+    if (auto ask = dynamic_cast<const AskExpr *>(&expression))
+    {
+        std::unique_ptr<Expr> newPrompt =
+            ask->prompt ? cloneExpressionReplacingParamsWithArgs(*ask->prompt, argumentValues, objectExpr) : nullptr;
+
+        return std::make_unique<AskExpr>(std::move(newPrompt));
+    }
+
+    if (auto createInst = dynamic_cast<const CreateInstanceExpr *>(&expression))
+    {
+        std::unique_ptr<Expr> newArgs =
+            createInst->constructorArgs
+                ? cloneExpressionReplacingParamsWithArgs(*createInst->constructorArgs, argumentValues, objectExpr)
+                : nullptr;
+
+        return std::make_unique<CreateInstanceExpr>(createInst->name, createInst->klass, std::move(newArgs));
+    }
+
+    if (auto convert = dynamic_cast<const ConvertToExpr *>(&expression))
+    {
+        std::unique_ptr<Expr> newVal =
+            convert->valueExpr ? cloneExpressionReplacingParamsWithArgs(*convert->valueExpr, argumentValues, objectExpr)
+                               : nullptr;
+
+        return std::make_unique<ConvertToExpr>(std::move(newVal), convert->targetType);
+    }
+
+    if (auto mc = dynamic_cast<const MethodCallExpr *>(&expression))
+    {
+        std::unique_ptr<Expr> newObj =
+            mc->object ? cloneExpressionReplacingParamsWithArgs(*mc->object, argumentValues, objectExpr) : nullptr;
+        std::vector<std::unique_ptr<Expr>> newArgs;
+        for (const auto &a : mc->args)
+            if (a)
+                newArgs.push_back(cloneExpressionReplacingParamsWithArgs(*a, argumentValues, objectExpr));
+
+        return std::make_unique<MethodCallExpr>(std::move(newObj), mc->method, std::move(newArgs), mc->interpreter);
+    }
+
+    return nullptr;
+}

--- a/src/jesus/optimizer/method_inliner.hpp
+++ b/src/jesus/optimizer/method_inliner.hpp
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <vector>
+#include <memory>
+#include <unordered_map>
+#include <string>
+
+#include "ast/stmt/stmt.hpp"
+#include "ast/expr/expr.hpp"
+#include "ast/stmt/create_method_stmt.hpp"
+#include "ast/expr/method_call_expr.hpp"
+
+/**
+ * @brief Replaces method call expressions with the inlined body of simple methods.
+ *
+ * MethodInliner identifies method calls whose bodies consist of simple return
+ * statements and substitutes the method call directly with the method's body,
+ * substituting parameter references with the call arguments.
+ *
+ * Example:
+ *
+ *     purpose add(number a, b):
+ *         return a + b
+ *     amen
+ *
+ *     say math.add(10, 20)
+ *
+ * becomes:
+ *
+ *     say 10 + 20
+ *
+ * "The Word became flesh and made his dwelling among us..."
+ * — John 1:14
+ */
+class MethodInliner
+{
+  public:
+    /**
+     * @brief Executes method inlining on an AST.
+     */
+    void run(std::vector<std::unique_ptr<Stmt>> &program);
+
+  private:
+    void collectMethodsFromStmt(
+        const Stmt &statement, std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods);
+
+    void optimizeBlock(
+        std::vector<std::unique_ptr<Stmt>> &stmts,
+        const std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods);
+
+    void optimizeBlock(
+        std::vector<std::shared_ptr<Stmt>> &stmts,
+        const std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods);
+
+    void optimizeStatement(
+        Stmt &statement, const std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods);
+
+    std::unique_ptr<Expr> optimizeExpression(
+        std::unique_ptr<Expr> expression,
+        const std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods);
+
+    std::unique_ptr<Expr> inlineMethodCall(
+        std::unique_ptr<MethodCallExpr> methodCall,
+        const std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods);
+
+    /**
+     * @brief Clone an expression,
+     * replacing every parameter (x, y) with the corresponding argument (2, 3),
+     * leaving everything else unchanged.
+     *
+     * This is the heart of the MethodInliner.
+     *
+     * The original method AST is NEVER modified, but cloned instead.
+     *
+     * Example:
+     *
+     *     purpose add(number x, number y):
+     *         return x + y
+     *     amen
+     *
+     *     add(2, 3)
+     *
+     * Before cloning, this method builds a mapping called argumentValues:
+     *
+     *     x -> LiteralExpr(2)
+     *     y -> LiteralExpr(3)
+     *
+     * During clone, the code below:
+     *
+     *     return x + y
+     *
+     * becomes:
+     *
+     *     return 2 + 3
+     *
+     * Then:
+     *
+     *     add(2, 3)
+     *
+     * in the end becomes:
+     *
+     *     2 + 3
+     *
+     * The resulting AST is an inlined clone of the method body.
+     *
+     * @param expression LiteralExpr(7)
+     * @param argumentValues  argumentValues["x"] = LiteralExpr(7);
+     */
+    std::unique_ptr<Expr> cloneExpressionReplacingParamsWithArgs(
+        const Expr &expression,
+        const std::unordered_map<std::string, const Expr *> &argumentValues,
+        const Expr *objectExpr);
+};

--- a/src/jesus/optimizer/optimizer.cpp
+++ b/src/jesus/optimizer/optimizer.cpp
@@ -2,6 +2,7 @@
 #include "constant_folder.hpp"
 #include "constant_propagator.hpp"
 #include "dead_code_eliminator.hpp"
+#include "method_inliner.hpp"
 
 void Optimizer::optimize(std::vector<std::unique_ptr<Stmt>> &program)
 {
@@ -9,5 +10,11 @@ void Optimizer::optimize(std::vector<std::unique_ptr<Stmt>> &program)
     ConstantPropagator().run(program);
     ConstantFolder().run(program);
     DeadCodeEliminator().run(program);
-}
 
+    MethodInliner().run(program);
+
+    ConstantFolder().run(program);
+    ConstantPropagator().run(program);
+    ConstantFolder().run(program);
+    DeadCodeEliminator().run(program);
+}

--- a/src/jesus/tests/optimizer/method_inliner/inline_simple.jesus
+++ b/src/jesus/tests/optimizer/method_inliner/inline_simple.jesus
@@ -1,0 +1,10 @@
+let there be Math:
+    purpose pi() -> number:
+        return 314 / 100
+    amen
+amen
+
+create Math math = 1
+say math pi
+
+ast

--- a/src/jesus/tests/optimizer/method_inliner/inline_simple.jesus.expected
+++ b/src/jesus/tests/optimizer/method_inliner/inline_simple.jesus.expected
@@ -1,0 +1,6 @@
+(double) 3.140000
+CreateClassStmt(name: 'Math', body: [
+  CreateMethodStmt('pi', body: [
+    ReturnStmt(LiteralExpr((double) 3.140000))])])
+CreateVarStmt(math, CreateInstanceExpr)
+SayStmt(LiteralExpr((double) 3.140000))

--- a/src/jesus/tests/repl/method_inliner.jesus
+++ b/src/jesus/tests/repl/method_inliner.jesus
@@ -1,0 +1,1 @@
+../optimizer/method_inliner/inline_simple.jesus

--- a/src/jesus/tests/repl/method_inliner.jesus.expected
+++ b/src/jesus/tests/repl/method_inliner.jesus.expected
@@ -1,0 +1,7 @@
+(Jesus) (Jesus) (Jesus) (Jesus) (double) 3.140000
+(Jesus) (Jesus) CreateClassStmt(name: 'Math', body: [
+  CreateMethodStmt('pi', body: [
+    ReturnStmt(BinaryExpr(operator: /, left: LiteralExpr((int) 314), right: LiteralExpr((int) 100)))])])
+CreateVarStmt(math, CreateInstanceExpr)
+SayStmt(MethodCallExpr)
+(Jesus) 


### PR DESCRIPTION
# Description

This PR introduces the `MethodInliner` optimization pass.

Method inlining replaces eligible method calls with a cloned version of the method body, substituting each parameter with the corresponding argument expression. This removes the runtime call overhead and enables subsequent optimization passes to simplify the resulting AST even further.

For example:

Before:

    let there be Math:
        purpose pi() -> number:
            return 314 / 100
        amen
    amen

    create Math math = 1
    say math pi

After MethodInliner:

    create Math math = 1
    say 314 / 100

After ConstantFolder:

    create Math math = 1
    say 3.14

## Highlights

- Added the `MethodInliner` optimization pass.
- Inlines simple methods that consist of a single `return` statement.
- Replaces method parameters with the corresponding argument expressions.
- Preserves the original method body by cloning the AST instead of modifying it.
- Added a unit test covering method inlining scenarios.

## Motivation

Inlining eliminates unnecessary method calls and exposes additional optimization opportunities. Once a method body is placed directly at the call site, later passes such as `ConstantFolder`, `ConstantPropagator`, and `DeadCodeEliminator` can simplify the generated code even further.

This optimization is another step toward producing a smaller and faster AST before bytecode generation.

# ✝️ Wisdom

> "**_The Word is very near you_**; it is in your mouth and in your heart." — **Deuteronomy 30:14**