### PR TITLE
Step 99: feat(optimizer):  Propagating const class attributes in addition to normal variables . Ref #93, #94, #96.

### DIFF
--- a/src/jesus/ast/expr/get_attr_expr.cpp
+++ b/src/jesus/ast/expr/get_attr_expr.cpp
@@ -5,9 +5,22 @@
 #include "interpreter/interpreter.hpp"
 #include "interpreter/runtime/instance.hpp"
 
-Value GetAttributeExpr::accept(ExprVisitor &visitor) const
+Value GetAttributeExpr::accept(ExprVisitor &visitor) const { return visitor.visitGetAttribute(*this); }
+
+Value GetAttributeExpr::evaluate(std::shared_ptr<Heart> heart) const
 {
-    return visitor.visitGetAttribute(*this);
+    Value obj = object->evaluate(heart);
+
+    std::shared_ptr<Instance> instance = obj.toInstance();
+
+    if (!instance)
+    {
+        throw std::runtime_error(
+            "Cannot access attribute '" + attribute + "' on '" + obj.toString() + "' value.\n" +
+            "Tip: ensure the value is a valid object before accessing its attributes.");
+    }
+
+    return instance->getAttribute(address);
 }
 
 std::shared_ptr<CreationType> GetAttributeExpr::getReturnType(ParserContext &ctx) const

--- a/src/jesus/ast/expr/get_attr_expr.hpp
+++ b/src/jesus/ast/expr/get_attr_expr.hpp
@@ -18,10 +18,7 @@ public:
     GetAttributeExpr(std::unique_ptr<Expr> object, std::string attribute, const VariableAddress address)
         : object(std::move(object)), attribute(std::move(attribute)), address(address), AssignableExpr(ExprKind::GetAttribute) {}
 
-    Value evaluate(std::shared_ptr<Heart> heart) const override
-    {
-        return object->evaluate(heart);
-    }
+    Value evaluate(std::shared_ptr<Heart> heart) const override;
 
     Value accept(ExprVisitor &visitor) const override;
 

--- a/src/jesus/optimizer/constant_folder.cpp
+++ b/src/jesus/optimizer/constant_folder.cpp
@@ -202,8 +202,7 @@ std::unique_ptr<Expr> ConstantFolder::optimizeExpression(std::unique_ptr<Expr> e
 
     if (auto binary = dynamic_cast<BinaryExpr *>(expression.get()))
     {
-        return optimizeBinaryExpr(
-            std::unique_ptr<BinaryExpr>(static_cast<BinaryExpr *>(expression.release())));
+        return optimizeBinaryExpr(std::unique_ptr<BinaryExpr>(static_cast<BinaryExpr *>(expression.release())));
     }
 
     if (auto listExpr = dynamic_cast<ListExpr *>(expression.get()))
@@ -283,7 +282,104 @@ std::unique_ptr<Expr> ConstantFolder::optimizeBinaryExpr(std::unique_ptr<BinaryE
     expression->right = optimizeExpression(std::move(expression->right));
 
     if (!expression->canEvaluateAtParseTime())
+    {
+        // -----------------------------------------------------------
+        // Reassociation for '+' and '-'
+        //
+        // The entire expression cannot be evaluated at parse time because
+        // its base may depend on a runtime value:
+        //
+        //     sum + 1 + 2 - 3 + 4
+        //
+        // However, the constant operands on the right side are already
+        // known at parse time, so we can combine them.
+        //
+        // The parser builds left-associative chains:
+        //
+        //     ((((sum + 1) + 2) - 3) + 4)
+        //
+        // We combine the constant operands while preserving their signs:
+        //
+        //     (sum + 1) - 2  becomes  sum + (-1)
+        //
+        //     (sum - 1) + 2  becomes  sum + 1
+        //
+        // The optimizer processes the tree bottom-up, so this transformation
+        // is repeated automatically:
+        //
+        //     sum + 1 + 2 - 3 + 4
+        //
+        // becomes:
+        //
+        //     sum + 4
+        //
+        // The important detail is that we do NOT assume '-' is associative.
+        // Instead, each constant is first converted to its signed value,
+        // and then the signed values are added.
+        // -----------------------------------------------------------F
+        if ((expression->op.type == TokenType::PLUS || expression->op.type == TokenType::MINUS) &&
+            expression->right->canEvaluateAtParseTime())
+        {
+            if (auto leftBin = dynamic_cast<BinaryExpr *>(expression->left.get()))
+            {
+                if ((leftBin->op.type == TokenType::PLUS || leftBin->op.type == TokenType::MINUS) &&
+                    leftBin->right->canEvaluateAtParseTime())
+                {
+                    try
+                    {
+                        // -----------------------------------------------
+                        //  We have:
+                        //
+                        //      (base +/- leftConstant) +/- rightConstant
+                        //
+                        //  Convert both constants to their signed values:
+                        //
+                        //      (sum + 1) + 2  ->  +1 + 2
+                        //      (sum + 1) - 2  ->  +1 - 2
+                        //      (sum - 1) + 2  ->  -1 + 2
+                        //      (sum - 1) - 2  ->  -1 - 2
+                        //
+                        //  Then fold the two constants together.
+                        //  -----------------------------------------------
+                        Value leftValue = leftBin->right->evaluate(nullptr);
+                        if (leftBin->op.type == TokenType::MINUS)
+                        {
+                            leftValue = Value(0) - leftValue;
+                        }
+
+                        Value rightValue = expression->right->evaluate(nullptr);
+                        if (expression->op.type == TokenType::MINUS)
+                        {
+                            rightValue = Value(0) - rightValue;
+                        }
+
+                        Value mergedValue = leftValue + rightValue;
+                        auto foldedConst = createLiteral(mergedValue);
+
+                        // -----------------------------------------------------
+                        //  Always rebuild using PLUS because the sign has already
+                        //  been incorporated into foldedConst.
+                        //
+                        //  Examples:
+                        //
+                        //      (sum + 1) + 2 -> sum + 3
+                        //      (sum + 1) - 2 -> sum + (-1)
+                        //      (sum - 1) + 2 -> sum + 1
+                        //      (sum - 1) - 2 -> sum + (-3)
+                        // -----------------------------------------------------
+                        Token plusToken(TokenType::PLUS, "+", Value("+"));
+
+                        return std::make_unique<BinaryExpr>(
+                            std::move(leftBin->left), plusToken, std::move(foldedConst));
+                    }
+                    catch (...)
+                    {
+                    }
+                }
+            }
+        }
         return expression;
+    }
 
     try
     {

--- a/src/jesus/optimizer/constant_propagator.cpp
+++ b/src/jesus/optimizer/constant_propagator.cpp
@@ -51,6 +51,17 @@ void ConstantPropagator::run(std::vector<std::unique_ptr<Stmt>> &program)
             collectModifiedVars(*stmt, modifiedVars, declaredVars);
     }
 
+    // ----------------------------------------------------------------
+    // Class attribute values
+    // ----------------------
+    // Every class attribute is declared with an initializer in the class
+    // body. A method body referencing an attribute (e.g. `return name`)
+    // carries the scopeId and slot of that class scope. When the attribute
+    // is never modified, its declared initial value is its constant value.
+    // ----------------------------------------------------------------
+    std::unordered_map<uint32_t, std::unordered_map<uint32_t, std::unique_ptr<Expr>>> classAttributeValues;
+    collectClassAttributeValues(program, classAttributeValues);
+
     // -----------------------------------------------------------------------
     // Pass 2
     // ------
@@ -62,7 +73,7 @@ void ConstantPropagator::run(std::vector<std::unique_ptr<Stmt>> &program)
         if (!stmt)
             continue;
 
-        replaceConstWithLiteralInStatement(*stmt, constVars);
+        replaceConstWithLiteralInStatement(*stmt, constVars, classAttributeValues, modifiedVars);
 
         if (auto create = dynamic_cast<CreateVarStmt *>(stmt.get()))
         {
@@ -82,10 +93,50 @@ void ConstantPropagator::run(std::vector<std::unique_ptr<Stmt>> &program)
     }
 }
 
+void ConstantPropagator::collectClassAttributeValues(
+    const std::vector<std::unique_ptr<Stmt>> &program,
+    std::unordered_map<uint32_t, std::unordered_map<uint32_t, std::unique_ptr<Expr>>> &classAttributeValues)
+{
+    for (const auto &stmt : program)
+    {
+        if (!stmt)
+            continue;
+
+        auto createClass = dynamic_cast<const CreateClassStmt *>(stmt.get());
+        if (!createClass || !createClass->userClass || !createClass->userClass->class_attributes)
+            continue;
+
+        const uint32_t scopeId = createClass->userClass->class_attributes->scopeId;
+
+        for (const auto &member : createClass->body)
+        {
+            if (!member)
+                continue;
+
+            auto attr = dynamic_cast<const CreateVarStmt *>(member.get());
+            if (!attr || !attr->value)
+                continue;
+
+            // Only attributes whose initializer is a compile-time constant
+            // can be propagated into a literal.
+            if (!attr->value->canEvaluateAtParseTime())
+                continue;
+
+            try
+            {
+                Value initialValue = attr->value->evaluate(nullptr);
+                auto literal = createLiteral(initialValue);
+                classAttributeValues[scopeId][attr->address.slot] = std::move(literal);
+            }
+            catch (...)
+            {
+            }
+        }
+    }
+}
+
 void ConstantPropagator::collectModifiedVars(
-        const Stmt &statement,
-        std::unordered_set<std::string> &modifiedVars,
-        std::unordered_set<std::string> &declaredVars)
+    const Stmt &statement, std::unordered_set<std::string> &modifiedVars, std::unordered_set<std::string> &declaredVars)
 {
     if (auto create = dynamic_cast<const CreateVarStmt *>(&statement))
     {
@@ -216,7 +267,7 @@ void ConstantPropagator::collectModifiedVars(
 }
 
 void ConstantPropagator::collectModifiedVarsFromExpr(
-        const Expr *expression, std::unordered_set<std::string> &modifiedVars)
+    const Expr *expression, std::unordered_set<std::string> &modifiedVars)
 {
     if (!expression)
         return;
@@ -230,6 +281,10 @@ void ConstantPropagator::collectModifiedVarsFromExpr(
     if (auto getAttr = dynamic_cast<const GetAttributeExpr *>(expression))
     {
         collectModifiedVarsFromExpr(getAttr->object.get(), modifiedVars);
+
+        // An attribute write (user.name = 'you') makes that attribute
+        // non-constant everywhere, so it must never be propagated.
+        modifiedVars.insert(getAttr->attribute);
         return;
     }
 
@@ -241,68 +296,79 @@ void ConstantPropagator::collectModifiedVarsFromExpr(
 }
 
 void ConstantPropagator::replaceConstWithLiteralInStatement(
-        Stmt &statement, const std::unordered_map<std::string, std::unique_ptr<Expr>> &constVars)
+    Stmt &statement,
+    const std::unordered_map<std::string, std::unique_ptr<Expr>> &constVars,
+    const std::unordered_map<uint32_t, std::unordered_map<uint32_t, std::unique_ptr<Expr>>> &classAttributeValues,
+    const std::unordered_set<std::string> &modifiedVars)
 {
     if (auto create = dynamic_cast<CreateVarStmt *>(&statement))
     {
-        create->value = replaceConstWithLiteralInExpression(std::move(create->value), constVars);
+        create->value = replaceConstWithLiteralInExpression(
+            std::move(create->value), constVars, classAttributeValues, modifiedVars);
         return;
     }
 
     if (auto update = dynamic_cast<UpdateVarStmt *>(&statement))
     {
-        update->value = replaceConstWithLiteralInExpression(std::move(update->value), constVars);
+        update->value = replaceConstWithLiteralInExpression(
+            std::move(update->value), constVars, classAttributeValues, modifiedVars);
         return;
     }
 
     if (auto assign = dynamic_cast<AssignStmt *>(&statement))
     {
-        assign->value = replaceConstWithLiteralInExpression(std::move(assign->value), constVars);
+        assign->value = replaceConstWithLiteralInExpression(
+            std::move(assign->value), constVars, classAttributeValues, modifiedVars);
         return;
     }
 
     if (auto printStmt = dynamic_cast<PrintStmt *>(&statement))
     {
-        printStmt->message = replaceConstWithLiteralInExpression(std::move(printStmt->message), constVars);
+        printStmt->message = replaceConstWithLiteralInExpression(
+            std::move(printStmt->message), constVars, classAttributeValues, modifiedVars);
         return;
     }
 
     if (auto returnStmt = dynamic_cast<ReturnStmt *>(&statement))
     {
-        returnStmt->value = replaceConstWithLiteralInExpression(std::move(returnStmt->value), constVars);
+        returnStmt->value = replaceConstWithLiteralInExpression(
+            std::move(returnStmt->value), constVars, classAttributeValues, modifiedVars);
         return;
     }
 
     if (auto ifStmt = dynamic_cast<IfStmt *>(&statement))
     {
-        ifStmt->condition = replaceConstWithLiteralInExpression(std::move(ifStmt->condition), constVars);
+        ifStmt->condition = replaceConstWithLiteralInExpression(
+            std::move(ifStmt->condition), constVars, classAttributeValues, modifiedVars);
         for (auto &child : ifStmt->thenBranch)
             if (child)
-                replaceConstWithLiteralInStatement(*child, constVars);
+                replaceConstWithLiteralInStatement(*child, constVars, classAttributeValues, modifiedVars);
 
         for (auto &child : ifStmt->otherwiseBranch)
             if (child)
-                replaceConstWithLiteralInStatement(*child, constVars);
+                replaceConstWithLiteralInStatement(*child, constVars, classAttributeValues, modifiedVars);
 
         return;
     }
 
     if (auto repeatWhile = dynamic_cast<RepeatWhileStmt *>(&statement))
     {
-        repeatWhile->condition = replaceConstWithLiteralInExpression(std::move(repeatWhile->condition), constVars);
+        repeatWhile->condition = replaceConstWithLiteralInExpression(
+            std::move(repeatWhile->condition), constVars, classAttributeValues, modifiedVars);
         for (auto &child : repeatWhile->body)
             if (child)
-                replaceConstWithLiteralInStatement(*child, constVars);
+                replaceConstWithLiteralInStatement(*child, constVars, classAttributeValues, modifiedVars);
 
         return;
     }
 
     if (auto repeatTimes = dynamic_cast<RepeatTimesStmt *>(&statement))
     {
-        repeatTimes->countExpr = replaceConstWithLiteralInExpression(std::move(repeatTimes->countExpr), constVars);
+        repeatTimes->countExpr = replaceConstWithLiteralInExpression(
+            std::move(repeatTimes->countExpr), constVars, classAttributeValues, modifiedVars);
         for (auto &child : repeatTimes->body)
             if (child)
-                replaceConstWithLiteralInStatement(*child, constVars);
+                replaceConstWithLiteralInStatement(*child, constVars, classAttributeValues, modifiedVars);
 
         return;
     }
@@ -311,16 +377,17 @@ void ConstantPropagator::replaceConstWithLiteralInStatement(
     {
         for (auto &child : repeatForever->body)
             if (child)
-                replaceConstWithLiteralInStatement(*child, constVars);
+                replaceConstWithLiteralInStatement(*child, constVars, classAttributeValues, modifiedVars);
         return;
     }
 
     if (auto forEach = dynamic_cast<ForEachStmt *>(&statement))
     {
-        forEach->iterable = replaceConstWithLiteralInExpression(std::move(forEach->iterable), constVars);
+        forEach->iterable = replaceConstWithLiteralInExpression(
+            std::move(forEach->iterable), constVars, classAttributeValues, modifiedVars);
         for (auto &child : forEach->body)
             if (child)
-                replaceConstWithLiteralInStatement(*child, constVars);
+                replaceConstWithLiteralInStatement(*child, constVars, classAttributeValues, modifiedVars);
 
         return;
     }
@@ -329,7 +396,7 @@ void ConstantPropagator::replaceConstWithLiteralInStatement(
     {
         for (auto &child : createClass->body)
             if (child)
-                replaceConstWithLiteralInStatement(*child, constVars);
+                replaceConstWithLiteralInStatement(*child, constVars, classAttributeValues, modifiedVars);
 
         return;
     }
@@ -338,7 +405,7 @@ void ConstantPropagator::replaceConstWithLiteralInStatement(
     {
         for (auto &child : createMethod->body)
             if (child)
-                replaceConstWithLiteralInStatement(*child, constVars);
+                replaceConstWithLiteralInStatement(*child, constVars, classAttributeValues, modifiedVars);
 
         return;
     }
@@ -347,29 +414,33 @@ void ConstantPropagator::replaceConstWithLiteralInStatement(
     {
         for (auto &child : tryStmt->tryBody)
             if (child)
-                replaceConstWithLiteralInStatement(*child, constVars);
+                replaceConstWithLiteralInStatement(*child, constVars, classAttributeValues, modifiedVars);
 
         for (auto &[type, body] : tryStmt->catchClauses)
             for (auto &child : body)
                 if (child)
-                    replaceConstWithLiteralInStatement(*child, constVars);
+                    replaceConstWithLiteralInStatement(*child, constVars, classAttributeValues, modifiedVars);
 
         for (auto &child : tryStmt->alwaysBody)
             if (child)
-                replaceConstWithLiteralInStatement(*child, constVars);
+                replaceConstWithLiteralInStatement(*child, constVars, classAttributeValues, modifiedVars);
 
         return;
     }
 
     if (auto resist = dynamic_cast<ResistStmt *>(&statement))
     {
-        resist->messageExpr = replaceConstWithLiteralInExpression(std::move(resist->messageExpr), constVars);
+        resist->messageExpr = replaceConstWithLiteralInExpression(
+            std::move(resist->messageExpr), constVars, classAttributeValues, modifiedVars);
         return;
     }
 }
 
 std::unique_ptr<Expr> ConstantPropagator::replaceConstWithLiteralInExpression(
-        std::unique_ptr<Expr> expression, const std::unordered_map<std::string, std::unique_ptr<Expr>> &constVars)
+    std::unique_ptr<Expr> expression,
+    const std::unordered_map<std::string, std::unique_ptr<Expr>> &constVars,
+    const std::unordered_map<uint32_t, std::unordered_map<uint32_t, std::unique_ptr<Expr>>> &classAttributeValues,
+    const std::unordered_set<std::string> &modifiedVars)
 {
     if (!expression)
         return nullptr;
@@ -397,25 +468,49 @@ std::unique_ptr<Expr> ConstantPropagator::replaceConstWithLiteralInExpression(
             return cloneExpr(*it->second);
         }
 
+        // ----------------------------------------------------------
+        // Class attributes are constant when they are never modified.
+        //
+        // A reference to an attribute ('return name' inside a method)
+        // carries the scopeId and slot of the class attributes scope,
+        // under which its declared initial value is recorded.
+        // ----------------------------------------------------------
+        if (varExpr->name != "my" && varExpr->name != "self" && varExpr->name != "this" && varExpr->name != "I")
+        {
+            auto scopeIt = classAttributeValues.find(varExpr->address.scopeId);
+            if (scopeIt != classAttributeValues.end())
+            {
+                auto slotIt = scopeIt->second.find(varExpr->address.slot);
+                if (slotIt != scopeIt->second.end() && !modifiedVars.contains(varExpr->name))
+                {
+                    return cloneExpr(*slotIt->second);
+                }
+            }
+        }
+
         return expression;
     }
 
     if (auto grouping = dynamic_cast<GroupingExpr *>(expression.get()))
     {
-        grouping->expression = replaceConstWithLiteralInExpression(std::move(grouping->expression), constVars);
+        grouping->expression = replaceConstWithLiteralInExpression(
+            std::move(grouping->expression), constVars, classAttributeValues, modifiedVars);
         return expression;
     }
 
     if (auto unary = dynamic_cast<UnaryExpr *>(expression.get()))
     {
-        unary->right = replaceConstWithLiteralInExpression(std::move(unary->right), constVars);
+        unary->right =
+            replaceConstWithLiteralInExpression(std::move(unary->right), constVars, classAttributeValues, modifiedVars);
         return expression;
     }
 
     if (auto binary = dynamic_cast<BinaryExpr *>(expression.get()))
     {
-        binary->left = replaceConstWithLiteralInExpression(std::move(binary->left), constVars);
-        binary->right = replaceConstWithLiteralInExpression(std::move(binary->right), constVars);
+        binary->left =
+            replaceConstWithLiteralInExpression(std::move(binary->left), constVars, classAttributeValues, modifiedVars);
+        binary->right = replaceConstWithLiteralInExpression(
+            std::move(binary->right), constVars, classAttributeValues, modifiedVars);
 
         return expression;
     }
@@ -423,7 +518,7 @@ std::unique_ptr<Expr> ConstantPropagator::replaceConstWithLiteralInExpression(
     if (auto listExpr = dynamic_cast<ListExpr *>(expression.get()))
     {
         for (auto &el : listExpr->elements)
-            el = replaceConstWithLiteralInExpression(std::move(el), constVars);
+            el = replaceConstWithLiteralInExpression(std::move(el), constVars, classAttributeValues, modifiedVars);
 
         return expression;
     }
@@ -432,8 +527,8 @@ std::unique_ptr<Expr> ConstantPropagator::replaceConstWithLiteralInExpression(
     {
         for (auto &[k, v] : dictExpr->entries)
         {
-            k = replaceConstWithLiteralInExpression(std::move(k), constVars);
-            v = replaceConstWithLiteralInExpression(std::move(v), constVars);
+            k = replaceConstWithLiteralInExpression(std::move(k), constVars, classAttributeValues, modifiedVars);
+            v = replaceConstWithLiteralInExpression(std::move(v), constVars, classAttributeValues, modifiedVars);
         }
 
         return expression;
@@ -441,9 +536,12 @@ std::unique_ptr<Expr> ConstantPropagator::replaceConstWithLiteralInExpression(
 
     if (auto condExpr = dynamic_cast<ConditionalExpr *>(expression.get()))
     {
-        condExpr->condition = replaceConstWithLiteralInExpression(std::move(condExpr->condition), constVars);
-        condExpr->thenBranch = replaceConstWithLiteralInExpression(std::move(condExpr->thenBranch), constVars);
-        condExpr->elseBranch = replaceConstWithLiteralInExpression(std::move(condExpr->elseBranch), constVars);
+        condExpr->condition = replaceConstWithLiteralInExpression(
+            std::move(condExpr->condition), constVars, classAttributeValues, modifiedVars);
+        condExpr->thenBranch = replaceConstWithLiteralInExpression(
+            std::move(condExpr->thenBranch), constVars, classAttributeValues, modifiedVars);
+        condExpr->elseBranch = replaceConstWithLiteralInExpression(
+            std::move(condExpr->elseBranch), constVars, classAttributeValues, modifiedVars);
 
         return expression;
     }
@@ -451,10 +549,11 @@ std::unique_ptr<Expr> ConstantPropagator::replaceConstWithLiteralInExpression(
     if (auto methodCall = dynamic_cast<MethodCallExpr *>(expression.get()))
     {
         if (methodCall->object)
-            methodCall->object = replaceConstWithLiteralInExpression(std::move(methodCall->object), constVars);
+            methodCall->object = replaceConstWithLiteralInExpression(
+                std::move(methodCall->object), constVars, classAttributeValues, modifiedVars);
 
         for (auto &arg : methodCall->args)
-            arg = replaceConstWithLiteralInExpression(std::move(arg), constVars);
+            arg = replaceConstWithLiteralInExpression(std::move(arg), constVars, classAttributeValues, modifiedVars);
 
         return expression;
     }
@@ -462,7 +561,8 @@ std::unique_ptr<Expr> ConstantPropagator::replaceConstWithLiteralInExpression(
     if (auto getAttr = dynamic_cast<GetAttributeExpr *>(expression.get()))
     {
         if (getAttr->object)
-            getAttr->object = replaceConstWithLiteralInExpression(std::move(getAttr->object), constVars);
+            getAttr->object = replaceConstWithLiteralInExpression(
+                std::move(getAttr->object), constVars, classAttributeValues, modifiedVars);
 
         return expression;
     }
@@ -470,10 +570,12 @@ std::unique_ptr<Expr> ConstantPropagator::replaceConstWithLiteralInExpression(
     if (auto indexExpr = dynamic_cast<IndexExpr *>(expression.get()))
     {
         if (indexExpr->collection)
-            indexExpr->collection = replaceConstWithLiteralInExpression(std::move(indexExpr->collection), constVars);
+            indexExpr->collection = replaceConstWithLiteralInExpression(
+                std::move(indexExpr->collection), constVars, classAttributeValues, modifiedVars);
 
         if (indexExpr->index)
-            indexExpr->index = replaceConstWithLiteralInExpression(std::move(indexExpr->index), constVars);
+            indexExpr->index = replaceConstWithLiteralInExpression(
+                std::move(indexExpr->index), constVars, classAttributeValues, modifiedVars);
 
         return expression;
     }
@@ -481,7 +583,7 @@ std::unique_ptr<Expr> ConstantPropagator::replaceConstWithLiteralInExpression(
     if (auto fmtString = dynamic_cast<FormattedStringExpr *>(expression.get()))
     {
         for (auto &expr : fmtString->expressions)
-            expr = replaceConstWithLiteralInExpression(std::move(expr), constVars);
+            expr = replaceConstWithLiteralInExpression(std::move(expr), constVars, classAttributeValues, modifiedVars);
 
         return expression;
     }

--- a/src/jesus/optimizer/constant_propagator.hpp
+++ b/src/jesus/optimizer/constant_propagator.hpp
@@ -67,14 +67,31 @@ class ConstantPropagator
 
   private:
     void collectModifiedVars(
-            const Stmt &statement,
-            std::unordered_set<std::string> &modifiedVars,
-            std::unordered_set<std::string> &declaredVars);
+        const Stmt &statement,
+        std::unordered_set<std::string> &modifiedVars,
+        std::unordered_set<std::string> &declaredVars);
 
     void collectModifiedVarsFromExpr(const Expr *expression, std::unordered_set<std::string> &modifiedVars);
 
+    /**
+     * @brief Collects the declared initial values of every class attribute in
+     * the program.
+     *
+     * A reference to a class attribute (a VariableExpr declared in the class
+     * scope, e.g. `return name` inside a method) carries the scopeId and
+     * slot of the class attributes scope. When the attribute is never modified
+     * its declared initial value is its constant value, so the reference can be
+     * replaced by that literal.
+     */
+    void collectClassAttributeValues(
+        const std::vector<std::unique_ptr<Stmt>> &program,
+        std::unordered_map<uint32_t, std::unordered_map<uint32_t, std::unique_ptr<Expr>>> &classAttributeValues);
+
     void replaceConstWithLiteralInStatement(
-            Stmt &statement, const std::unordered_map<std::string, std::unique_ptr<Expr>> &constVars);
+        Stmt &statement,
+        const std::unordered_map<std::string, std::unique_ptr<Expr>> &constVars,
+        const std::unordered_map<uint32_t, std::unordered_map<uint32_t, std::unique_ptr<Expr>>> &classAttributeValues,
+        const std::unordered_set<std::string> &modifiedVars);
 
     /**
      * @brief This is the heart of ConstantPropagator.
@@ -85,7 +102,10 @@ class ConstantPropagator
      *    leave the expression unchanged.
      */
     std::unique_ptr<Expr> replaceConstWithLiteralInExpression(
-            std::unique_ptr<Expr> expression, const std::unordered_map<std::string, std::unique_ptr<Expr>> &constVars);
+        std::unique_ptr<Expr> expression,
+        const std::unordered_map<std::string, std::unique_ptr<Expr>> &constVars,
+        const std::unordered_map<uint32_t, std::unordered_map<uint32_t, std::unique_ptr<Expr>>> &classAttributeValues,
+        const std::unordered_set<std::string> &modifiedVars);
 
     std::unique_ptr<Expr> cloneExpr(const Expr &expr);
     std::unique_ptr<Expr> createLiteral(const Value &value);

--- a/src/jesus/optimizer/method_inliner.cpp
+++ b/src/jesus/optimizer/method_inliner.cpp
@@ -37,7 +37,7 @@
 
 void MethodInliner::run(std::vector<std::unique_ptr<Stmt>> &program)
 {
-    std::unordered_map<std::string, const CreateMethodStmt *> knownMethods;
+    std::unordered_map<std::string, InlinableMethod> knownMethods;
 
     // Pass 1: Collect method definitions
     for (const auto &stmt : program)
@@ -51,7 +51,7 @@ void MethodInliner::run(std::vector<std::unique_ptr<Stmt>> &program)
 }
 
 void MethodInliner::collectMethodsFromStmt(
-    const Stmt &statement, std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods)
+    const Stmt &statement, std::unordered_map<std::string, InlinableMethod> &knownMethods)
 {
     // ----------------------------------------------------
     // Methods in Jesus are always declared inside classes.
@@ -59,6 +59,10 @@ void MethodInliner::collectMethodsFromStmt(
     // ----------------------------------------------------
     if (auto createClass = dynamic_cast<const CreateClassStmt *>(&statement))
     {
+        const Heart *classAttributes = nullptr;
+        if (createClass->userClass)
+            classAttributes = createClass->userClass->class_attributes.get();
+
         for (const auto &stmt : createClass->body)
         {
             if (stmt)
@@ -66,7 +70,7 @@ void MethodInliner::collectMethodsFromStmt(
                 if (auto method = dynamic_cast<const CreateMethodStmt *>(stmt.get()))
                 {
                     // FIXME: two classes may have the same method names
-                    knownMethods[method->name] = method;
+                    knownMethods[method->name] = {method, classAttributes};
                 }
             }
         }
@@ -75,8 +79,7 @@ void MethodInliner::collectMethodsFromStmt(
 }
 
 void MethodInliner::optimizeBlock(
-    std::vector<std::unique_ptr<Stmt>> &stmts,
-    const std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods)
+    std::vector<std::unique_ptr<Stmt>> &stmts, const std::unordered_map<std::string, InlinableMethod> &knownMethods)
 {
     for (auto &stmt : stmts)
     {
@@ -86,8 +89,7 @@ void MethodInliner::optimizeBlock(
 }
 
 void MethodInliner::optimizeBlock(
-    std::vector<std::shared_ptr<Stmt>> &stmts,
-    const std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods)
+    std::vector<std::shared_ptr<Stmt>> &stmts, const std::unordered_map<std::string, InlinableMethod> &knownMethods)
 {
     for (auto &stmt : stmts)
     {
@@ -97,7 +99,7 @@ void MethodInliner::optimizeBlock(
 }
 
 void MethodInliner::optimizeStatement(
-    Stmt &statement, const std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods)
+    Stmt &statement, const std::unordered_map<std::string, InlinableMethod> &knownMethods)
 {
     if (auto create = dynamic_cast<CreateVarStmt *>(&statement))
     {
@@ -214,7 +216,7 @@ void MethodInliner::optimizeStatement(
 }
 
 std::unique_ptr<Expr> MethodInliner::optimizeExpression(
-    std::unique_ptr<Expr> expression, const std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods)
+    std::unique_ptr<Expr> expression, const std::unordered_map<std::string, InlinableMethod> &knownMethods)
 {
     if (!expression)
         return nullptr;
@@ -333,8 +335,7 @@ std::unique_ptr<Expr> MethodInliner::optimizeExpression(
 }
 
 std::unique_ptr<Expr> MethodInliner::inlineMethodCall(
-    std::unique_ptr<MethodCallExpr> methodCall,
-    const std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods)
+    std::unique_ptr<MethodCallExpr> methodCall, const std::unordered_map<std::string, InlinableMethod> &knownMethods)
 {
     if (methodCall->object)
         methodCall->object = optimizeExpression(std::move(methodCall->object), knownMethods);
@@ -355,6 +356,16 @@ std::unique_ptr<Expr> MethodInliner::inlineMethodCall(
         methodBody = &method->body;
         methodParams = method->params.get();
     }
+
+    // ---------------------------------------------------------
+    // Find the class attributes of the method being called, so
+    // that references to instance attributes can be rewritten as
+    // attribute accesses on the receiver object (user.name).
+    // ---------------------------------------------------------
+    const Heart *classAttributes = nullptr;
+    auto knownMethod = knownMethods.find(methodName);
+    if (knownMethod != knownMethods.end())
+        classAttributes = knownMethod->second.classAttributes;
 
     if (methodBody && methodBody->size() == 1)
     {
@@ -387,8 +398,8 @@ std::unique_ptr<Expr> MethodInliner::inlineMethodCall(
                     }
                 }
 
-                auto inlined =
-                    cloneExpressionReplacingParamsWithArgs(*retStmt->value, argumentValues, methodCall->object.get());
+                auto inlined = cloneExpressionReplacingParamsWithArgs(
+                    *retStmt->value, argumentValues, methodCall->object.get(), classAttributes);
                 if (inlined)
                 {
                     return optimizeExpression(std::move(inlined), knownMethods);
@@ -401,7 +412,10 @@ std::unique_ptr<Expr> MethodInliner::inlineMethodCall(
 }
 
 std::unique_ptr<Expr> MethodInliner::cloneExpressionReplacingParamsWithArgs(
-    const Expr &expression, const std::unordered_map<std::string, const Expr *> &argumentValues, const Expr *objectExpr)
+    const Expr &expression,
+    const std::unordered_map<std::string, const Expr *> &argumentValues,
+    const Expr *objectExpr,
+    const Heart *classAttributes)
 {
     //--------------------------------------------------------------
     // Parameter substitution.
@@ -426,7 +440,7 @@ std::unique_ptr<Expr> MethodInliner::cloneExpressionReplacingParamsWithArgs(
         if (it != argumentValues.end() && it->second)
         {
             // This call clones the literal argument value (it->second is the value)
-            return cloneExpressionReplacingParamsWithArgs(*it->second, {}, nullptr);
+            return cloneExpressionReplacingParamsWithArgs(*it->second, {}, nullptr, classAttributes);
         }
         // The 'heart' of the method ends here.
         // ------------------------------------
@@ -434,9 +448,29 @@ std::unique_ptr<Expr> MethodInliner::cloneExpressionReplacingParamsWithArgs(
         if ((varExpr->name == "my" || varExpr->name == "this" || varExpr->name == "I" || varExpr->name == "self") &&
             objectExpr)
         {
-            return cloneExpressionReplacingParamsWithArgs(*objectExpr, {}, nullptr);
+            return cloneExpressionReplacingParamsWithArgs(*objectExpr, {}, nullptr, classAttributes);
         }
 
+        // ----------------------------------------------------------
+        // An instance attribute is rewritten as an attribute access on
+        // the receiver object: 'name' becomes 'user.name'.
+        //
+        // The parse-time class scope is not reachable from the call
+        // site, so the reference must be resolved through the instance.
+        // ----------------------------------------------------------
+        if (classAttributes && classAttributes->varExistsInHierarchy(varExpr->name))
+        {
+            if (!objectExpr)
+                return nullptr;
+
+            return std::make_unique<GetAttributeExpr>(
+                cloneExpressionReplacingParamsWithArgs(*objectExpr, {}, nullptr, classAttributes),
+                varExpr->name,
+                varExpr->address);
+        }
+
+        // A global variable keeps its reference: its address is still
+        // valid at the call site.
         return std::make_unique<VariableExpr>(varExpr->address, varExpr->name);
     }
 
@@ -464,21 +498,22 @@ std::unique_ptr<Expr> MethodInliner::cloneExpressionReplacingParamsWithArgs(
     if (auto grouping = dynamic_cast<const GroupingExpr *>(&expression))
     {
         return std::make_unique<GroupingExpr>(
-            cloneExpressionReplacingParamsWithArgs(*grouping->expression, argumentValues, objectExpr));
+            cloneExpressionReplacingParamsWithArgs(*grouping->expression, argumentValues, objectExpr, classAttributes));
     }
 
     if (auto unary = dynamic_cast<const UnaryExpr *>(&expression))
     {
         return std::make_unique<UnaryExpr>(
-            unary->op, cloneExpressionReplacingParamsWithArgs(*unary->right, argumentValues, objectExpr));
+            unary->op,
+            cloneExpressionReplacingParamsWithArgs(*unary->right, argumentValues, objectExpr, classAttributes));
     }
 
     if (auto binary = dynamic_cast<const BinaryExpr *>(&expression))
     {
         return std::make_unique<BinaryExpr>(
-            cloneExpressionReplacingParamsWithArgs(*binary->left, argumentValues, objectExpr),
+            cloneExpressionReplacingParamsWithArgs(*binary->left, argumentValues, objectExpr, classAttributes),
             binary->op,
-            cloneExpressionReplacingParamsWithArgs(*binary->right, argumentValues, objectExpr));
+            cloneExpressionReplacingParamsWithArgs(*binary->right, argumentValues, objectExpr, classAttributes));
     }
 
     if (auto listExpr = dynamic_cast<const ListExpr *>(&expression))
@@ -486,7 +521,8 @@ std::unique_ptr<Expr> MethodInliner::cloneExpressionReplacingParamsWithArgs(
         std::vector<std::unique_ptr<Expr>> elements;
         for (const auto &el : listExpr->elements)
             if (el)
-                elements.push_back(cloneExpressionReplacingParamsWithArgs(*el, argumentValues, objectExpr));
+                elements.push_back(
+                    cloneExpressionReplacingParamsWithArgs(*el, argumentValues, objectExpr, classAttributes));
 
         return std::make_unique<ListExpr>(std::move(elements), listExpr->listType);
     }
@@ -496,8 +532,11 @@ std::unique_ptr<Expr> MethodInliner::cloneExpressionReplacingParamsWithArgs(
         std::vector<std::pair<std::unique_ptr<Expr>, std::unique_ptr<Expr>>> entries;
         for (const auto &[key, value] : dictExpr->entries)
         {
-            auto newK = key ? cloneExpressionReplacingParamsWithArgs(*key, argumentValues, objectExpr) : nullptr;
-            auto newV = value ? cloneExpressionReplacingParamsWithArgs(*value, argumentValues, objectExpr) : nullptr;
+            auto newK = key ? cloneExpressionReplacingParamsWithArgs(*key, argumentValues, objectExpr, classAttributes)
+                            : nullptr;
+            auto newV =
+                value ? cloneExpressionReplacingParamsWithArgs(*value, argumentValues, objectExpr, classAttributes)
+                      : nullptr;
             entries.push_back({std::move(newK), std::move(newV)});
         }
 
@@ -507,30 +546,32 @@ std::unique_ptr<Expr> MethodInliner::cloneExpressionReplacingParamsWithArgs(
     if (auto condExpr = dynamic_cast<const ConditionalExpr *>(&expression))
     {
         return std::make_unique<ConditionalExpr>(
-            cloneExpressionReplacingParamsWithArgs(*condExpr->condition, argumentValues, objectExpr),
-            cloneExpressionReplacingParamsWithArgs(*condExpr->thenBranch, argumentValues, objectExpr),
-            cloneExpressionReplacingParamsWithArgs(*condExpr->elseBranch, argumentValues, objectExpr));
+            cloneExpressionReplacingParamsWithArgs(*condExpr->condition, argumentValues, objectExpr, classAttributes),
+            cloneExpressionReplacingParamsWithArgs(*condExpr->thenBranch, argumentValues, objectExpr, classAttributes),
+            cloneExpressionReplacingParamsWithArgs(*condExpr->elseBranch, argumentValues, objectExpr, classAttributes));
     }
 
     if (auto getAttr = dynamic_cast<const GetAttributeExpr *>(&expression))
     {
         std::unique_ptr<Expr> newObj =
-            getAttr->object ? cloneExpressionReplacingParamsWithArgs(*getAttr->object, argumentValues, objectExpr)
-                            : nullptr;
+            getAttr->object
+                ? cloneExpressionReplacingParamsWithArgs(*getAttr->object, argumentValues, objectExpr, classAttributes)
+                : nullptr;
 
         return std::make_unique<GetAttributeExpr>(std::move(newObj), getAttr->attribute, getAttr->address);
     }
 
     if (auto indexExpr = dynamic_cast<const IndexExpr *>(&expression))
     {
-        std::unique_ptr<Expr> newColl =
-            indexExpr->collection
-                ? cloneExpressionReplacingParamsWithArgs(*indexExpr->collection, argumentValues, objectExpr)
-                : nullptr;
+        std::unique_ptr<Expr> newColl = indexExpr->collection
+                                            ? cloneExpressionReplacingParamsWithArgs(
+                                                  *indexExpr->collection, argumentValues, objectExpr, classAttributes)
+                                            : nullptr;
 
         std::unique_ptr<Expr> newIdx =
-            indexExpr->index ? cloneExpressionReplacingParamsWithArgs(*indexExpr->index, argumentValues, objectExpr)
-                             : nullptr;
+            indexExpr->index
+                ? cloneExpressionReplacingParamsWithArgs(*indexExpr->index, argumentValues, objectExpr, classAttributes)
+                : nullptr;
 
         return std::make_unique<IndexExpr>(std::move(newColl), std::move(newIdx));
     }
@@ -540,7 +581,8 @@ std::unique_ptr<Expr> MethodInliner::cloneExpressionReplacingParamsWithArgs(
         std::vector<std::unique_ptr<Expr>> exprs;
         for (const auto &e : fmtString->expressions)
             if (e)
-                exprs.push_back(cloneExpressionReplacingParamsWithArgs(*e, argumentValues, objectExpr));
+                exprs.push_back(
+                    cloneExpressionReplacingParamsWithArgs(*e, argumentValues, objectExpr, classAttributes));
 
         return std::make_unique<FormattedStringExpr>(fmtString->raw, fmtString->parts, std::move(exprs));
     }
@@ -548,8 +590,9 @@ std::unique_ptr<Expr> MethodInliner::cloneExpressionReplacingParamsWithArgs(
     if (auto parity = dynamic_cast<const ParityCheckExpr *>(&expression))
     {
         std::unique_ptr<Expr> newTarget =
-            parity->target ? cloneExpressionReplacingParamsWithArgs(*parity->target, argumentValues, objectExpr)
-                           : nullptr;
+            parity->target
+                ? cloneExpressionReplacingParamsWithArgs(*parity->target, argumentValues, objectExpr, classAttributes)
+                : nullptr;
 
         return std::make_unique<ParityCheckExpr>(std::move(newTarget), parity->negate, parity->checkOdd);
     }
@@ -557,7 +600,9 @@ std::unique_ptr<Expr> MethodInliner::cloneExpressionReplacingParamsWithArgs(
     if (auto ask = dynamic_cast<const AskExpr *>(&expression))
     {
         std::unique_ptr<Expr> newPrompt =
-            ask->prompt ? cloneExpressionReplacingParamsWithArgs(*ask->prompt, argumentValues, objectExpr) : nullptr;
+            ask->prompt
+                ? cloneExpressionReplacingParamsWithArgs(*ask->prompt, argumentValues, objectExpr, classAttributes)
+                : nullptr;
 
         return std::make_unique<AskExpr>(std::move(newPrompt));
     }
@@ -565,18 +610,19 @@ std::unique_ptr<Expr> MethodInliner::cloneExpressionReplacingParamsWithArgs(
     if (auto createInst = dynamic_cast<const CreateInstanceExpr *>(&expression))
     {
         std::unique_ptr<Expr> newArgs =
-            createInst->constructorArgs
-                ? cloneExpressionReplacingParamsWithArgs(*createInst->constructorArgs, argumentValues, objectExpr)
-                : nullptr;
+            createInst->constructorArgs ? cloneExpressionReplacingParamsWithArgs(
+                                              *createInst->constructorArgs, argumentValues, objectExpr, classAttributes)
+                                        : nullptr;
 
         return std::make_unique<CreateInstanceExpr>(createInst->name, createInst->klass, std::move(newArgs));
     }
 
     if (auto convert = dynamic_cast<const ConvertToExpr *>(&expression))
     {
-        std::unique_ptr<Expr> newVal =
-            convert->valueExpr ? cloneExpressionReplacingParamsWithArgs(*convert->valueExpr, argumentValues, objectExpr)
-                               : nullptr;
+        std::unique_ptr<Expr> newVal = convert->valueExpr
+                                           ? cloneExpressionReplacingParamsWithArgs(
+                                                 *convert->valueExpr, argumentValues, objectExpr, classAttributes)
+                                           : nullptr;
 
         return std::make_unique<ConvertToExpr>(std::move(newVal), convert->targetType);
     }
@@ -584,11 +630,14 @@ std::unique_ptr<Expr> MethodInliner::cloneExpressionReplacingParamsWithArgs(
     if (auto mc = dynamic_cast<const MethodCallExpr *>(&expression))
     {
         std::unique_ptr<Expr> newObj =
-            mc->object ? cloneExpressionReplacingParamsWithArgs(*mc->object, argumentValues, objectExpr) : nullptr;
+            mc->object
+                ? cloneExpressionReplacingParamsWithArgs(*mc->object, argumentValues, objectExpr, classAttributes)
+                : nullptr;
         std::vector<std::unique_ptr<Expr>> newArgs;
         for (const auto &a : mc->args)
             if (a)
-                newArgs.push_back(cloneExpressionReplacingParamsWithArgs(*a, argumentValues, objectExpr));
+                newArgs.push_back(
+                    cloneExpressionReplacingParamsWithArgs(*a, argumentValues, objectExpr, classAttributes));
 
         return std::make_unique<MethodCallExpr>(std::move(newObj), mc->method, std::move(newArgs), mc->interpreter);
     }

--- a/src/jesus/optimizer/method_inliner.hpp
+++ b/src/jesus/optimizer/method_inliner.hpp
@@ -41,27 +41,37 @@ class MethodInliner
     void run(std::vector<std::unique_ptr<Stmt>> &program);
 
   private:
+    /**
+     * @brief A method known to the inliner, together with the scope holding
+     * the attributes of the class that declares it.
+     */
+    struct InlinableMethod
+    {
+        const CreateMethodStmt *stmt;
+        const Heart *classAttributes;
+    };
+
     void collectMethodsFromStmt(
-        const Stmt &statement, std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods);
+        const Stmt &statement, std::unordered_map<std::string, InlinableMethod> &knownMethods);
 
     void optimizeBlock(
         std::vector<std::unique_ptr<Stmt>> &stmts,
-        const std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods);
+        const std::unordered_map<std::string, InlinableMethod> &knownMethods);
 
     void optimizeBlock(
         std::vector<std::shared_ptr<Stmt>> &stmts,
-        const std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods);
+        const std::unordered_map<std::string, InlinableMethod> &knownMethods);
 
     void optimizeStatement(
-        Stmt &statement, const std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods);
+        Stmt &statement, const std::unordered_map<std::string, InlinableMethod> &knownMethods);
 
     std::unique_ptr<Expr> optimizeExpression(
         std::unique_ptr<Expr> expression,
-        const std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods);
+        const std::unordered_map<std::string, InlinableMethod> &knownMethods);
 
     std::unique_ptr<Expr> inlineMethodCall(
         std::unique_ptr<MethodCallExpr> methodCall,
-        const std::unordered_map<std::string, const CreateMethodStmt *> &knownMethods);
+        const std::unordered_map<std::string, InlinableMethod> &knownMethods);
 
     /**
      * @brief Clone an expression,
@@ -109,5 +119,6 @@ class MethodInliner
     std::unique_ptr<Expr> cloneExpressionReplacingParamsWithArgs(
         const Expr &expression,
         const std::unordered_map<std::string, const Expr *> &argumentValues,
-        const Expr *objectExpr);
+        const Expr *objectExpr,
+        const Heart *classAttributes);
 };

--- a/src/jesus/tests/optimizer/constant_folder/fold_sum_with_variable.jesus
+++ b/src/jesus/tests/optimizer/constant_folder/fold_sum_with_variable.jesus
@@ -1,0 +1,5 @@
+create number sum = 0
+sum = sum + 1 + 1 + 1
+say sum
+
+ast

--- a/src/jesus/tests/optimizer/constant_folder/fold_sum_with_variable.jesus.expected
+++ b/src/jesus/tests/optimizer/constant_folder/fold_sum_with_variable.jesus.expected
@@ -1,0 +1,4 @@
+(int) 3
+CreateVarStmt(sum, LiteralExpr((int) 0))
+UpdateVarStmt('sum', value: BinaryExpr(operator: +, left: VariableExpr('sum'), right: LiteralExpr((int) 3)))
+SayStmt(VariableExpr('sum'))

--- a/src/jesus/tests/optimizer/dead_code_eliminator/zoo.jesus
+++ b/src/jesus/tests/optimizer/dead_code_eliminator/zoo.jesus
@@ -1,0 +1,43 @@
+let there be Zoo:
+    create number aarvark = 1
+    create number baboon = 1
+    create number cat = 1
+    create number donkey = 1
+    create number elephant = 1
+    create number fox = 1
+
+    purpose ant() -> number:
+        return aarvark
+    amen
+
+    purpose banana() -> number:
+        return baboon
+    amen
+
+    purpose tuna() -> number:
+        return cat
+    amen
+
+    purpose hay() -> number:
+        return donkey
+    amen
+
+    purpose grass() -> number:
+        return elephant
+    amen
+
+    purpose mouse() -> number:
+        return fox
+    amen
+amen
+
+create Zoo zoo = 1
+create number sum = 0
+
+repeat while sum < 20:
+    sum = sum + zoo ant + zoo banana  + zoo tuna  + zoo hay  + zoo grass  + zoo mouse
+amen
+
+say sum
+
+ast

--- a/src/jesus/tests/optimizer/dead_code_eliminator/zoo.jesus.expected
+++ b/src/jesus/tests/optimizer/dead_code_eliminator/zoo.jesus.expected
@@ -1,0 +1,5 @@
+(int) 24
+CreateVarStmt(sum, LiteralExpr((int) 0))
+RepeatWhileStmt(condition: BinaryExpr(operator: <, left: VariableExpr('sum'), right: LiteralExpr((int) 20)), body: [
+  UpdateVarStmt('sum', value: BinaryExpr(operator: +, left: VariableExpr('sum'), right: LiteralExpr((int) 6)))])
+SayStmt(VariableExpr('sum'))

--- a/src/jesus/tests/optimizer/method_inliner/inline_attribute_reference.jesus
+++ b/src/jesus/tests/optimizer/method_inliner/inline_attribute_reference.jesus
@@ -1,0 +1,12 @@
+let there be Zoo:
+    create number aarvark = 1
+
+    purpose ant() -> number:
+        return aarvark
+    amen
+amen
+
+create Zoo zoo = 1
+say zoo ant
+
+ast

--- a/src/jesus/tests/optimizer/method_inliner/inline_attribute_reference.jesus.expected
+++ b/src/jesus/tests/optimizer/method_inliner/inline_attribute_reference.jesus.expected
@@ -1,0 +1,2 @@
+(int) 1
+SayStmt(LiteralExpr((int) 1))

--- a/src/jesus/tests/optimizer/method_inliner/inline_global_reference.jesus
+++ b/src/jesus/tests/optimizer/method_inliner/inline_global_reference.jesus
@@ -1,0 +1,12 @@
+create number PI = 3.14
+
+let there be Math:
+    purpose getPi() -> number:
+        return PI
+    amen
+amen
+
+create Math math = 1
+say math getPi
+
+ast

--- a/src/jesus/tests/optimizer/method_inliner/inline_global_reference.jesus.expected
+++ b/src/jesus/tests/optimizer/method_inliner/inline_global_reference.jesus.expected
@@ -1,0 +1,2 @@
+(double) 3.140000
+SayStmt(LiteralExpr((double) 3.140000))


### PR DESCRIPTION
# Description

This PR optimizes method calls whose results can be resolved from constant class
attributes.

Previously, expressions such as:

    sum = sum + zoo ant + zoo banana + zoo tuna + zoo hay + zoo grass + zoo mouse

were not being inlined. The method calls remained in the runtime AST,
even though every method simply returned a constant class attribute.

They are now **propagated, folded, and inlined**.

## Example

Given:

    let there be Zoo:
        create number aarvark = 1
        create number baboon = 1
        create number cat = 1
        create number donkey = 1
        create number elephant = 1
        create number fox = 1

        purpose ant() -> number:
            return aarvark
        amen

        ...
    amen

and:

    sum = sum + zoo ant + zoo banana + zoo tuna + zoo hay + zoo grass + zoo mouse

The optimizer now produces:

    sum = sum + 6

instead of keeping six method calls in the runtime expression.

## Result

Before:

    sum + zoo ant + zoo banana + zoo tuna + zoo hay + zoo grass + zoo mouse

After:

    sum + 6

This removes unnecessary method calls and arithmetic operations from
the runtime path.

## Changes

- Fixed `GetAttributeExpr` to return the requested attribute value.
- Added propagation of constant class attributes to `ConstantPropagator`.
- Folded consecutive `+` and `-` constant operands.
- Added tests covering constant attributes, method inlining, global
  references, constant folding, and dead-code elimination.

## Verification

The resulting AST is:

    UpdateVarStmt(
        'sum',
        BinaryExpr(
            operator: +,
            left: VariableExpr('sum'),
            right: LiteralExpr((int) 6)
        )
    )

instead of six runtime method calls.

# ✝️ Wisdom
> "**Test everything**; hold fast what is good." — _**1 Thessalonians 5:21**_

